### PR TITLE
PWRS5PZ-13: Initialize parser class

### DIFF
--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -164,7 +164,7 @@ public:
 
     argument_parser(const argument_parser&) = delete;
     argument_parser(argument_parser&&) = delete;
-    argument_parser& operator=(const argument_parser&) = delete;
+    argument_parser& operator= (const argument_parser&) = delete;
 
     ~argument_parser() = default;
 
@@ -178,7 +178,7 @@ public:
         return *this;
     }
 
-    friend std::ostream& operator<<(std::ostream& os, const argument_parser& parser) {
+    friend std::ostream& operator<< (std::ostream& os, const argument_parser& parser) {
         if (parser._program_name)
             os << parser._program_name.value() << std::endl;
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -156,4 +156,41 @@ private:
 
 } // namespace detail
 
+
+
+class argument_parser {
+public:
+    argument_parser() = default;
+
+    argument_parser(const argument_parser&) = delete;
+    argument_parser(argument_parser&&) = delete;
+    argument_parser& operator=(const argument_parser&) = delete;
+
+    ~argument_parser() = default;
+
+    argument_parser& program_name(const std::string_view name) {
+        this->_program_name = name;
+        return *this;
+    }
+
+    argument_parser& program_description(const std::string_view description) {
+        this->_program_description = description;
+        return *this;
+    }
+
+    friend std::ostream& operator<<(std::ostream& os, const argument_parser& parser) {
+        if (parser._program_name)
+            os << parser._program_name.value() << std::endl;
+
+        if (parser._program_description)
+            os << parser._program_description.value() << std::endl;
+
+        return os;
+    }
+
+private:
+    std::optional<std::string_view> _program_name;
+    std::optional<std::string_view> _program_description;
+};
+
 } // namespace ap

--- a/test/tests/test_argument_parser_ostream.cpp
+++ b/test/tests/test_argument_parser_ostream.cpp
@@ -33,9 +33,7 @@ TEST_CASE("operator<< should push correct data to the output stream") {
         std::string name = "test program name";
         std::string description = "test program description";
 
-        parser
-            .program_name(name)
-            .program_description(description);
+        parser.program_name(name).program_description(description);
 
         expected_ss << name << std::endl << description << std::endl;
     }

--- a/test/tests/test_argument_parser_ostream.cpp
+++ b/test/tests/test_argument_parser_ostream.cpp
@@ -1,0 +1,48 @@
+#define AP_TESTING
+
+#include "../doctest.h"
+
+#include <ap/argument_parser.hpp>
+
+#include <sstream>
+
+using namespace ap;
+
+
+TEST_CASE("operator<< should push correct data to the output stream") {
+    argument_parser parser;
+
+    std::stringstream ss;
+    std::stringstream expected_ss;
+
+    SUBCASE("nothing by default") {}
+
+    SUBCASE("only program name if nothing else set") {
+        std::string name = "test program name";
+        parser.program_name(name);
+        expected_ss << name << std::endl;
+    }
+
+    SUBCASE("only program description if nothing else set") {
+        std::string description = "test program description";
+        parser.program_description(description);
+        expected_ss << description << std::endl;
+    }
+
+    SUBCASE("program name and description if both specified") {
+        std::string name = "test program name";
+        std::string description = "test program description";
+
+        parser
+            .program_name(name)
+            .program_description(description);
+
+        expected_ss << name << std::endl << description << std::endl;
+    }
+
+    CAPTURE(expected_ss);
+
+    ss << parser;
+
+    REQUIRE_EQ(ss.str(), expected_ss.str());
+}


### PR DESCRIPTION
Initialized the `argument_parser` class (without core functionality):
* Adding program name and description
* Printing parser info using `<<` operator
* Output operator tests