### PR TITLE
YT-CPPAP-8: Fix typos and rename some elements

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,10 +160,10 @@ Parameters which can be specified for both positional and optional arguments inc
           .action<ap::valued_action>([](const double& value) { return 1. / value; });
     ```
 
-    Actions can also be used to perform some value checking logic, e.g. the predefined `check_file_exists_action` which checks if a file with a given name exists:
+    Actions can also be used to perform some value checking logic, e.g. the predefined `check_file_exists` which checks if a file with a given name exists:
     ```c++
     parser.add_optional_argument("input", "i")
-          .action<ap::void_action>(ap::action::check_file_exists_action);
+          .action<ap::void_action>(ap::action::check_file_exists());
     ```
 
 **Optional argument specific parameters**
@@ -231,7 +231,7 @@ The supported default arguments are:
     ```c++
     // equivalent to:
     parser.add_positional_argument<std::string>("input")
-          .action<ap::void_action>(ap::action::check_file_exists_action)
+          .action<ap::void_action>(ap::action::check_file_exists())
           .help("Input file path");
     ```
 
@@ -262,14 +262,14 @@ The supported default arguments are:
     parser.add_optional_argument("input", "i")
           .required()
           .nargs(1)
-          .action<ap::void_action>(ap::action::check_file_exists_action)
+          .action<ap::void_action>(ap::action::check_file_exists())
           .help("Input file path");
 
     // multi_input - equivalent to:
     parser.add_optional_argument("input", "i")
           .required()
           .nargs(ap::nargs::at_least(1))
-          .action<ap::void_action>(ap::action::check_file_exists_action)
+          .action<ap::void_action>(ap::action::check_file_exists())
           .help("Input files paths");
     ```
 
@@ -298,14 +298,14 @@ To parse the command-line arguments use the `argument_parser::parse_args` method
 // power.cpp
 #include <ap/argument_parser.hpp>
 
-#include <iostream>
 #include <cmath>
+#include <iostream>
 
 int main(int argc, char* argv[]) {
     // create the parser class instance
     ap::argument_parser parser;
     parser.program_name("power calculator")
-          .program_description("calculates the value of an expression: base & exponent");
+          .program_description("calculates the value of an expression: base ^ exponent");
 
     // add arguments
     parser.add_positional_argument<double>("base").help("the exponentation base value");
@@ -363,11 +363,11 @@ int main(int argc, char* argv[]) {
 
     **NOTE:** For each positional argument there must be **exactly one value**.
     ```shell
-    ./test_program
+    ./power
     # out:
     # [ERROR] : No values parsed for a required argument [base]
     # power calculator
-    # calculates the value of an expression: base & exponent
+    # calculates the value of an expression: base ^ exponent
     #         [base] : the exponentation base value
     #         [exponent,e] : the exponent value
     #         [help,h] : Display help message

--- a/README.md
+++ b/README.md
@@ -10,17 +10,17 @@ Command-line argument parser for C++20
 
 ## Overview
 
-The `CPP-AP` library has been developed for the *Team Programming* course at the *Wrocław University of Science and Technology*.
-
-Faculty: *W04N - Faculty of Information and Communication Technology*
-
-Field of study: *Algorithmic Computer Science*
-
-<br />
-
 The goal of the project was to create a light,  intuitive and simple to use command-line argument parser library for the `C++20` and newer standards.
 
 The `CPP-AP` library does not require installing any additional tools or heavy libraries, like with `boost::program_options`. Much like with the `Doctest` framework - the only thing you need to do is copy the `argument_parser.hpp` file into the include directory of your project and you're set to go.
+
+> **NOTE:** [v1.0](https://github.com/SpectraL519/cpp-ap/commit/9a9e5360766b732f322ae2efe3cf5ec5f9268eef) of the library has been developed for the *Team Programming* course at the *Wrocław University of Science and Technology*.
+>
+> Faculty: *W04N - Faculty of Information and Communication Technology*
+>
+> Field of study: *Algorithmic Computer Science*
+>
+> The project has received the 1st place at the 2024 CreatiWITy competition organized by the faculty. The article in Polish can be found on the [faculty website](https://wit.pwr.edu.pl/aktualnosci/oto-laureaci-konkursu-creatiwity-273.html). Please note that this is not a technical article :)
 
 <br />
 <br />
@@ -79,18 +79,18 @@ The parser supports both positional and optional arguments. Both argument types 
 To add an argument to the parameter's configurations use the following syntax:
 
 ```c++
-parser.add_<positional/optional>_argument<value_type>("argument_name");
+parser.add_<positional/optional>_argument<value_type>("argument");
 ```
 
 or
 
 ```c++
-parser.add_<positional/optional>_argument<value_type>("argument_name", "a");
+parser.add_<positional/optional>_argument<value_type>("argument", "a");
 ```
 
 **NOTE:** The library supports any argument value types which meet the following requirements:
-* The `std::ostream& operator<<` must be overloaded for a value type
-* The type must have a copy constructor and an assignment operator
+* The `std::ostream& operator<<` is overloaded for the value type
+* The value type has a copy constructor and an assignment operator
 
 **NOTE:** If the `value_type` is not provided, `std::string` will be used.
 

--- a/change_log.md
+++ b/change_log.md
@@ -30,9 +30,10 @@
 * Aligned the `.clang-format` configuration file
 * Added the `install_clang17_toolchain.sh` env script
 * Added the `format` workflow
-* Switched from the `<algorithm>` to the `<ranges>` library for all current container operations
+* Switched to the `std::ranges` and `std::views` algorithms for all current container operations
 * Modified the `argument_name` structure - renamed members: `name` to `primary`, `short_name` to `secondary`
 * Added `argument_name::match(string_view)` and `argument_name::match(argument_name)` functions
 * Added aliases for default argument enum classes:
     * `ap::default_argument::positional` = `ap::default_posarg`
     * `ap::default_argument::optional` = `ap::default_optarg`
+* Renamed the predefined: `ap::action::check_file_exists_action` -> `ap::action::check_file_exists`


### PR DESCRIPTION
- Fixed some typos and incorrect examples in the readme file
- Renamed and refactored the `ap::action::check_file_exists_action()` function