### PR TITLE
PWRS5PZ-14: Add parser functionality - adding arguments

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -58,7 +58,7 @@ AllowShortCaseLabelsOnASingleLine:   false
 AllowShortEnumsOnASingleLine:        true
 AllowShortFunctionsOnASingleLine:    Inline
 AllowShortIfStatementsOnASingleLine: Never
-AllowShortLambdasOnASingleLine:      All
+AllowShortLambdasOnASingleLine:      Inline
 AllowShortLoopsOnASingleLine:        false
 
 AlwaysBreakAfterDefinitionReturnType: None

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -59,6 +59,7 @@ struct argument_name {
     }
 
     friend std::ostream& operator<< (std::ostream& os, const argument_name& arg_name) {
+        // TODO: use str()
         os << "[" << arg_name.name;
         if (arg_name.short_name)
             os << "," << arg_name.short_name.value();
@@ -339,25 +340,26 @@ public:
     }
 
 private:
-    void _check_arg_name_present(const std::string_view& name) const {
-        static const auto name_eq_predicate =
-            [this, &name](const detail::argument_interface& arg) {
-                return name == arg.name();
-            };
+    void _check_arg_name_present(const std::string_view name) const {
+        const auto name_eq_predicate = [name](const detail::argument_interface& arg) {
+            return name == arg.name();
+        };
 
         if (std::find_if(
                 this->_positional_args.begin(), this->_positional_args.end(), name_eq_predicate
-            ) != this->_positional_args.end())
+            ) != this->_positional_args.end()) {
             throw std::invalid_argument(
-                "Argument name [" + std::string(name) + "] invalid!\n\tName already used in another argument"
+                "Argument name [" + std::string(name) + "] invalid! Name already used in another argument"
             );
+        }
 
         if (std::find_if(
                 this->_optional_args.begin(), this->_optional_args.end(), name_eq_predicate
-            ) != this->_optional_args.end())
+            ) != this->_optional_args.end()) {
             throw std::invalid_argument(
-                "Argument name [" + std::string(name) + "] invalid!\n\tName already used in another argument"
+                "Argument name [" + std::string(name) + "] invalid! Name already used in another argument"
             );
+        }
     }
 
     std::optional<std::string_view> _program_name;
@@ -368,21 +370,21 @@ private:
 };
 
 template <>
-detail::argument_type<positional>&
+inline detail::argument_type<positional>&
     argument_parser::add_argument<positional>(const std::string_view name) {
     this->_check_arg_name_present(name);
     return this->_positional_args.emplace_back(name);
 }
 
 template <>
-detail::argument_type<optional>&
+inline detail::argument_type<optional>&
     argument_parser::add_argument<optional>(const std::string_view name) {
     this->_check_arg_name_present(name);
     return this->_optional_args.emplace_back(name);
 }
 
 template <>
-detail::argument_type<positional>& argument_parser::add_argument<positional>(
+inline detail::argument_type<positional>& argument_parser::add_argument<positional>(
     const std::string_view name, const std::string_view short_name
 ) {
     this->_check_arg_name_present(name);
@@ -391,7 +393,7 @@ detail::argument_type<positional>& argument_parser::add_argument<positional>(
 }
 
 template <>
-detail::argument_type<optional>& argument_parser::add_argument<optional>(
+inline detail::argument_type<optional>& argument_parser::add_argument<optional>(
     const std::string_view name, const std::string_view short_name
 ) {
     this->_check_arg_name_present(name);

--- a/test/testing_friend_definitions.hpp
+++ b/test/testing_friend_definitions.hpp
@@ -6,14 +6,6 @@
 
 namespace ap::detail {
 
-bool testing_argument_is_positional(const argument_interface& argument) {
-    return argument.is_positional();
-}
-
-bool testing_argument_is_optional(const argument_interface& argument) {
-    return argument.is_optional();
-}
-
 bool testing_argument_has_value(const argument_interface& argument) {
     return argument.has_value();
 }

--- a/test/tests/test_argument_parser_add_argument.cpp
+++ b/test/tests/test_argument_parser_add_argument.cpp
@@ -49,4 +49,25 @@ TEST_CASE("add_argument should return the correct argument type based on "
     }
 }
 
+TEST_CASE("add_argument should throw only when adding an argument with "
+          "previously used name") {
+    ap::argument_parser ap;
+
+    ap.add_argument<ap::positional>(name, short_name);
+
+    SUBCASE("adding argument with a unique name") {
+        REQUIRE_NOTHROW(ap.add_argument<ap::positional>(other_name, other_short_name));
+    }
+
+    SUBCASE("adding argument with a previously used long name") {
+        REQUIRE_THROWS_AS(ap.add_argument<ap::positional>(name), std::invalid_argument);
+    }
+
+    SUBCASE("adding argument with a previously used short name") {
+        REQUIRE_THROWS_AS(
+            ap.add_argument<ap::positional>(other_name, short_name), std::invalid_argument
+        );
+    }
+}
+
 TEST_SUITE_END();

--- a/test/tests/test_argument_parser_add_argument.cpp
+++ b/test/tests/test_argument_parser_add_argument.cpp
@@ -1,0 +1,52 @@
+#define AP_TESTING
+
+#include "../doctest.h"
+
+#include <ap/argument_parser.hpp>
+
+#include <iostream>
+
+using namespace ap::detail;
+
+
+namespace {
+
+constexpr std::string_view name = "test";
+constexpr std::string_view short_name = "t";
+
+constexpr std::string_view other_name = "other";
+constexpr std::string_view other_short_name = "o";
+
+} // namespace
+
+
+TEST_SUITE_BEGIN("test_argument_parser_add_argument");
+
+TEST_CASE("add_argument should return the correct argument type based on "
+          "template parameter") {
+    ap::argument_parser ap;
+
+    SUBCASE("positional_argument when ap::positional is passed as the parameter") {
+        SUBCASE("with just the long name") {
+            const auto& argument = ap.add_argument<ap::positional>(name);
+            REQUIRE(is_positional<decltype(argument)>());
+        }
+        SUBCASE("with both names") {
+            const auto& argument = ap.add_argument<ap::positional>(name, short_name);
+            REQUIRE(is_positional<decltype(argument)>());
+        }
+    }
+
+    SUBCASE("optional_argument when ap::optional is passed as the parameter") {
+        SUBCASE("with just the long name") {
+            const auto& argument = ap.add_argument<ap::optional>(name);
+            REQUIRE(is_optional<decltype(argument)>());
+        }
+        SUBCASE("with both names") {
+            const auto& argument = ap.add_argument<ap::optional>(name, short_name);
+            REQUIRE(is_optional<decltype(argument)>());
+        }
+    }
+}
+
+TEST_SUITE_END();

--- a/test/tests/test_optional_argument.cpp
+++ b/test/tests/test_optional_argument.cpp
@@ -37,8 +37,8 @@ TEST_CASE("optional argument should be optional and not "
           "positional") {
     const auto argument = default_optional_argument_long_name();
 
-    REQUIRE(testing_argument_is_optional(argument));
-    REQUIRE_FALSE(testing_argument_is_positional(argument));
+    REQUIRE(is_optional<decltype(argument)>());
+    REQUIRE_FALSE(is_positional<decltype(argument)>());
 }
 
 TEST_CASE("has_value() should return false by default") {

--- a/test/tests/test_positional_argument.cpp
+++ b/test/tests/test_positional_argument.cpp
@@ -36,8 +36,8 @@ TEST_SUITE_BEGIN("test_positional_argument");
 TEST_CASE("positonal argument should be positional and not optional") {
     const auto argument = default_positional_argument_long_name();
 
-    REQUIRE(testing_argument_is_positional(argument));
-    REQUIRE_FALSE(testing_argument_is_optional(argument));
+    REQUIRE(is_positional<decltype(argument)>());
+    REQUIRE_FALSE(is_optional<decltype(argument)>());
 }
 
 TEST_CASE("has_value() should return false by default") {


### PR DESCRIPTION
Added:
* the `valid_argument_type` concept
* the `add_argument()` function to the parser class
* all the necessary members
* unit tests covering the added functionality