### PR TITLE
PWRS5PZ-31: Project namespace refinement

### DIFF
--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -32,7 +32,7 @@ template <typename T>
 concept readable =
     requires(T value, std::istream& input_stream) { input_stream >> value; };
 
-} // utility
+} // namespace utility
 
 namespace argument {
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -26,11 +26,15 @@ namespace ap {
 
 class argument_parser;
 
-namespace detail {
+namespace utility {
 
 template <typename T>
 concept readable =
     requires(T value, std::istream& input_stream) { input_stream >> value; };
+
+}
+
+namespace argument {
 
 struct argument_name {
     argument_name() = delete;
@@ -74,6 +78,8 @@ struct argument_name {
     const std::optional<std::string> short_name;
 };
 
+namespace detail {
+
 class argument_interface {
 public:
     using value_type = void;
@@ -105,8 +111,10 @@ protected:
     virtual const std::optional<std::string_view>& help() const = 0;
 };
 
-template <readable T>
-class positional_argument : public argument_interface {
+} // namespace detail
+
+template <utility::readable T>
+class positional_argument : public detail::argument_interface {
 public:
     using value_type = T;
 
@@ -180,8 +188,8 @@ private:
     std::stringstream _ss;
 };
 
-template <readable T>
-class optional_argument : public argument_interface {
+template <utility::readable T>
+class optional_argument : public detail::argument_interface {
 public:
     using value_type = T;
 
@@ -273,7 +281,7 @@ private:
     std::stringstream _ss;
 };
 
-} // namespace detail
+} // namespace argument
 
 class argument_parser {
 public:
@@ -295,45 +303,45 @@ public:
         return *this;
     }
 
-    template <detail::readable T = std::string>
-    detail::positional_argument<T>& add_positional_argument(std::string_view name) {
+    template <utility::readable T = std::string>
+    argument::positional_argument<T>& add_positional_argument(std::string_view name) {
         // TODO: check forbidden characters
         this->_check_arg_name_present(name);
         this->_positional_args.push_back(
-            std::make_unique<detail::positional_argument<T>>(name));
-        return static_cast<detail::positional_argument<T>&>(
+            std::make_unique<argument::positional_argument<T>>(name));
+        return static_cast<argument::positional_argument<T>&>(
             *this->_positional_args.back());
     }
 
-    template <detail::readable T = std::string>
-    detail::positional_argument<T>& add_positional_argument(
+    template <utility::readable T = std::string>
+    argument::positional_argument<T>& add_positional_argument(
         std::string_view name, std::string_view short_name
     ) {
         // TODO: check forbidden characters
         this->_check_arg_name_present(name);
         this->_check_arg_name_present(short_name);
         this->_positional_args.push_back(
-            std::make_unique<detail::positional_argument<T>>(name, short_name));
-        return static_cast<detail::positional_argument<T>&>(
+            std::make_unique<argument::positional_argument<T>>(name, short_name));
+        return static_cast<argument::positional_argument<T>&>(
             *this->_positional_args.back());
     }
 
-    template <detail::readable T = std::string>
-    detail::optional_argument<T>& add_optional_argument(std::string_view name) {
+    template <utility::readable T = std::string>
+    argument::optional_argument<T>& add_optional_argument(std::string_view name) {
         // TODO: check forbidden characters
         this->_check_arg_name_present(name);
-        this->_optional_args.push_back(std::make_unique<detail::optional_argument<T>>(name));
-        return static_cast<detail::optional_argument<T>&>(*this->_optional_args.back());
+        this->_optional_args.push_back(std::make_unique<argument::optional_argument<T>>(name));
+        return static_cast<argument::optional_argument<T>&>(*this->_optional_args.back());
     }
 
-    template <detail::readable T = std::string>
-    detail::optional_argument<T>& add_optional_argument(std::string_view name, std::string_view short_name) {
+    template <utility::readable T = std::string>
+    argument::optional_argument<T>& add_optional_argument(std::string_view name, std::string_view short_name) {
         // TODO: check forbidden/allowed characters
         this->_check_arg_name_present(name);
         this->_check_arg_name_present(short_name);
         this->_optional_args.push_back(
-            std::make_unique<detail::optional_argument<T>>(name, short_name));
-        return static_cast<detail::optional_argument<T>&>(*this->_optional_args.back());
+            std::make_unique<argument::optional_argument<T>>(name, short_name));
+        return static_cast<argument::optional_argument<T>&>(*this->_optional_args.back());
     }
 
     void parse_args(int argc, char* argv[]) {
@@ -386,9 +394,9 @@ private:
     using cmd_argument_list = std::vector<std::string>;
     using cmd_argument_list_iterator = typename cmd_argument_list::const_iterator;
 
-    using argument_ptr_type = std::unique_ptr<detail::argument_interface>;
+    using argument_ptr_type = std::unique_ptr<argument::detail::argument_interface>;
     using argument_opt_type =
-        std::optional<std::reference_wrapper<detail::argument_interface>>;
+        std::optional<std::reference_wrapper<argument::detail::argument_interface>>;
     using argument_list_type = std::vector<argument_ptr_type>;
     using argument_list_iterator = typename argument_list_type::iterator;
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -32,7 +32,7 @@ template <typename T>
 concept readable =
     requires(T value, std::istream& input_stream) { input_stream >> value; };
 
-}
+} // utility
 
 namespace argument {
 

--- a/test/include/argument_parser_test_fixture.hpp
+++ b/test/include/argument_parser_test_fixture.hpp
@@ -74,8 +74,8 @@ struct argument_parser_test_fixture {
         delete[] argv;
     }
 
-    ap::detail::argument_name prepare_arg_name(std::size_t i) const {
-        return ap::detail::argument_name(
+    ap::argument::argument_name prepare_arg_name(std::size_t i) const {
+        return ap::argument::argument_name(
             "test_arg_" + std::to_string(i), "ta_" + std::to_string(i)
         );
     }

--- a/test/include/optional_argument_test_fixture.hpp
+++ b/test/include/optional_argument_test_fixture.hpp
@@ -6,9 +6,9 @@
 
 #include <cstring>
 
-using ap::detail::argument_name;
-using ap::detail::optional_argument;
-using ap::detail::readable;
+using ap::argument::argument_name;
+using ap::argument::optional_argument;
+using ap::utility::readable;
 
 namespace ap_testing {
 

--- a/test/include/positional_argument_test_fixture.hpp
+++ b/test/include/positional_argument_test_fixture.hpp
@@ -6,9 +6,9 @@
 
 #include <cstring>
 
-using ap::detail::argument_name;
-using ap::detail::positional_argument;
-using ap::detail::readable;
+using ap::argument::argument_name;
+using ap::argument::positional_argument;
+using ap::utility::readable;
 
 namespace ap_testing {
 

--- a/test/tests/test_argument_name.cpp
+++ b/test/tests/test_argument_name.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <string_view>
 
-using namespace ap::detail;
+using namespace ap::argument;
 
 
 namespace {

--- a/test/tests/test_argument_parser_add_argument.cpp
+++ b/test/tests/test_argument_parser_add_argument.cpp
@@ -7,7 +7,7 @@
 
 #include <iostream>
 
-using namespace ap::detail;
+using namespace ap::argument;
 
 
 namespace {

--- a/test/tests/test_argument_parser_parse_args.cpp
+++ b/test/tests/test_argument_parser_parse_args.cpp
@@ -8,7 +8,7 @@
 #include <ap/argument_parser.hpp>
 #include <argument_parser_test_fixture.hpp>
 
-using namespace ap::detail;
+using namespace ap::argument;
 
 namespace {
 

--- a/test/tests/test_optional_argument.cpp
+++ b/test/tests/test_optional_argument.cpp
@@ -8,7 +8,7 @@
 #include <string_view>
 
 using namespace ap_testing;
-using ap::detail::optional_argument;
+using ap::argument::optional_argument;
 
 namespace {
 

--- a/test/tests/test_positional_argument.cpp
+++ b/test/tests/test_positional_argument.cpp
@@ -8,7 +8,7 @@
 #include <string_view>
 
 using namespace ap_testing;
-using ap::detail::positional_argument;
+using ap::argument::positional_argument;
 
 namespace {
 


### PR DESCRIPTION
Move the following elements to given namespace:

- argument_name                          ->     ap::argument
- argument_interface                     ->     ap::argument::detail
- positional_argument                    ->     ap::argument
- optional_argument                       ->     ap::argument
- all concepts and helper structs    ->     ap::utility

Align tests to use correct namespaces