### PR TITLE
YT-CPPAP-5: Rename the argument_name members

### DIFF
--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -147,7 +147,7 @@ public:
     ~range() = default;
 
     /// @return True if the range is [1, 1].
-    [[nodiscard]] inline bool is_default() const {
+    [[nodiscard]] bool is_default() const {
         return this->_default;
     }
 
@@ -350,7 +350,7 @@ struct argument_name {
      * @param other The argument_name instance to compare with.
      * @return Equality of argument names.
      */
-    inline bool operator==(const argument_name& other) const {
+    bool operator==(const argument_name& other) const {
         return this->primary == other.primary;
     }
 
@@ -359,12 +359,12 @@ struct argument_name {
      * @param name The string view to compare with.
      * @return Equality of names comparison (either primary or secondary name).
      */
-    inline bool operator==(std::string_view name) const {
+    bool operator==(std::string_view name) const {
         return name == this->primary or (this->secondary and name == this->secondary.value());
     }
 
     /// @brief Get a string representation of the argument_name.
-    [[nodiscard]] inline std::string str() const {
+    [[nodiscard]] std::string str() const {
         return this->secondary
                  ? ("[" + this->primary + "," + this->secondary.value() + "]")
                  : ("[" + this->primary + "]");
@@ -639,7 +639,7 @@ public:
      * @param other Another positional_argument for comparison.
      * @return Result of equality
      */
-    inline bool operator==(const positional_argument& other) const {
+    bool operator==(const positional_argument& other) const {
         return this->_name == other._name;
     }
 
@@ -648,7 +648,7 @@ public:
      * @param help_msg The help message to set.
      * @return Reference to the positional_argument.
      */
-    inline positional_argument& help(std::string_view help_msg) override {
+    positional_argument& help(std::string_view help_msg) override {
         this->_help_msg = help_msg;
         return *this;
     }
@@ -659,7 +659,7 @@ public:
      * @return Reference to the positional_argument.
      * @note Requires T to be equality comparable.
      */
-    inline positional_argument& choices(const std::vector<value_type>& choices)
+    positional_argument& choices(const std::vector<value_type>& choices)
     requires(utility::equality_comparable<value_type>)
     {
         this->_choices = choices;
@@ -674,14 +674,14 @@ public:
      * @return Reference to the positional_argument.
      */
     template <ap::action::detail::valid_action_specifier AS, std::invocable<value_type&> F>
-    inline positional_argument& action(F&& action) {
+    positional_argument& action(F&& action) {
         using callable_type = ap::action::detail::callable_type<AS, value_type>;
         this->_action = std::forward<callable_type>(action);
         return *this;
     }
 
     /// @return True if the positional argument is optional., false if required.
-    [[nodiscard]] inline bool is_optional() const override {
+    [[nodiscard]] bool is_optional() const override {
         return this->_optional;
     }
 
@@ -698,22 +698,22 @@ public:
 
 private:
     /// @return Reference the name of the positional argument.
-    [[nodiscard]] inline const detail::argument_name& name() const override {
+    [[nodiscard]] const detail::argument_name& name() const override {
         return this->_name;
     }
 
     /// @return Optional help message for the positional argument.
-    [[nodiscard]] inline const std::optional<std::string>& help() const override {
+    [[nodiscard]] const std::optional<std::string>& help() const override {
         return this->_help_msg;
     }
 
     /// @return True if the positional argument is required, false otherwise
-    [[nodiscard]] inline bool is_required() const override {
+    [[nodiscard]] bool is_required() const override {
         return this->_required;
     }
 
     /// @return True if bypassing the required status is enabled for the positional argument, false otherwise.
-    [[nodiscard]] inline bool bypass_required_enabled() const override {
+    [[nodiscard]] bool bypass_required_enabled() const override {
         return this->_bypass_required;
     }
 
@@ -724,12 +724,12 @@ private:
     void set_used() override {}
 
     /// @return True if the positional argument is used, false otherwise.
-    [[nodiscard]] inline bool is_used() const override {
+    [[nodiscard]] bool is_used() const override {
         return this->_value.has_value();
     }
 
     /// @return The number of times the positional argument is used.
-    [[nodiscard]] inline std::size_t nused() const override {
+    [[nodiscard]] std::size_t nused() const override {
         return static_cast<std::size_t>(this->_value.has_value());
     }
 
@@ -759,27 +759,27 @@ private:
     }
 
     /// @return True if the positional argument has a value, false otherwise.
-    [[nodiscard]] inline bool has_value() const override {
+    [[nodiscard]] bool has_value() const override {
         return this->_value.has_value();
     }
 
     /// @return True if the positional argument has parsed values, false otherwise.
-    [[nodiscard]] inline bool has_parsed_values() const override {
+    [[nodiscard]] bool has_parsed_values() const override {
         return this->_value.has_value();
     }
 
     /// @return Ordering relationship of positional argument range.
-    [[nodiscard]] inline std::weak_ordering nvalues_in_range() const override {
+    [[nodiscard]] std::weak_ordering nvalues_in_range() const override {
         return this->_value.has_value() ? std::weak_ordering::equivalent : std::weak_ordering::less;
     }
 
     /// @brief Get the stored value of the positional argument.
-    [[nodiscard]] inline const std::any& value() const override {
+    [[nodiscard]] const std::any& value() const override {
         return this->_value;
     }
 
     /// @return Reference to the vector of parsed values for the positional argument.
-    [[nodiscard]] inline const std::vector<std::any>& values() const override {
+    [[nodiscard]] const std::vector<std::any>& values() const override {
         throw std::logic_error("Positional argument " + this->_name.primary + "has only 1 value.");
     }
 
@@ -788,7 +788,7 @@ private:
      * @param choice The value to check against choices.
      * @return True if the choice valid, false otherwise.
      */
-    [[nodiscard]] inline bool _is_valid_choice(const value_type& choice) const {
+    [[nodiscard]] bool _is_valid_choice(const value_type& choice) const {
         return this->_choices.empty() or std::ranges::find(this->_choices, choice) != this->_choices.end();
     }
 
@@ -856,7 +856,7 @@ public:
      * @param other The optional_argument to compare with.
      * @return Equality of comparison.
      */
-    inline bool operator==(const optional_argument& other) const {
+    bool operator==(const optional_argument& other) const {
         return this->_name == other._name;
     }
 
@@ -865,7 +865,7 @@ public:
      * @param help_msg The help message to set.
      * @return Reference to the optional_argument.
      */
-    inline optional_argument& help(std::string_view help_msg) override {
+    optional_argument& help(std::string_view help_msg) override {
         this->_help_msg = help_msg;
         return *this;
     }
@@ -874,7 +874,7 @@ public:
      * @brief Mark the optional argument as required.
      * @return Reference to the optional_argument.
      */
-    inline optional_argument& required() {
+    optional_argument& required() {
         this->_required = true;
         return *this;
     }
@@ -883,7 +883,7 @@ public:
      * @brief Enable bypassing the required status for the optional argument.
      * @return Reference to the optional_argument.
      */
-    inline optional_argument& bypass_required() {
+    optional_argument& bypass_required() {
         this->_bypass_required = true;
         return *this;
     }
@@ -893,7 +893,7 @@ public:
      * @param range The nargs range to set.
      * @return Reference to the optional_argument.
      */
-    inline optional_argument& nargs(const ap::nargs::range& range) {
+    optional_argument& nargs(const ap::nargs::range& range) {
         this->_nargs_range = range;
         return *this;
     }
@@ -903,7 +903,7 @@ public:
      * @param count The count for nargs range.
      * @return Reference to the optional_argument.
      */
-    inline optional_argument& nargs(const count_type count) {
+    optional_argument& nargs(const count_type count) {
         this->_nargs_range = ap::nargs::range(count);
         return *this;
     }
@@ -914,7 +914,7 @@ public:
      * @param nhigh The upper bound for nargs range.
      * @return Reference to the optional_argument.
      */
-    inline optional_argument& nargs(const count_type nlow, const count_type nhigh) {
+    optional_argument& nargs(const count_type nlow, const count_type nhigh) {
         this->_nargs_range = ap::nargs::range(nlow, nhigh);
         return *this;
     }
@@ -927,7 +927,7 @@ public:
      * @return Reference to the optional_argument.
      */
     template <ap::action::detail::valid_action_specifier AS, std::invocable<value_type&> F>
-    inline optional_argument& action(F&& action) {
+    optional_argument& action(F&& action) {
         using callable_type = ap::action::detail::callable_type<AS, value_type>;
         this->_action = std::forward<callable_type>(action);
         return *this;
@@ -939,7 +939,7 @@ public:
      * @return Reference to the optional_argument.
      * @note Requires T to be equality comparable.
      */
-    inline optional_argument& choices(const std::vector<value_type>& choices)
+    optional_argument& choices(const std::vector<value_type>& choices)
     requires(utility::equality_comparable<value_type>)
     {
         this->_choices = choices;
@@ -967,7 +967,7 @@ public:
     }
 
     /// @return True if argument is optional, false otherwise.
-    [[nodiscard]] inline bool is_optional() const override {
+    [[nodiscard]] bool is_optional() const override {
         return this->_optional;
     }
 
@@ -983,22 +983,22 @@ public:
 
 private:
     /// @return Reference to the name of the optional argument.
-    [[nodiscard]] inline const detail::argument_name& name() const override {
+    [[nodiscard]] const detail::argument_name& name() const override {
         return this->_name;
     }
 
     /// @return Reference to the optional help message for the optional argument.
-    [[nodiscard]] inline const std::optional<std::string>& help() const override {
+    [[nodiscard]] const std::optional<std::string>& help() const override {
         return this->_help_msg;
     }
 
     /// @return True if the optional argument is required, false otherwise.
-    [[nodiscard]] inline bool is_required() const override {
+    [[nodiscard]] bool is_required() const override {
         return this->_required;
     }
 
     /// @return True if bypassing the required status is enabled for the optional argument, false otherwise.
-    [[nodiscard]] inline bool bypass_required_enabled() const override {
+    [[nodiscard]] bool bypass_required_enabled() const override {
         return this->_bypass_required;
     }
 
@@ -1008,12 +1008,12 @@ private:
     }
 
     /// @return True if the optional argument is used, false otherwise.
-    [[nodiscard]] inline bool is_used() const override {
+    [[nodiscard]] bool is_used() const override {
         return this->_nused > 0;
     }
 
     /// @return The number of times the optional argument is used.
-    [[nodiscard]] inline std::size_t nused() const override {
+    [[nodiscard]] std::size_t nused() const override {
         return this->_nused;
     }
 
@@ -1043,12 +1043,12 @@ private:
     }
 
     /// @return True if the optional argument has a value, false otherwise.
-    [[nodiscard]] inline bool has_value() const override {
+    [[nodiscard]] bool has_value() const override {
         return this->has_parsed_values() or this->_has_predefined_value();
     }
 
     /// @return True if parsed values are available for the optional argument, false otherwise.
-    [[nodiscard]] inline bool has_parsed_values() const override {
+    [[nodiscard]] bool has_parsed_values() const override {
         return not this->_values.empty();
     }
 
@@ -1064,22 +1064,22 @@ private:
     }
 
     /// @return Reference to the stored value of the optional argument.
-    [[nodiscard]] inline const std::any& value() const override {
+    [[nodiscard]] const std::any& value() const override {
         return this->_values.empty() ? this->_predefined_value() : this->_values.front();
     }
 
     /// @return Reference to the vector of parsed values for the optional argument.
-    [[nodiscard]] inline const std::vector<std::any>& values() const override {
+    [[nodiscard]] const std::vector<std::any>& values() const override {
         return this->_values;
     }
 
     /// @return True if the optional argument has a predefined value, false otherwise.
-    [[nodiscard]] inline bool _has_predefined_value() const {
+    [[nodiscard]] bool _has_predefined_value() const {
         return this->_default_value.has_value() or (this->is_used() and this->_implicit_value.has_value());
     }
 
     /// @return Reference to the predefined value of the optional argument.
-    [[nodiscard]] inline const std::any& _predefined_value() const {
+    [[nodiscard]] const std::any& _predefined_value() const {
         return this->is_used() ? this->_implicit_value : this->_default_value;
     }
 
@@ -1088,7 +1088,7 @@ private:
      * @param choice The value to check against choices.
      * @return True if choice is valid, false otherwise.
      */
-    [[nodiscard]] inline bool _is_valid_choice(const value_type& choice) const {
+    [[nodiscard]] bool _is_valid_choice(const value_type& choice) const {
         return this->_choices.empty() or std::ranges::find(this->_choices, choice) != this->_choices.end();
     }
 
@@ -1156,7 +1156,7 @@ public:
      * @param name The name of the program.
      * @return Reference to the argument parser.
      */
-    inline argument_parser& program_name(std::string_view name) {
+    argument_parser& program_name(std::string_view name) {
         this->_program_name = name;
         return *this;
     }
@@ -1166,7 +1166,7 @@ public:
      * @param description The description of the program.
      * @return Reference to the argument parser.
      */
-    inline argument_parser& program_description(std::string_view description) {
+    argument_parser& program_description(std::string_view description) {
         this->_program_description = description;
         return *this;
     }
@@ -1176,7 +1176,7 @@ public:
      * @param args Vector of default positional argument categories.
      * @return Reference to the argument parser.
      */
-    inline argument_parser& default_positional_arguments(const std::vector<default_argument::positional>& args) {
+    argument_parser& default_positional_arguments(const std::vector<default_argument::positional>& args) {
         for (const auto arg : args)
             this->_add_default_positional_argument(arg);
         return *this;
@@ -1187,7 +1187,7 @@ public:
      * @param args Vector of default optional argument categories.
      * @return Reference to the argument parser.
      */
-    inline argument_parser& default_optional_arguments(const std::vector<default_argument::optional>& args) {
+    argument_parser& default_optional_arguments(const std::vector<default_argument::optional>& args) {
         for (const auto arg : args)
             this->_add_default_optional_argument(arg);
         return *this;
@@ -1435,7 +1435,7 @@ private:
          * @param other Another cmd_argument to compare with.
          * @return Boolean statement of equality comparison.
          */
-        inline bool operator==(const cmd_argument& other) const {
+        bool operator==(const cmd_argument& other) const {
             return this->discriminator == other.discriminator and this->value == other.value;
         }
 
@@ -1512,7 +1512,7 @@ private:
      * @param name The name of the argument.
      * @return Argument predicate based on the provided name.
      */
-    [[nodiscard]] inline argument_predicate_type _name_eq_predicate(const std::string_view& name) const {
+    [[nodiscard]] argument_predicate_type _name_eq_predicate(const std::string_view& name) const {
         return [&name](const argument_ptr_type& arg) { return name == arg->name(); };
     }
 
@@ -1522,7 +1522,7 @@ private:
      * @param secondary_name The secondary name of the argument.
      * @return Argument predicate based on the provided name and secondary name.
      */
-    [[nodiscard]] inline argument_predicate_type _name_eq_predicate(
+    [[nodiscard]] argument_predicate_type _name_eq_predicate(
         const std::string_view& primary_name, const std::string_view& secondary_name
     ) const {
         return [&primary_name, &secondary_name](const argument_ptr_type& arg) {
@@ -1682,7 +1682,7 @@ private:
      * @brief Check if optional arguments can bypass the required arguments.
      * @return True if optional arguments can bypass required arguments, false otherwise.
      */
-    [[nodiscard]] inline bool _bypass_required_args() const {
+    [[nodiscard]] bool _bypass_required_args() const {
         return std::ranges::any_of(this->_optional_args, [](const argument_ptr_type& arg) {
             return arg->is_used() and arg->bypass_required_enabled();
         });

--- a/test/include/argument_parser_test_fixture.hpp
+++ b/test/include/argument_parser_test_fixture.hpp
@@ -27,7 +27,7 @@ struct argument_parser_test_fixture {
         return "--test_arg_" + std::to_string(i);
     }
 
-    [[nodiscard]] std::string prepare_arg_flag_short(std::size_t i) const {
+    [[nodiscard]] std::string prepare_arg_flag_secondary(std::size_t i) const {
         return "-ta_" + std::to_string(i);
     }
 
@@ -87,12 +87,12 @@ struct argument_parser_test_fixture {
     void add_arguments(ap::argument_parser& parser, std::size_t num_args, std::size_t args_split) const {
         for (std::size_t i = 0; i < args_split; i++) { // positional args
             const auto arg_name = prepare_arg_name(i);
-            parser.add_positional_argument(arg_name.name, arg_name.short_name.value());
+            parser.add_positional_argument(arg_name.primary, arg_name.secondary.value());
         }
 
         for (std::size_t i = args_split; i < num_args; i++) { // optional args
             const auto arg_name = prepare_arg_name(i);
-            parser.add_optional_argument(arg_name.name, arg_name.short_name.value());
+            parser.add_optional_argument(arg_name.primary, arg_name.secondary.value());
         }
     }
 
@@ -105,7 +105,7 @@ struct argument_parser_test_fixture {
         }
         for (std::size_t i = args_split; i < num_args; i++) { // optional args
             cmd_args.push_back(cmd_argument{
-                cmd_argument::type_discriminator::flag, prepare_arg_name(i).name });
+                cmd_argument::type_discriminator::flag, prepare_arg_name(i).primary });
             cmd_args.push_back(cmd_argument{ cmd_argument::type_discriminator::value, prepare_arg_value(i) });
         }
 

--- a/test/source/test_argument_name.cpp
+++ b/test/source/test_argument_name.cpp
@@ -12,55 +12,55 @@ using namespace ap::argument::detail;
 
 namespace {
 
-constexpr std::string_view name = "test";
-constexpr std::string_view short_name = "t";
+constexpr std::string_view primary_name = "test";
+constexpr std::string_view secondary_name = "t";
 
-constexpr std::string_view other_name = "other";
-constexpr std::string_view other_short_name = "o";
+constexpr std::string_view other_primary_name = "other";
+constexpr std::string_view other_secondary_name = "o";
 
-argument_name default_argument_name_long_name() {
-    return argument_name(name);
+argument_name default_argument_name_primary_only() {
+    return argument_name(primary_name);
 }
 
-argument_name default_argument_name_both_names() {
-    return argument_name(name, short_name);
+argument_name default_argument_name_primary_and_secondary() {
+    return argument_name(primary_name, secondary_name);
 }
 
 } // namespace
 
 TEST_SUITE_BEGIN("test_argument_name");
 
-TEST_CASE("argument_name.name member should be correctly "
+TEST_CASE("argument_name.primary member should be correctly "
           "initialized") {
-    const auto arg_name = default_argument_name_long_name();
+    const auto arg_name = default_argument_name_primary_only();
 
-    REQUIRE_EQ(arg_name.name, name);
+    REQUIRE_EQ(arg_name.primary, primary_name);
 }
 
 TEST_CASE("argument_name members should be correctly "
           "initialized") {
-    const auto arg_name = default_argument_name_both_names();
+    const auto arg_name = default_argument_name_primary_and_secondary();
 
-    REQUIRE_EQ(arg_name.name, name);
+    REQUIRE_EQ(arg_name.primary, primary_name);
 
-    REQUIRE(arg_name.short_name);
-    REQUIRE_EQ(arg_name.short_name.value(), short_name);
+    REQUIRE(arg_name.secondary);
+    REQUIRE_EQ(arg_name.secondary.value(), secondary_name);
 }
 
 TEST_CASE("argument_name::operator==(argument_name) should "
           "return true if "
-          "long names are equal") {
-    const auto arg_name_a = default_argument_name_long_name();
-    const auto arg_name_b = default_argument_name_both_names();
+          "primary names are equal") {
+    const auto arg_name_a = default_argument_name_primary_only();
+    const auto arg_name_b = default_argument_name_primary_and_secondary();
 
     REQUIRE(arg_name_a == arg_name_b);
 }
 
 TEST_CASE("argument_name::operator==(argument_name) should "
           "return false if "
-          "long names are not equal") {
-    const auto arg_name_a = default_argument_name_long_name();
-    const auto arg_name_b = argument_name(other_name, other_short_name);
+          "primary names are not equal") {
+    const auto arg_name_a = default_argument_name_primary_only();
+    const auto arg_name_b = argument_name(other_primary_name, other_secondary_name);
 
     REQUIRE_FALSE(arg_name_a == arg_name_b);
 }
@@ -68,49 +68,49 @@ TEST_CASE("argument_name::operator==(argument_name) should "
 TEST_CASE("argument_name::operator==(string_view) should "
           "return true if at "
           "least one name matches") {
-    SUBCASE("argument_name with long name only") {
-        const auto arg_name = default_argument_name_long_name();
+    SUBCASE("argument_name with primary name only") {
+        const auto arg_name = default_argument_name_primary_only();
 
-        REQUIRE(arg_name == name);
+        REQUIRE(arg_name == primary_name);
     }
 
     SUBCASE("argument_name with both names") {
-        const auto arg_name = default_argument_name_both_names();
+        const auto arg_name = default_argument_name_primary_and_secondary();
 
-        REQUIRE(arg_name == name);
-        REQUIRE(arg_name == short_name);
+        REQUIRE(arg_name == primary_name);
+        REQUIRE(arg_name == secondary_name);
     }
 }
 
 TEST_CASE("argument_name::operator==(string_view) should "
           "return false if no "
           "name matches") {
-    SUBCASE("argument_name with long name only") {
-        const auto arg_name = default_argument_name_long_name();
+    SUBCASE("argument_name with primary name only") {
+        const auto arg_name = default_argument_name_primary_only();
 
-        REQUIRE_FALSE(arg_name == other_name);
-        REQUIRE_FALSE(arg_name == other_short_name);
+        REQUIRE_FALSE(arg_name == other_primary_name);
+        REQUIRE_FALSE(arg_name == other_secondary_name);
     }
 
     SUBCASE("argument_name with both names") {
-        const auto arg_name = default_argument_name_both_names();
+        const auto arg_name = default_argument_name_primary_and_secondary();
 
-        REQUIRE_FALSE(arg_name == other_name);
-        REQUIRE_FALSE(arg_name == other_short_name);
+        REQUIRE_FALSE(arg_name == other_primary_name);
+        REQUIRE_FALSE(arg_name == other_secondary_name);
     }
 }
 
 TEST_CASE("operator<< should push correct data to the output stream") {
     std::stringstream ss, expected_ss;
 
-    SUBCASE("argument_name with long name only") {
-        ss << default_argument_name_long_name();
-        expected_ss << "[" << name << "]";
+    SUBCASE("argument_name with primary name only") {
+        ss << default_argument_name_primary_only();
+        expected_ss << "[" << primary_name << "]";
     }
 
     SUBCASE("argument_name with both names") {
-        ss << default_argument_name_both_names();
-        expected_ss << "[" << name << "," << short_name << "]";
+        ss << default_argument_name_primary_and_secondary();
+        expected_ss << "[" << primary_name << "," << secondary_name << "]";
     }
 
     CAPTURE(ss);

--- a/test/source/test_argument_parser_add_argument.cpp
+++ b/test/source/test_argument_parser_add_argument.cpp
@@ -13,11 +13,11 @@ using namespace ap::argument;
 
 namespace {
 
-constexpr std::string_view name = "test";
-constexpr std::string_view short_name = "t";
+constexpr std::string_view primary_name = "test";
+constexpr std::string_view secondary_name = "t";
 
-constexpr std::string_view other_name = "other";
-constexpr std::string_view other_short_name = "o";
+constexpr std::string_view other_primary_name = "other";
+constexpr std::string_view other_secondary_name = "o";
 
 } // namespace
 
@@ -50,7 +50,7 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "default_optional_arguments shou
 }
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "add_positional_argument should return a positional argument reference") {
-    const auto& argument = sut.add_positional_argument(name, short_name);
+    const auto& argument = sut.add_positional_argument(primary_name, secondary_name);
     REQUIRE_FALSE(argument.is_optional());
 }
 
@@ -59,23 +59,23 @@ TEST_CASE_FIXTURE(
     "add_positional_argument should throw only when adding an"
     "argument with a previously used name"
 ) {
-    sut.add_positional_argument(name, short_name);
+    sut.add_positional_argument(primary_name, secondary_name);
 
     SUBCASE("adding argument with a unique name") {
-        REQUIRE_NOTHROW(sut.add_positional_argument(other_name, other_short_name));
+        REQUIRE_NOTHROW(sut.add_positional_argument(other_primary_name, other_secondary_name));
     }
 
-    SUBCASE("adding argument with a previously used long name") {
-        REQUIRE_THROWS_AS(sut.add_positional_argument(name, other_short_name), ap::error::argument_name_used_error);
+    SUBCASE("adding argument with a previously used primary name") {
+        REQUIRE_THROWS_AS(sut.add_positional_argument(primary_name, other_secondary_name), ap::error::argument_name_used_error);
     }
 
-    SUBCASE("adding argument with a previously used short name") {
-        REQUIRE_THROWS_AS(sut.add_positional_argument(other_name, short_name), ap::error::argument_name_used_error);
+    SUBCASE("adding argument with a previously used secondary name") {
+        REQUIRE_THROWS_AS(sut.add_positional_argument(other_primary_name, secondary_name), ap::error::argument_name_used_error);
     }
 }
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "add_optional_argument should return an optional argument reference") {
-    const auto& argument = sut.add_optional_argument(name, short_name);
+    const auto& argument = sut.add_optional_argument(primary_name, secondary_name);
     REQUIRE(argument.is_optional());
 }
 
@@ -84,18 +84,18 @@ TEST_CASE_FIXTURE(
     "add_optional_argument should throw only when adding an"
     "argument with a previously used name"
 ) {
-    sut.add_optional_argument(name, short_name);
+    sut.add_optional_argument(primary_name, secondary_name);
 
     SUBCASE("adding argument with a unique name") {
-        REQUIRE_NOTHROW(sut.add_optional_argument(other_name, other_short_name));
+        REQUIRE_NOTHROW(sut.add_optional_argument(other_primary_name, other_secondary_name));
     }
 
-    SUBCASE("adding argument with a previously used long name") {
-        REQUIRE_THROWS_AS(sut.add_optional_argument(name, other_short_name), ap::error::argument_name_used_error);
+    SUBCASE("adding argument with a previously used primary name") {
+        REQUIRE_THROWS_AS(sut.add_optional_argument(primary_name, other_secondary_name), ap::error::argument_name_used_error);
     }
 
-    SUBCASE("adding argument with a previously used short name") {
-        REQUIRE_THROWS_AS(sut.add_optional_argument(other_name, short_name), ap::error::argument_name_used_error);
+    SUBCASE("adding argument with a previously used secondary name") {
+        REQUIRE_THROWS_AS(sut.add_optional_argument(other_primary_name, secondary_name), ap::error::argument_name_used_error);
     }
 }
 
@@ -103,39 +103,39 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "add_flag should return an optio
     const optional_argument_test_fixture opt_arg_fixture;
 
     SUBCASE("StoreImplicitly = true") {
-        auto& argument = sut.add_flag(name, short_name);
+        auto& argument = sut.add_flag(primary_name, secondary_name);
 
         REQUIRE(argument.is_optional());
-        REQUIRE_FALSE(sut.value<bool>(name));
+        REQUIRE_FALSE(sut.value<bool>(primary_name));
 
         opt_arg_fixture.sut_set_used(argument);
-        REQUIRE(sut.value<bool>(name));
+        REQUIRE(sut.value<bool>(primary_name));
     }
 
     SUBCASE("StoreImplicitly = false") {
-        auto& argument = sut.add_flag<false>(name, short_name);
+        auto& argument = sut.add_flag<false>(primary_name, secondary_name);
 
         REQUIRE(argument.is_optional());
-        REQUIRE(sut.value<bool>(name));
+        REQUIRE(sut.value<bool>(primary_name));
 
         opt_arg_fixture.sut_set_used(argument);
-        REQUIRE_FALSE(sut.value<bool>(name));
+        REQUIRE_FALSE(sut.value<bool>(primary_name));
     }
 }
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "add_flag should throw only when adding and argument with a previously used name") {
-    sut.add_flag(name, short_name);
+    sut.add_flag(primary_name, secondary_name);
 
     SUBCASE("adding argument with a unique name") {
-        REQUIRE_NOTHROW(sut.add_flag(other_name, other_short_name));
+        REQUIRE_NOTHROW(sut.add_flag(other_primary_name, other_secondary_name));
     }
 
-    SUBCASE("adding argument with a previously used long name") {
-        REQUIRE_THROWS_AS(sut.add_flag(name, other_short_name), ap::error::argument_name_used_error);
+    SUBCASE("adding argument with a previously used primary name") {
+        REQUIRE_THROWS_AS(sut.add_flag(primary_name, other_secondary_name), ap::error::argument_name_used_error);
     }
 
-    SUBCASE("adding argument with a previously used short name") {
-        REQUIRE_THROWS_AS(sut.add_flag(other_name, short_name), ap::error::argument_name_used_error);
+    SUBCASE("adding argument with a previously used secondary name") {
+        REQUIRE_THROWS_AS(sut.add_flag(other_primary_name, secondary_name), ap::error::argument_name_used_error);
     }
 }
 

--- a/test/source/test_argument_parser_add_argument.cpp
+++ b/test/source/test_argument_parser_add_argument.cpp
@@ -66,11 +66,15 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("adding argument with a previously used primary name") {
-        REQUIRE_THROWS_AS(sut.add_positional_argument(primary_name, other_secondary_name), ap::error::argument_name_used_error);
+        REQUIRE_THROWS_AS(
+            sut.add_positional_argument(primary_name, other_secondary_name), ap::error::argument_name_used_error
+        );
     }
 
     SUBCASE("adding argument with a previously used secondary name") {
-        REQUIRE_THROWS_AS(sut.add_positional_argument(other_primary_name, secondary_name), ap::error::argument_name_used_error);
+        REQUIRE_THROWS_AS(
+            sut.add_positional_argument(other_primary_name, secondary_name), ap::error::argument_name_used_error
+        );
     }
 }
 
@@ -91,11 +95,15 @@ TEST_CASE_FIXTURE(
     }
 
     SUBCASE("adding argument with a previously used primary name") {
-        REQUIRE_THROWS_AS(sut.add_optional_argument(primary_name, other_secondary_name), ap::error::argument_name_used_error);
+        REQUIRE_THROWS_AS(
+            sut.add_optional_argument(primary_name, other_secondary_name), ap::error::argument_name_used_error
+        );
     }
 
     SUBCASE("adding argument with a previously used secondary name") {
-        REQUIRE_THROWS_AS(sut.add_optional_argument(other_primary_name, secondary_name), ap::error::argument_name_used_error);
+        REQUIRE_THROWS_AS(
+            sut.add_optional_argument(other_primary_name, secondary_name), ap::error::argument_name_used_error
+        );
     }
 }
 

--- a/test/source/test_argument_parser_parse_args.cpp
+++ b/test/source/test_argument_parser_parse_args.cpp
@@ -22,10 +22,10 @@ constexpr std::size_t non_default_args_split = non_default_num_args / 2;
 
 const std::string invalid_arg_name = "invalid_arg";
 
-const std::string positional_arg_name = "positional_arg";
-const std::string positional_arg_short_name = "pa";
-const std::string optional_arg_name = "optional_arg";
-const std::string optional_arg_short_name = "oa";
+const std::string positional_arg_name_primary = "positional_arg";
+const std::string positional_arg_name_secondary = "pa";
+const std::string optional_arg_name_primary = "optional_arg";
+const std::string optional_arg_name_secondary = "oa";
 
 } // namespace
 
@@ -121,8 +121,8 @@ TEST_CASE_FIXTURE(
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE(sut_get_argument(arg_name.name));
-        REQUIRE(sut_get_argument(arg_name.short_name.value()));
+        REQUIRE(sut_get_argument(arg_name.primary));
+        REQUIRE(sut_get_argument(arg_name.secondary.value()));
     }
 }
 
@@ -132,7 +132,7 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "parse_args should throw when th
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
     const auto required_arg_name = prepare_arg_name(non_default_num_args);
-    sut.add_optional_argument(required_arg_name.name, required_arg_name.short_name.value()).required();
+    sut.add_optional_argument(required_arg_name.primary, required_arg_name.secondary.value()).required();
 
     const auto argc = get_argc(non_default_num_args, non_default_args_split);
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
@@ -149,7 +149,7 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "parse_args should throw when an
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
     const auto range_arg_name = prepare_arg_name(non_default_num_args);
-    sut.add_optional_argument(range_arg_name.name, range_arg_name.short_name.value()).nargs(at_least(1));
+    sut.add_optional_argument(range_arg_name.primary, range_arg_name.secondary.value()).nargs(at_least(1));
 
     REQUIRE_THROWS_AS(sut.parse_args(argc, argv), ap::error::invalid_nvalues_error);
 
@@ -164,7 +164,7 @@ TEST_CASE_FIXTURE(
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
     const auto required_arg_name = prepare_arg_name(non_default_num_args);
-    sut.add_optional_argument(required_arg_name.name, required_arg_name.short_name.value()).required();
+    sut.add_optional_argument(required_arg_name.primary, required_arg_name.secondary.value()).required();
 
     int argc;
     char** argv;
@@ -201,7 +201,7 @@ TEST_CASE_FIXTURE(
 
     const auto bypass_required_arg_name = prepare_arg_name(non_default_num_args);
     sut.add_optional_argument<bool>(
-           bypass_required_arg_name.name, bypass_required_arg_name.short_name.value()
+           bypass_required_arg_name.primary, bypass_required_arg_name.secondary.value()
     )
         .default_value(false)
         .implicit_value(true)
@@ -216,11 +216,11 @@ TEST_CASE_FIXTURE(
 
     std::string arg_flag;
 
-    SUBCASE("long flag") {
+    SUBCASE("primary name flag") {
         arg_flag = prepare_arg_flag(non_default_num_args);
     }
-    SUBCASE("short flag") {
-        arg_flag = prepare_arg_flag_short(non_default_num_args);
+    SUBCASE("secondary name flag") {
+        arg_flag = prepare_arg_flag_secondary(non_default_num_args);
     }
 
     CAPTURE(arg_flag);
@@ -229,7 +229,7 @@ TEST_CASE_FIXTURE(
     std::strcpy(argv[1], arg_flag.c_str());
 
     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    REQUIRE(sut.value<bool>(bypass_required_arg_name.name));
+    REQUIRE(sut.value<bool>(bypass_required_arg_name.primary));
 
     free_argv(argc, argv);
 }
@@ -253,7 +253,7 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "has_value should return false w
 
     const auto required_arg_name = prepare_arg_name(non_default_num_args);
 
-    sut.add_optional_argument(required_arg_name.name, required_arg_name.short_name.value()).required();
+    sut.add_optional_argument(required_arg_name.primary, required_arg_name.secondary.value()).required();
 
     const auto num_args = non_default_num_args + 1;
 
@@ -269,8 +269,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "has_value should return false w
 
         for (std::size_t i = 0; i < non_default_num_args; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE(sut.has_value(arg_name.name));
-            REQUIRE(sut.has_value(arg_name.short_name.value()));
+            REQUIRE(sut.has_value(arg_name.primary));
+            REQUIRE(sut.has_value(arg_name.secondary.value()));
         }
     }
     SUBCASE("only the necessary arguments have values") {
@@ -286,18 +286,18 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "has_value should return false w
 
         for (std::size_t i = 0; i < non_default_args_split; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE(sut.has_value(arg_name.name));
-            REQUIRE(sut.has_value(arg_name.short_name.value()));
+            REQUIRE(sut.has_value(arg_name.primary));
+            REQUIRE(sut.has_value(arg_name.secondary.value()));
         }
         for (std::size_t i = non_default_args_split; i < non_default_num_args; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE_FALSE(sut.has_value(arg_name.name));
-            REQUIRE_FALSE(sut.has_value(arg_name.short_name.value()));
+            REQUIRE_FALSE(sut.has_value(arg_name.primary));
+            REQUIRE_FALSE(sut.has_value(arg_name.secondary.value()));
         }
         for (std::size_t i = non_default_num_args; i < num_args; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE(sut.has_value(arg_name.name));
-            REQUIRE(sut.has_value(arg_name.short_name.value()));
+            REQUIRE(sut.has_value(arg_name.primary));
+            REQUIRE(sut.has_value(arg_name.secondary.value()));
         }
     }
 
@@ -330,8 +330,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "value() should throw before cal
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_THROWS_AS(sut.value(arg_name.name), ap::error::invalid_value_type_error);
-        REQUIRE_THROWS_AS(sut.value(arg_name.short_name.value()), ap::error::invalid_value_type_error);
+        REQUIRE_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
+        REQUIRE_THROWS_AS(sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error);
     }
 }
 
@@ -340,7 +340,7 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "value() should throw if the giv
 
     const auto required_arg_name = prepare_arg_name(non_default_num_args);
 
-    sut.add_optional_argument(required_arg_name.name, required_arg_name.short_name.value()).required();
+    sut.add_optional_argument(required_arg_name.primary, required_arg_name.secondary.value()).required();
 
     const auto num_args = non_default_num_args + 1;
 
@@ -356,18 +356,18 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "value() should throw if the giv
 
     for (std::size_t i = 0; i < non_default_args_split; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_NOTHROW(sut.value(arg_name.name));
-        REQUIRE_NOTHROW(sut.value(arg_name.short_name.value()));
+        REQUIRE_NOTHROW(sut.value(arg_name.primary));
+        REQUIRE_NOTHROW(sut.value(arg_name.secondary.value()));
     }
     for (std::size_t i = non_default_args_split; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_THROWS_AS(sut.value(arg_name.name), ap::error::invalid_value_type_error);
-        REQUIRE_THROWS_AS(sut.value(arg_name.short_name.value()), ap::error::invalid_value_type_error);
+        REQUIRE_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
+        REQUIRE_THROWS_AS(sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error);
     }
     for (std::size_t i = non_default_num_args; i < num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_NOTHROW(sut.value(arg_name.name));
-        REQUIRE_NOTHROW(sut.value(arg_name.short_name.value()));
+        REQUIRE_NOTHROW(sut.value(arg_name.primary));
+        REQUIRE_NOTHROW(sut.value(arg_name.secondary.value()));
     }
 
     free_argv(argc, argv);
@@ -388,8 +388,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "value() should throw if an argu
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
 
-        REQUIRE(sut.has_value(arg_name.name));
-        REQUIRE_THROWS_AS(sut.value<invalid_value_type>(arg_name.name), ap::error::invalid_value_type_error);
+        REQUIRE(sut.has_value(arg_name.primary));
+        REQUIRE_THROWS_AS(sut.value<invalid_value_type>(arg_name.primary), ap::error::invalid_value_type_error);
     }
 
     free_argv(argc, argv);
@@ -404,7 +404,7 @@ TEST_CASE_FIXTURE(
 
     const auto required_arg_name = prepare_arg_name(non_default_num_args);
 
-    sut.add_optional_argument(required_arg_name.name, required_arg_name.short_name.value()).required();
+    sut.add_optional_argument(required_arg_name.primary, required_arg_name.secondary.value()).required();
 
     const auto num_args = non_default_num_args + 1;
 
@@ -417,9 +417,9 @@ TEST_CASE_FIXTURE(
         const auto arg_name = prepare_arg_name(i);
         const auto arg_value = prepare_arg_value(i);
 
-        REQUIRE(sut.has_value(arg_name.name));
-        REQUIRE_EQ(sut.value(arg_name.name), arg_value);
-        REQUIRE_EQ(sut.value(arg_name.short_name.value()), arg_value);
+        REQUIRE(sut.has_value(arg_name.primary));
+        REQUIRE_EQ(sut.value(arg_name.primary), arg_value);
+        REQUIRE_EQ(sut.value(arg_name.secondary.value()), arg_value);
     }
 
     free_argv(argc, argv);
@@ -435,8 +435,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return 0 before ca
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_EQ(sut.count(arg_name.name), 0u);
-        REQUIRE_EQ(sut.count(arg_name.short_name.value()), 0u);
+        REQUIRE_EQ(sut.count(arg_name.primary), 0u);
+        REQUIRE_EQ(sut.count(arg_name.secondary.value()), 0u);
     }
 }
 
@@ -454,8 +454,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return 0 if there 
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return the number of argument's flag usage") {
     // prepare sut
-    sut.add_positional_argument(positional_arg_name, positional_arg_short_name);
-    sut.add_optional_argument(optional_arg_name, optional_arg_short_name).nargs(ap::nargs::any());
+    sut.add_positional_argument(positional_arg_name_primary, positional_arg_name_secondary);
+    sut.add_optional_argument(optional_arg_name_primary, optional_arg_name_secondary).nargs(ap::nargs::any());
 
     // expected values
     const std::size_t positional_count = 1u;
@@ -472,8 +472,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return the number 
     argv[1] = new char[positional_arg_value.length() + 1];
     std::strcpy(argv[1], positional_arg_value.c_str());
 
-    const std::string optional_arg_flag = "--" + optional_arg_name;
-    const std::string optional_arg_value = optional_arg_name + "_value";
+    const std::string optional_arg_flag = "--" + optional_arg_name_primary;
+    const std::string optional_arg_value = optional_arg_name_primary + "_value";
     for (std::size_t i = 2; i < argc; i += 2) {
         if (i == argc - 1) {
             argv[i] = new char[optional_arg_value.length() + 1];
@@ -492,8 +492,8 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return the number 
     sut.parse_args(argc, argv);
 
     // test count
-    REQUIRE_EQ(sut.count(positional_arg_name), positional_count);
-    REQUIRE_EQ(sut.count(optional_arg_name), optional_count);
+    REQUIRE_EQ(sut.count(positional_arg_name_primary), positional_count);
+    REQUIRE_EQ(sut.count(optional_arg_name_primary), optional_count);
 
     // free argv
     free_argv(argc, argv);
@@ -505,28 +505,28 @@ TEST_SUITE_END(); // test_argument_parser_parse_args::count
 TEST_SUITE_BEGIN("test_argument_parser_parse_args::values");
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should throw when calling with a positional argument's name") {
-    sut.add_positional_argument(positional_arg_name, positional_arg_short_name);
+    sut.add_positional_argument(positional_arg_name_primary, positional_arg_name_secondary);
 
-    REQUIRE_THROWS_AS(sut.values(positional_arg_name), std::logic_error);
-    REQUIRE_THROWS_AS(sut.values(positional_arg_short_name), std::logic_error);
+    REQUIRE_THROWS_AS(sut.values(positional_arg_name_primary), std::logic_error);
+    REQUIRE_THROWS_AS(sut.values(positional_arg_name_secondary), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should return an empty vector if an argument has no values") {
-    sut.add_optional_argument(optional_arg_name, optional_arg_short_name);
+    sut.add_optional_argument(optional_arg_name_primary, optional_arg_name_secondary);
 
-    SUBCASE("calling with argument's long name") {
-        const auto& values = sut.values(optional_arg_name);
+    SUBCASE("calling with argument's primary name") {
+        const auto& values = sut.values(optional_arg_name_primary);
         REQUIRE(values.empty());
     }
 
-    SUBCASE("calling with argument's short name") {
-        const auto& values = sut.values(optional_arg_short_name);
+    SUBCASE("calling with argument's secondary name") {
+        const auto& values = sut.values(optional_arg_name_secondary);
         REQUIRE(values.empty());
     }
 }
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should throw when an argument has values but the given type is invalid") {
-    sut.add_optional_argument(optional_arg_name, optional_arg_short_name).nargs(at_least(1));
+    sut.add_optional_argument(optional_arg_name_primary, optional_arg_name_secondary).nargs(at_least(1));
 
     // prepare argc & argv
     const int argc = 5;
@@ -535,7 +535,7 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should throw when an a
     argv[0] = new char[8];
     std::strcpy(argv[0], "program");
 
-    const std::string flag = "--" + optional_arg_name;
+    const std::string flag = "--" + optional_arg_name_primary;
     argv[1] = new char[flag.length() + 1];
     std::strcpy(argv[1], flag.c_str());
     for (int i = 2; i < argc; i++) {
@@ -547,9 +547,9 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should throw when an a
     // parse args
     sut.parse_args(argc, argv);
 
-    REQUIRE_THROWS_AS(sut.values<invalid_argument_value_type>(optional_arg_name), ap::error::invalid_value_type_error);
+    REQUIRE_THROWS_AS(sut.values<invalid_argument_value_type>(optional_arg_name_primary), ap::error::invalid_value_type_error);
     REQUIRE_THROWS_AS(
-        sut.values<invalid_argument_value_type>(optional_arg_short_name), ap::error::invalid_value_type_error
+        sut.values<invalid_argument_value_type>(optional_arg_name_secondary), ap::error::invalid_value_type_error
     );
 
     free_argv(argc, argv);
@@ -563,7 +563,7 @@ TEST_CASE_FIXTURE(
     const std::string default_value = "default_value";
     const std::string implicit_value = "implicit_value";
 
-    sut.add_optional_argument(optional_arg_name, optional_arg_short_name)
+    sut.add_optional_argument(optional_arg_name_primary, optional_arg_name_secondary)
         .default_value(default_value)
         .implicit_value(implicit_value);
 
@@ -582,7 +582,7 @@ TEST_CASE_FIXTURE(
         argc = 2;
         argv = new char*[argc];
 
-        const auto optional_arg_flag = "--" + optional_arg_name;
+        const auto optional_arg_flag = "--" + optional_arg_name_primary;
         argv[1] = new char[optional_arg_flag.length() + 1];
         std::strcpy(argv[1], optional_arg_flag.c_str());
         expected_value = implicit_value;
@@ -598,7 +598,7 @@ TEST_CASE_FIXTURE(
     // parse args
     sut.parse_args(argc, argv);
 
-    const auto& stored_values = sut.values(optional_arg_name);
+    const auto& stored_values = sut.values(optional_arg_name_primary);
 
     REQUIRE_EQ(stored_values.size(), 1);
     REQUIRE_EQ(stored_values.front(), expected_value);
@@ -611,7 +611,7 @@ TEST_CASE_FIXTURE(
     "values() should return a correct vector of values when there is an argument with "
     "a given name and parsed values present"
 ) {
-    sut.add_optional_argument(optional_arg_name, optional_arg_short_name).nargs(at_least(1));
+    sut.add_optional_argument(optional_arg_name_primary, optional_arg_name_secondary).nargs(at_least(1));
 
     // prepare argc & argv
     const int argc = 5;
@@ -620,7 +620,7 @@ TEST_CASE_FIXTURE(
     argv[0] = new char[8];
     std::strcpy(argv[0], "program");
 
-    const std::string flag = "--" + optional_arg_name;
+    const std::string flag = "--" + optional_arg_name_primary;
     argv[1] = new char[flag.length() + 1];
     std::strcpy(argv[1], flag.c_str());
 
@@ -636,7 +636,7 @@ TEST_CASE_FIXTURE(
     // parse args
     sut.parse_args(argc, argv);
 
-    const auto& stored_values = sut.values(optional_arg_name);
+    const auto& stored_values = sut.values(optional_arg_name_primary);
 
     REQUIRE_EQ(stored_values.size(), values.size());
     for (std::size_t i = 0; i < stored_values.size(); i++)

--- a/test/source/test_argument_parser_parse_args.cpp
+++ b/test/source/test_argument_parser_parse_args.cpp
@@ -31,8 +31,6 @@ const std::string optional_arg_name_secondary = "oa";
 
 TEST_SUITE_BEGIN("test_argument_parser_parse_args");
 
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::_preprocess_input");
-
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "_preprocess_input should return an empty vector for no command-line arguments") {
     const auto argc = get_argc(default_num_args, default_num_args);
     auto argv = prepare_argv(default_num_args, default_num_args);
@@ -71,11 +69,6 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "_preprocess_input should return
     free_argv(argc, argv);
 }
 
-TEST_SUITE_END(); // test_argument_parser_parse_args::_preprocess_input
-
-
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::_parse_args_impl");
-
 TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
     "_parse_args_impl should throw when there is a non-positional value specified "
@@ -96,11 +89,6 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "_parse_args_impl should not thr
 
     REQUIRE_NOTHROW(sut_parse_args_impl(cmd_args));
 }
-
-TEST_SUITE_END(); // test_argument_parser_parse_args::_parse_args_impl
-
-
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::_get_argument");
 
 TEST_CASE_FIXTURE(
     argument_parser_test_fixture,
@@ -125,8 +113,6 @@ TEST_CASE_FIXTURE(
         REQUIRE(sut_get_argument(arg_name.secondary.value()));
     }
 }
-
-TEST_SUITE_END(); // test_argument_parser_parse_args::_get_argument
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "parse_args should throw when there is no value specified for a required optional argument") {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -234,8 +220,6 @@ TEST_CASE_FIXTURE(
     free_argv(argc, argv);
 }
 
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::has_value");
-
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "has_value should return false if there is no argument with given name present") {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
@@ -306,11 +290,6 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "has_value should return false w
 
     free_argv(argc, argv);
 }
-
-TEST_SUITE_END(); // test_argument_parser_parse_args::has_value
-
-
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::value");
 
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "value() should throw if there is no argument with given name present") {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -425,11 +404,6 @@ TEST_CASE_FIXTURE(
     free_argv(argc, argv);
 }
 
-TEST_SUITE_END(); // test_argument_parser_parse_args::value
-
-
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::count");
-
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return 0 before calling parse_args") {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
@@ -499,11 +473,6 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return the number 
     free_argv(argc, argv);
 }
 
-TEST_SUITE_END(); // test_argument_parser_parse_args::count
-
-
-TEST_SUITE_BEGIN("test_argument_parser_parse_args::values");
-
 TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should throw when calling with a positional argument's name") {
     sut.add_positional_argument(positional_arg_name_primary, positional_arg_name_secondary);
 
@@ -547,7 +516,9 @@ TEST_CASE_FIXTURE(argument_parser_test_fixture, "values() should throw when an a
     // parse args
     sut.parse_args(argc, argv);
 
-    REQUIRE_THROWS_AS(sut.values<invalid_argument_value_type>(optional_arg_name_primary), ap::error::invalid_value_type_error);
+    REQUIRE_THROWS_AS(
+        sut.values<invalid_argument_value_type>(optional_arg_name_primary), ap::error::invalid_value_type_error
+    );
     REQUIRE_THROWS_AS(
         sut.values<invalid_argument_value_type>(optional_arg_name_secondary), ap::error::invalid_value_type_error
     );
@@ -644,7 +615,5 @@ TEST_CASE_FIXTURE(
 
     free_argv(argc, argv);
 }
-
-TEST_SUITE_END(); // test_argument_parser_parse_args::values
 
 TEST_SUITE_END(); // test_argument_parser_parse_args

--- a/test/source/test_optional_argument.cpp
+++ b/test/source/test_optional_argument.cpp
@@ -15,8 +15,8 @@ using ap::argument::optional_argument;
 
 namespace {
 
-constexpr std::string_view long_name = "test";
-constexpr std::string_view short_name = "t";
+constexpr std::string_view primary_name = "test";
+constexpr std::string_view secondary_name = "t";
 
 using test_value_type = int;
 using invalid_value_type = double;
@@ -26,8 +26,8 @@ sut_type prepare_argument(std::string_view name) {
     return sut_type(name);
 }
 
-sut_type prepare_argument(std::string_view name, std::string_view long_name) {
-    return sut_type(name, long_name);
+sut_type prepare_argument(std::string_view primary_name, std::string_view secondary_name) {
+    return sut_type(primary_name, secondary_name);
 }
 
 const std::string empty_str = "";
@@ -48,41 +48,41 @@ const range non_default_range = range(1u, default_choices.size());
 TEST_SUITE_BEGIN("test_optional_argument");
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_optional() should return true") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE(sut.is_optional());
 }
 
-TEST_CASE_FIXTURE(optional_argument_test_fixture, "name() should return value passed to the optional argument constructor for long name") {
-    const auto sut = prepare_argument(long_name);
+TEST_CASE_FIXTURE(optional_argument_test_fixture, "name() should return value passed to the optional argument constructor for primary name") {
+    const auto sut = prepare_argument(primary_name);
 
     const auto name = sut_get_name(sut);
 
-    REQUIRE_EQ(name, long_name);
-    REQUIRE_NE(name, short_name);
+    REQUIRE_EQ(name, primary_name);
+    REQUIRE_NE(name, secondary_name);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "name() and short_name() should return value passed to the optional"
-    "argument constructor for both long and short names"
+    "name() and secondary_name() should return value passed to the optional"
+    "argument constructor for both primary and secondary names"
 ) {
-    const auto sut = prepare_argument(long_name, short_name);
+    const auto sut = prepare_argument(primary_name, secondary_name);
 
     const auto name = sut_get_name(sut);
 
-    REQUIRE_EQ(name, long_name);
-    REQUIRE_EQ(name, short_name);
+    REQUIRE_EQ(name, primary_name);
+    REQUIRE_EQ(name, secondary_name);
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "help() should return nullopt by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_get_help(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "help() should return message if one has been provided") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     constexpr std::string_view help_msg = "test help msg";
     sut.help(help_msg);
@@ -94,13 +94,13 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "help() should return message 
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_required() should return false by default") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_is_required(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_required() should return true is argument is set to be required") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut.required();
 
@@ -108,20 +108,20 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_required() should return t
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_used() should return false by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_used() should return true when argument contains value") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut_set_value(sut, std::to_string(value_1));
 
     REQUIRE(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "nused() should return 0 by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_EQ(sut_get_nused(sut), 0u);
 }
@@ -131,7 +131,7 @@ TEST_CASE_FIXTURE(
     "is_used() should return the number of times the argument's flag has been used "
     "[number of set_used() function calls]"
 ) {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     constexpr std::size_t nused = 5u;
     for (std::size_t n = 0; n < nused; n++)
@@ -141,13 +141,13 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return false by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return true if value is set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 
@@ -155,7 +155,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return tru
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return true if a default value is set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.default_value(default_value);
 
     REQUIRE(sut_has_value(sut));
@@ -163,14 +163,14 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return tru
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return false if an implicit value is set but the argument is not used") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.implicit_value(implicit_value);
 
     REQUIRE_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return true if an implicit value is set and the agument is used") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.implicit_value(implicit_value);
 
     sut_set_used(sut);
@@ -180,7 +180,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return tru
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_parsed_values() should return false by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_parsed_values(sut));
 }
@@ -190,7 +190,7 @@ TEST_CASE_FIXTURE(
     "has_parsed_values() should return false regardles of the "
     "default_value and implicit_value parameters"
 ) {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     SUBCASE("default_value") {
         sut.default_value(default_value);
@@ -210,7 +210,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_parsed_values() should true if the value is set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 
@@ -218,13 +218,13 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_parsed_values() should tr
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return default any object if argument's value has not been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_get_value(sut).has_value());
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return the argument's value if it has been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 
@@ -233,7 +233,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return the arg
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return the default value if one has been provided and argument is not used") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.default_value(value_1);
 
     REQUIRE(sut_has_value(sut));
@@ -241,7 +241,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return the def
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return the implicit value if one has been provided and argument is used") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.implicit_value(implicit_value);
 
     sut_set_used(sut);
@@ -251,7 +251,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "value() should return the imp
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should throw when value_type cannot be obtained from given string") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_AS(sut_set_value(sut, empty_str), ap::error::invalid_value_error);
@@ -268,7 +268,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should throw w
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "set_value(any) should throw when parameter passed to value() is not present in the choices set"
 ) {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_choices(sut, default_choices);
 
@@ -278,7 +278,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should accept the given value when it's present in the choices set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut_set_choices(sut, default_choices);
 
     const std::vector<test_value_type> correct_values = default_choices;
@@ -298,7 +298,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should accept 
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should throw when a value has already been set when nargs is default") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value_1)));
     REQUIRE(sut_has_value(sut));
@@ -307,7 +307,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should throw w
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should accept multiple values if nargs is not detault") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.nargs(non_default_range);
 
     for (const auto value : default_choices) {
@@ -323,7 +323,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should accept 
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should perform the specified action") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     SUBCASE("valued action") {
         const auto double_valued_action = [](const test_value_type& value) { return 2 * value; };
@@ -348,13 +348,13 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "set_value(any) should perform
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "nvalues_in_range() should return equivalent if nargs has not been set") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE(std::is_eq(sut_nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "nvalues_in_range() should return equivalent if a default value has been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.nargs(non_default_range);
 
     sut.default_value(default_value);
@@ -367,7 +367,7 @@ TEST_CASE_FIXTURE(
     "nvalues_in_range() should return equivalent only when the number of values "
     "is in the specified range"
 ) {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut.nargs(non_default_range);
 
     REQUIRE(std::is_lt(sut_nvalues_in_range(sut)));

--- a/test/source/test_positional_argument.cpp
+++ b/test/source/test_positional_argument.cpp
@@ -12,8 +12,8 @@ using ap::argument::positional_argument;
 
 namespace {
 
-constexpr std::string_view long_name = "test";
-constexpr std::string_view short_name = "t";
+constexpr std::string_view primary_name = "test";
+constexpr std::string_view secondary_name = "t";
 
 using test_value_type = int;
 using sut_type = positional_argument<test_value_type>;
@@ -22,8 +22,8 @@ sut_type prepare_argument(std::string_view name) {
     return sut_type(name);
 }
 
-sut_type prepare_argument(std::string_view name, std::string_view long_name) {
-    return sut_type(name, long_name);
+sut_type prepare_argument(std::string_view primary_name, std::string_view secondary_name) {
+    return sut_type(primary_name, secondary_name);
 }
 
 const std::string empty_str = "";
@@ -40,41 +40,41 @@ constexpr test_value_type invalid_choice = 4;
 TEST_SUITE_BEGIN("test_positional_argument");
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_optional() should return false") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut.is_optional());
 }
 
-TEST_CASE_FIXTURE(positional_argument_test_fixture, "name() should return value passed to the optional argument constructor for long name") {
-    const auto sut = prepare_argument(long_name);
+TEST_CASE_FIXTURE(positional_argument_test_fixture, "name() should return value passed to the optional argument constructor for primary name") {
+    const auto sut = prepare_argument(primary_name);
 
     const auto name = sut_get_name(sut);
 
-    REQUIRE_EQ(name, long_name);
-    REQUIRE_NE(name, short_name);
+    REQUIRE_EQ(name, primary_name);
+    REQUIRE_NE(name, secondary_name);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
-    "name() and short_name() should return value passed to the optional"
-    "argument constructor for both long and short names"
+    "name() and secondary_name() should return value passed to the optional"
+    "argument constructor for both primary and secondary names"
 ) {
-    const auto sut = prepare_argument(long_name, short_name);
+    const auto sut = prepare_argument(primary_name, secondary_name);
 
     const auto name = sut_get_name(sut);
 
-    REQUIRE_EQ(name, long_name);
-    REQUIRE_EQ(name, short_name);
+    REQUIRE_EQ(name, primary_name);
+    REQUIRE_EQ(name, secondary_name);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "help() should return nullopt by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_get_help(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "help() should return message if one has been provided") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     constexpr std::string_view help_msg = "test help msg";
     sut.help(help_msg);
@@ -86,45 +86,45 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "help() should return messag
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_required() should return true") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE(sut_is_required(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_used() should return false by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_used() should return true when argument contains value") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut_set_value(sut, std::to_string(value_1));
 
     REQUIRE(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "nused() should return 0 by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_EQ(sut_get_nused(sut), 0u);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_used() should return 1 when argument contains value") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut_set_value(sut, std::to_string(value_1));
 
     REQUIRE_EQ(sut_get_nused(sut), 1u);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return false by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return true is value is set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 
@@ -132,13 +132,13 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return t
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_parsed_values() should return false by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_parsed_values() should true if the value is set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 
@@ -146,7 +146,7 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_parsed_values() should 
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "set_value(any) should throw when a value has already been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value_1)));
     REQUIRE(sut_has_value(sut));
@@ -155,7 +155,7 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "set_value(any) should throw
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "set_value(any) should throw when value_type cannot be obtained from given string") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_AS(sut_set_value(sut, empty_str), ap::error::invalid_value_error);
@@ -172,7 +172,7 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "set_value(any) should throw
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "set_value(any) should throw when parameter passed to value() is not present in the choices set"
 ) {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_choices(sut, default_choices);
 
@@ -186,7 +186,7 @@ TEST_CASE_FIXTURE(
     "set_value(any) should accept the given value only when no value has been set yet "
     "and if the given value is present in the choices set"
 ) {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
     sut_set_choices(sut, default_choices);
 
     const std::vector<test_value_type> correct_values = default_choices;
@@ -206,7 +206,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "set_value(any) should perform the specified action") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     SUBCASE("valued action") {
         const auto double_valued_action = [](const test_value_type& value) { return 2 * value; };
@@ -231,14 +231,14 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "set_value(any) should perfo
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "value() should return default any object if argument's value has not been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_value(sut));
     REQUIRE_THROWS_AS(std::any_cast<test_value_type>(sut_get_value(sut)), std::bad_any_cast);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "value() should return the argument's value if it has been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 
@@ -247,19 +247,19 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "value() should return the a
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "values() should throw logic_error") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     REQUIRE_THROWS_AS(sut_get_values(sut), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "nvalues_in_range() should return less by default") {
-    const auto sut = prepare_argument(long_name);
+    const auto sut = prepare_argument(primary_name);
 
     REQUIRE(std::is_lt(sut_nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "nvalues_in_range() should return equivalent if a value has been set") {
-    auto sut = prepare_argument(long_name);
+    auto sut = prepare_argument(primary_name);
 
     sut_set_value(sut, std::to_string(value_1));
 


### PR DESCRIPTION
Renamed the `argument_name` structure members:
* `name` -> `primary`
* `short_name` -> `secondary`

Aligned the code and unit tests to use the new names 