### PR TITLE
PWRS5PZ-34: Bypassing required arguments

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -7,8 +7,15 @@ int main(int argc, char* argv[]) {
     ap::argument_parser parser;
     parser
         .program_name("power")
-        .program_description(
-            "calculates the value of expression: base ^ exponent");
+        .program_description("calculates the value of expression: base ^ exponent");
+
+    parser
+        .add_optional_argument<bool>("help", "h")
+        .default_value(false)
+        .implicit_value(true)
+        .nargs(0)
+        .help("displays help message")
+        .bypass_required();
 
     parser.add_positional_argument<double>("base");
     parser
@@ -19,8 +26,13 @@ int main(int argc, char* argv[]) {
         parser.parse_args(argc, argv);
     }
     catch (const std::exception& err) {
-        std::cerr << err.what() << std::endl << parser << std::endl;
+        std::cerr << "[ERROR] : " << err.what() << std::endl << parser << std::endl;
         std::exit(1);
+    }
+
+    if (parser.value<bool>("help")) {
+        std::cout << parser << std::endl;
+        std::exit(0);
     }
 
     const auto base = parser.value<double>("base");

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -691,6 +691,10 @@ public:
 
     void parse_args(int argc, char* argv[]) {
         this->_parse_args_impl(this->_process_input(argc, argv));
+
+        if (this->_bypass_required_args())
+            return;
+
         this->_check_required_args();
         this->_check_nvalues_in_range(); // TODO: add tests
     }
@@ -929,16 +933,16 @@ private:
         }
     }
 
-    void _check_required_args() const {
-        // TODO: align tests
-        if (std::any_of(
-                std::cbegin(this->_optional_args), std::cend(this->_optional_args),
-                [](const argument_ptr_type& arg) {
-                    return arg->is_used() and arg->bypass_required_enabled();
-                }
-            )
-        ) return;
+    [[nodiscard]] inline bool _bypass_required_args() const {
+        return std::any_of(
+            std::cbegin(this->_optional_args), std::cend(this->_optional_args),
+            [](const argument_ptr_type& arg) {
+                return arg->is_used() and arg->bypass_required_enabled();
+            }
+        );
+    }
 
+    void _check_required_args() const {
         for (const auto& arg : this->_positional_args)
             if (not arg->is_used())
                 throw std::runtime_error("[_check_required_args#1] TODO: msg");

--- a/test/tests/test_argument_parser_parse_args.cpp
+++ b/test/tests/test_argument_parser_parse_args.cpp
@@ -91,45 +91,6 @@ TEST_SUITE_BEGIN("test_argument_parser_parse_args::_parse_args_impl");
 
 TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
-    "_parse_args_impl should throw when input argument list is empty"
-) {
-    add_arguments(sut, non_default_num_args, non_default_args_split);
-
-    constexpr int no_args = 0;
-    const auto cmd_args = prepare_cmd_arg_list(no_args, no_args);
-
-    REQUIRE_THROWS_AS(sut_parse_args_impl(cmd_args), std::runtime_error);
-}
-
-TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
-    "_parse_args_impl should throw when there is less input"
-    "arguments than there are positional arguments"
-) {
-    add_arguments(sut, non_default_num_args, non_default_args_split);
-
-    const auto num_positional_values = non_default_num_args / 4;
-    const auto cmd_args =
-        prepare_cmd_arg_list(num_positional_values, num_positional_values);
-
-    REQUIRE_THROWS_AS(sut_parse_args_impl(cmd_args), std::runtime_error);
-}
-
-TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
-    "_parse_args_impl should throw when there is less input positional"
-    "argument values than there are positional arguments"
-) {
-    add_arguments(sut, non_default_num_args, non_default_args_split);
-
-    auto cmd_args = prepare_cmd_arg_list(non_default_num_args, non_default_args_split);
-    cmd_args.erase(std::next(cmd_args.begin(), non_default_args_split - 1));
-
-    REQUIRE_THROWS_AS(sut_parse_args_impl(cmd_args), std::runtime_error);
-}
-
-TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
     "_parse_args_impl should throw when there is a non-positional value specified "
     "without an argument flag present before the value"
 ) {


### PR DESCRIPTION
Add a `bypass_required()` function to the `optional_argument` class.
This function should set a flag of an argument which enables the option to bypass the requirement of specifying values of positional and `required` optional arguments.
Modify argument parsing to acount for the added functionality.
Modify existing and add new test cases to cover the added functionality