### PR TITLE
PWRS5PZ-35: Default arguments

### DIFF
--- a/example/main.cpp
+++ b/example/main.cpp
@@ -7,20 +7,15 @@ int main(int argc, char* argv[]) {
     ap::argument_parser parser;
     parser
         .program_name("power")
-        .program_description("calculates the value of expression: base ^ exponent");
-
-    parser
-        .add_optional_argument<bool>("help", "h")
-        .default_value(false)
-        .implicit_value(true)
-        .nargs(0)
-        .help("displays help message")
-        .bypass_required();
+        .program_description("calculates the value of expression: base ^ exponent")
+        .default_optional_arguments({ap::default_argument::optional::help});
 
     parser.add_positional_argument<double>("base");
     parser
         .add_optional_argument<double>("exponent", "e")
-        .default_value(static_cast<double>(1));
+        .default_value(0.)
+        .implicit_value(1.)
+        .nargs(ap::nargs::up_to(5));
 
     try {
         parser.parse_args(argc, argv);
@@ -36,9 +31,10 @@ int main(int argc, char* argv[]) {
     }
 
     const auto base = parser.value<double>("base");
-    const auto exp = parser.value<double>("exponent");
+    const auto vexp = parser.values<double>("exponent");
 
-    std::cout << base << " ^ " << exp << " = " << std::pow(base, exp) << std::endl;
+    for (const auto exp : vexp)
+        std::cout << base << " ^ " << exp << " = " << std::pow(base, exp) << std::endl;
 
     return 0;
 }

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -728,14 +728,14 @@ public:
 
     template <bool StoreImplicitly = true>
     argument::optional_argument<bool>& add_flag(std::string_view name) {
-        // TODO: add tests
         return this->add_optional_argument<bool>(name)
                     .default_value(not StoreImplicitly).implicit_value(StoreImplicitly);
     }
 
     template <bool StoreImplicitly = true>
-    argument::optional_argument<bool>& add_flag(std::string_view name, std::string_view short_name) {
-        // TODO: add tests
+    argument::optional_argument<bool>& add_flag(
+        std::string_view name, std::string_view short_name
+    ) {
         return this->add_optional_argument<bool>(name, short_name)
                     .default_value(not StoreImplicitly).implicit_value(StoreImplicitly);
     }

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -729,7 +729,9 @@ public:
     template <bool StoreImplicitly = true>
     argument::optional_argument<bool>& add_flag(std::string_view name) {
         return this->add_optional_argument<bool>(name)
-                    .default_value(not StoreImplicitly).implicit_value(StoreImplicitly);
+                    .default_value(not StoreImplicitly)
+                    .implicit_value(StoreImplicitly)
+                    .nargs(0);
     }
 
     template <bool StoreImplicitly = true>
@@ -737,7 +739,9 @@ public:
         std::string_view name, std::string_view short_name
     ) {
         return this->add_optional_argument<bool>(name, short_name)
-                    .default_value(not StoreImplicitly).implicit_value(StoreImplicitly);
+                    .default_value(not StoreImplicitly)
+                    .implicit_value(StoreImplicitly)
+                    .nargs(0);
     }
 
     void parse_args(int argc, char* argv[]) {

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -768,7 +768,7 @@ public:
 
 private:
     struct cmd_argument {
-        enum class type_discriminator { flag, value };
+        enum class type_discriminator : bool { flag, value };
 
         cmd_argument() = default;
         cmd_argument(const cmd_argument&) = default;

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -108,7 +108,7 @@ public:
 
     [[nodiscard]] std::weak_ordering contains(const range::count_type n) const {
         if (not (this->_nlow.has_value() or this->_nhigh.has_value()))
-            return std::weak_ordering::equivalent; // TODO: add tests
+            return std::weak_ordering::equivalent;
 
         if (this->_nlow.has_value() and this->_nhigh.has_value()) {
             if (n < this->_nlow.value())
@@ -162,7 +162,6 @@ private:
 }
 
 [[nodiscard]] inline range any() {
-    // TODO: add tests
     return range(std::nullopt, std::nullopt);
 }
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -205,6 +205,8 @@ detail::callable_type<ap::void_action, T> default_action{ [](T&) {} };
 
 namespace argument {
 
+namespace detail {
+
 struct argument_name {
     argument_name() = delete;
     argument_name& operator= (const argument_name&) = delete;
@@ -246,8 +248,6 @@ struct argument_name {
     const std::string name;
     const std::optional<std::string> short_name;
 };
-
-namespace detail {
 
 class argument_interface {
 public:
@@ -329,7 +329,7 @@ public:
 #endif
 
 private:
-    [[nodiscard]] inline const argument_name& name() const override {
+    [[nodiscard]] inline const detail::argument_name& name() const override {
         return this->_name;
     }
 
@@ -408,7 +408,7 @@ private:
     using action_type = ap::action::detail::action_variant_type<T>;
 
     static constexpr bool _optional{false};
-    const argument_name _name;
+    const detail::argument_name _name;
     std::optional<std::string> _help_msg;
 
     static constexpr bool _required{true};
@@ -502,7 +502,7 @@ public:
 #endif
 
 private:
-    [[nodiscard]] inline const argument_name& name() const override {
+    [[nodiscard]] inline const detail::argument_name& name() const override {
         return this->_name;
     }
 
@@ -597,7 +597,7 @@ private:
     using action_type = ap::action::detail::action_variant_type<T>;
 
     static constexpr bool _optional{true};
-    const argument_name _name;
+    const detail::argument_name _name;
     std::optional<std::string> _help_msg;
 
     bool _required{false};

--- a/test/include/argument_parser_test_fixture.hpp
+++ b/test/include/argument_parser_test_fixture.hpp
@@ -6,6 +6,8 @@
 
 #include <cstring>
 
+using ap::argument::detail::argument_name;
+
 namespace ap_testing {
 
 struct argument_parser_test_fixture {
@@ -21,27 +23,29 @@ struct argument_parser_test_fixture {
     using invalid_argument_value_type = int;
 
     // test utility functions
-    std::string prepare_arg_flag(std::size_t i) const {
+    [[nodiscard]] std::string prepare_arg_flag(std::size_t i) const {
         return "--test_arg_" + std::to_string(i);
     }
 
-    std::string prepare_arg_flag_short(std::size_t i) const {
+    [[nodiscard]] std::string prepare_arg_flag_short(std::size_t i) const {
         return "-ta_" + std::to_string(i);
     }
 
-    argument_value_type prepare_arg_value(std::size_t i) const {
+    [[nodiscard]] argument_value_type prepare_arg_value(std::size_t i) const {
         return "test_value_" + std::to_string(i);
     }
 
-    std::size_t get_args_length(std::size_t num_args, std::size_t args_split) const {
+    [[nodiscard]] std::size_t get_args_length(
+        std::size_t num_args, std::size_t args_split
+    ) const {
         return args_split + 2 * (num_args - args_split);
     }
 
-    int get_argc(std::size_t num_args, std::size_t args_split) const {
+    [[nodiscard]] int get_argc(std::size_t num_args, std::size_t args_split) const {
         return static_cast<int>(get_args_length(num_args, args_split) + 1);
     }
 
-    char** prepare_argv(std::size_t num_args, std::size_t args_split) const {
+    [[nodiscard]] char** prepare_argv(std::size_t num_args, std::size_t args_split) const {
         char** argv = new char*[get_argc(num_args, args_split)];
 
         argv[0] = new char[8];
@@ -78,13 +82,13 @@ struct argument_parser_test_fixture {
         delete[] argv;
     }
 
-    ap::argument::argument_name prepare_arg_name(std::size_t i) const {
-        return ap::argument::argument_name(
-            "test_arg_" + std::to_string(i), "ta_" + std::to_string(i)
-        );
+    [[nodiscard]] argument_name prepare_arg_name(std::size_t i) const {
+        return argument_name("test_arg_" + std::to_string(i), "ta_" + std::to_string(i));
     }
 
-    void add_arguments(ap::argument_parser& parser, std::size_t num_args, std::size_t args_split) const {
+    void add_arguments(
+        ap::argument_parser& parser, std::size_t num_args, std::size_t args_split
+    ) const {
         for (std::size_t i = 0; i < args_split; i++) { // positional args
             const auto arg_name = prepare_arg_name(i);
             parser.add_positional_argument(arg_name.name, arg_name.short_name.value());
@@ -96,7 +100,9 @@ struct argument_parser_test_fixture {
         }
     }
 
-    cmd_argument_list prepare_cmd_arg_list(std::size_t num_args, std::size_t args_split) const {
+    [[nodiscard]] cmd_argument_list prepare_cmd_arg_list(
+        std::size_t num_args, std::size_t args_split
+    ) const {
         cmd_argument_list cmd_args;
         cmd_args.reserve(get_args_length(num_args, args_split));
 
@@ -115,15 +121,15 @@ struct argument_parser_test_fixture {
     }
 
     // argument_parser private function accessors
-    const std::optional<std::string>& sut_get_program_name() const {
+    [[nodiscard]] const std::optional<std::string>& sut_get_program_name() const {
         return sut._program_name;
     }
 
-    const std::optional<std::string>& sut_get_program_description() const {
+    [[nodiscard]] const std::optional<std::string>& sut_get_program_description() const {
         return sut._program_description;
     }
 
-    cmd_argument_list sut_process_input(int argc, char* argv[]) const {
+    [[nodiscard]] cmd_argument_list sut_process_input(int argc, char* argv[]) const {
         return sut._process_input(argc, argv);
     }
 
@@ -131,7 +137,7 @@ struct argument_parser_test_fixture {
         sut._parse_args_impl(cmd_args);
     }
 
-    argument_opt_type sut_get_argument(std::string_view arg_name) const {
+    [[nodiscard]] argument_opt_type sut_get_argument(std::string_view arg_name) const {
         return sut._get_argument(arg_name);
     }
 

--- a/test/include/optional_argument_test_fixture.hpp
+++ b/test/include/optional_argument_test_fixture.hpp
@@ -6,7 +6,7 @@
 
 #include <cstring>
 
-using ap::argument::argument_name;
+using ap::argument::detail::argument_name;
 using ap::argument::optional_argument;
 using ap::utility::readable;
 

--- a/test/include/optional_argument_test_fixture.hpp
+++ b/test/include/optional_argument_test_fixture.hpp
@@ -20,14 +20,14 @@ struct optional_argument_test_fixture {
     using value_type = typename optional_argument<T>::value_type;
 
     template <readable T>
-    inline void sut_set_used(optional_argument<T>& sut) {
+    inline void sut_set_used(optional_argument<T>& sut) const {
         return sut.set_used();
     }
 
     template <readable T>
     inline optional_argument<T>& sut_set_value(
         optional_argument<T>& sut, const std::string& str_value
-    ) {
+    ) const {
         sut.set_used();
         return sut.set_value(str_value);
     }
@@ -35,7 +35,7 @@ struct optional_argument_test_fixture {
     template <readable T>
     inline optional_argument<T>& sut_set_choices(
         optional_argument<T>& sut, const std::vector<value_type<T>>& choices
-    ) {
+    ) const {
         return sut.choices(choices);
     }
 

--- a/test/include/positional_argument_test_fixture.hpp
+++ b/test/include/positional_argument_test_fixture.hpp
@@ -6,7 +6,7 @@
 
 #include <cstring>
 
-using ap::argument::argument_name;
+using ap::argument::detail::argument_name;
 using ap::argument::positional_argument;
 using ap::utility::readable;
 

--- a/test/include/positional_argument_test_fixture.hpp
+++ b/test/include/positional_argument_test_fixture.hpp
@@ -29,7 +29,7 @@ struct positional_argument_test_fixture {
     template <readable T>
     inline positional_argument<T>& sut_set_choices(
         positional_argument<T>& sut, const std::vector<value_type<T>>& choices
-    ) {
+    ) const {
         return sut.choices(choices);
     }
 

--- a/test/tests/test_argument_name.cpp
+++ b/test/tests/test_argument_name.cpp
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <string_view>
 
-using namespace ap::argument;
+using namespace ap::argument::detail;
 
 
 namespace {

--- a/test/tests/test_argument_parser_add_argument.cpp
+++ b/test/tests/test_argument_parser_add_argument.cpp
@@ -28,6 +28,40 @@ TEST_SUITE_BEGIN("test_argument_parser_add_argument");
 
 TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
+    "default_positional_arguments should add the specified arguments"
+) {
+    sut.default_positional_arguments({
+        ap::default_argument::positional::input,
+        ap::default_argument::positional::output
+    });
+
+    REQUIRE_FALSE(sut_get_argument("input")->get().is_optional());
+    REQUIRE_FALSE(sut_get_argument("output")->get().is_optional());
+}
+
+TEST_CASE_FIXTURE(
+    argument_parser_test_fixture,
+    "default_optional_arguments should add the specified arguments"
+) {
+    sut.default_optional_arguments({
+        ap::default_argument::optional::help,
+        ap::default_argument::optional::input,
+        ap::default_argument::optional::output
+    });
+
+    REQUIRE(sut_get_argument("help")->get().is_optional());
+    REQUIRE(sut_get_argument("h")->get().is_optional());
+
+    REQUIRE(sut_get_argument("input")->get().is_optional());
+    REQUIRE(sut_get_argument("i")->get().is_optional());
+
+    REQUIRE(sut_get_argument("output")->get().is_optional());
+    REQUIRE(sut_get_argument("o")->get().is_optional());
+}
+
+
+TEST_CASE_FIXTURE(
+    argument_parser_test_fixture,
     "add_positional_argument should return a positional argument reference"
 ) {
     const auto& argument = sut.add_positional_argument(name, short_name);

--- a/test/tests/test_argument_parser_add_argument.cpp
+++ b/test/tests/test_argument_parser_add_argument.cpp
@@ -4,6 +4,7 @@
 
 #include <ap/argument_parser.hpp>
 #include <argument_parser_test_fixture.hpp>
+#include <optional_argument_test_fixture.hpp>
 
 #include <iostream>
 
@@ -29,34 +30,14 @@ TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
     "add_positional_argument should return a positional argument reference"
 ) {
-    SUBCASE("with just the long name") {
-        const auto& argument = sut.add_positional_argument(name);
-        REQUIRE_FALSE(argument.is_optional());
-    }
-    SUBCASE("with both names") {
-        const auto& argument = sut.add_positional_argument(name, short_name);
-        REQUIRE_FALSE(argument.is_optional());
-    }
-}
-
-TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
-    "add_optional_argument should return a positional argument reference"
-) {
-    SUBCASE("with just the long name") {
-        const auto& argument = sut.add_optional_argument(name);
-        REQUIRE(argument.is_optional());
-    }
-    SUBCASE("with both names") {
-        const auto& argument = sut.add_optional_argument(name, short_name);
-        REQUIRE(argument.is_optional());
-    }
+    const auto& argument = sut.add_positional_argument(name, short_name);
+    REQUIRE_FALSE(argument.is_optional());
 }
 
 TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
     "add_positional_argument should throw only when adding an"
-    "argument with previously used name"
+    "argument with a previously used name"
 ) {
     sut.add_positional_argument(name, short_name);
 
@@ -65,7 +46,8 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("adding argument with a previously used long name") {
-        REQUIRE_THROWS_AS(sut.add_positional_argument(name), std::invalid_argument);
+        REQUIRE_THROWS_AS(
+            sut.add_positional_argument(name, other_short_name), std::invalid_argument);
     }
 
     SUBCASE("adding argument with a previously used short name") {
@@ -75,10 +57,19 @@ TEST_CASE_FIXTURE(
     }
 }
 
+
+TEST_CASE_FIXTURE(
+    argument_parser_test_fixture,
+    "add_optional_argument should return an optional argument reference"
+) {
+    const auto& argument = sut.add_optional_argument(name, short_name);
+    REQUIRE(argument.is_optional());
+}
+
 TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
     "add_optional_argument should throw only when adding an"
-    "argument with previously used name"
+    "argument with a previously used name"
 ) {
     sut.add_optional_argument(name, short_name);
 
@@ -87,11 +78,59 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("adding argument with a previously used long name") {
-        REQUIRE_THROWS_AS(sut.add_optional_argument(name), std::invalid_argument);
+        REQUIRE_THROWS_AS(
+            sut.add_optional_argument(name, other_short_name), std::invalid_argument);
     }
 
     SUBCASE("adding argument with a previously used short name") {
         REQUIRE_THROWS_AS(sut.add_optional_argument(other_name, short_name), std::invalid_argument);
+    }
+}
+
+
+TEST_CASE_FIXTURE(
+    argument_parser_test_fixture,
+    "add_flag should return an optional argument reference with flag parameters"
+) {
+    const optional_argument_test_fixture opt_arg_fixture;
+
+    SUBCASE("StoreImplicitly = true") {
+        auto& argument = sut.add_flag(name, short_name);
+
+        REQUIRE(argument.is_optional());
+        REQUIRE_FALSE(sut.value<bool>(name));
+
+        opt_arg_fixture.sut_set_used(argument);
+        REQUIRE(sut.value<bool>(name));
+    }
+
+    SUBCASE("StoreImplicitly = false") {
+        auto& argument = sut.add_flag<false>(name, short_name);
+
+        REQUIRE(argument.is_optional());
+        REQUIRE(sut.value<bool>(name));
+
+        opt_arg_fixture.sut_set_used(argument);
+        REQUIRE_FALSE(sut.value<bool>(name));
+    }
+}
+
+TEST_CASE_FIXTURE(
+    argument_parser_test_fixture,
+    "add_flag should throw only when adding and argument with a previously used name"
+) {
+    sut.add_flag(name, short_name);
+
+    SUBCASE("adding argument with a unique name") {
+        REQUIRE_NOTHROW(sut.add_flag(other_name, other_short_name));
+    }
+
+    SUBCASE("adding argument with a previously used long name") {
+        REQUIRE_THROWS_AS(sut.add_flag(name, other_short_name), std::invalid_argument);
+    }
+
+    SUBCASE("adding argument with a previously used short name") {
+        REQUIRE_THROWS_AS(sut.add_flag(other_name, short_name), std::invalid_argument);
     }
 }
 

--- a/test/tests/test_nargs_range.cpp
+++ b/test/tests/test_nargs_range.cpp
@@ -101,6 +101,17 @@ TEST_CASE("range builders should return correct range objects") {
         REQUIRE(std::is_gt(sut.contains(nhigh + 1)));
         REQUIRE(std::is_gt(sut.contains(nmax)));
     }
+
+    SUBCASE("any") {
+        const auto sut = any();
+
+        REQUIRE(std::is_eq(sut.contains(nmin)));
+        REQUIRE(std::is_eq(sut.contains(ndefault)));
+        REQUIRE(std::is_eq(sut.contains(nlow)));
+        REQUIRE(std::is_eq(sut.contains(nmid)));
+        REQUIRE(std::is_eq(sut.contains(nhigh)));
+        REQUIRE(std::is_eq(sut.contains(nmax)));
+    }
 }
 
 TEST_SUITE_END(); // test_nargs_range


### PR DESCRIPTION
1. Added:
   * the `add_flag<bool>(name)` function to the parser
   * the `ap::defeault_argument` struct
   * the `default_{positional/optional}_arguments(vector<default_arg_specifier>)` functions to the argument parser
   * explicit enum class underlying types
   * tests covering the added functionality
2. Moved the `argument_name` class to the `ap::argument::detail` namespace