### PR TITLE
YT-CPPGL-9: Clean up the unit tests

### DIFF
--- a/tests/source/test_argument_name.cpp
+++ b/tests/source/test_argument_name.cpp
@@ -10,184 +10,143 @@
 using namespace ap_testing;
 using namespace ap::argument::detail;
 
-namespace {
-
-constexpr std::string_view primary_name = "test";
-constexpr std::string_view secondary_name = "t";
-
-constexpr std::string_view other_primary_name = "other";
-constexpr std::string_view other_secondary_name = "o";
-
-argument_name default_argument_name_primary() {
-    return argument_name(primary_name);
-}
-
-argument_name default_argument_name_primary_and_secondary() {
-    return argument_name(primary_name, secondary_name);
-}
-
-} // namespace
-
 TEST_SUITE_BEGIN("test_argument_name");
 
-TEST_CASE("argument_name.primary member should be correctly initialized") {
-    const auto arg_name = default_argument_name_primary();
+struct test_argument_name {
+    const std::string_view primary_name_1 = "test";
+    const std::string_view secondary_name_1 = "t";
 
-    REQUIRE_EQ(arg_name.primary, primary_name);
+    const argument_name arg_name_primary_1{primary_name_1};
+    const argument_name arg_name_full_1{primary_name_1, secondary_name_1};
+
+    const std::string_view primary_name_2 = "other";
+    const std::string_view secondary_name_2 = "o";
+
+    const argument_name arg_name_primary_2{primary_name_2};
+    const argument_name arg_name_full_2{primary_name_2, secondary_name_2};
+};
+
+TEST_CASE_FIXTURE(
+    test_argument_name, "argument_name.primary member should be correctly initialized"
+) {
+    CHECK_EQ(arg_name_primary_1.primary, primary_name_1);
+    CHECK_EQ(arg_name_primary_2.primary, primary_name_2);
 }
 
-TEST_CASE("argument_name members should be correctly initialized") {
-    const auto arg_name = default_argument_name_primary_and_secondary();
+TEST_CASE_FIXTURE(test_argument_name, "argument_name members should be correctly initialized") {
+    REQUIRE_EQ(arg_name_full_1.primary, primary_name_1);
 
-    REQUIRE_EQ(arg_name.primary, primary_name);
-
-    REQUIRE(arg_name.secondary);
-    REQUIRE_EQ(arg_name.secondary.value(), secondary_name);
+    REQUIRE(arg_name_full_1.secondary);
+    CHECK_EQ(arg_name_full_1.secondary.value(), secondary_name_1);
 }
 
-TEST_CASE("argument_name::operator==(argument_name) should return false if only one argument has "
-          "both primary and secondary values") {
-    const auto arg_name_a = default_argument_name_primary();
-    const auto arg_name_b = default_argument_name_primary_and_secondary();
-
-    REQUIRE_NE(arg_name_a, arg_name_b);
-    REQUIRE_NE(arg_name_b, arg_name_a);
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "operator==(argument_name) should return false if only one argument has both primary and "
+    "secondary values"
+) {
+    CHECK_NE(arg_name_primary_1, arg_name_full_1);
+    CHECK_NE(arg_name_full_1, arg_name_primary_1);
 }
 
-TEST_CASE("argument_name::operator==(argument_name) should return false if primary names are not "
-          "equal") {
-    const auto arg_name_a = default_argument_name_primary();
-    const auto arg_name_b = argument_name{other_primary_name};
-
-    REQUIRE_NE(arg_name_a, arg_name_b);
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "operator==(argument_name) should return false if primary names are not equal"
+) {
+    CHECK_NE(arg_name_primary_1, arg_name_primary_2);
+    CHECK_NE(arg_name_full_1, arg_name_full_2);
 }
 
-TEST_CASE("argument_name::operator==(argument_name) should return false if secondary names are not "
-          "equal") {
-    const auto arg_name_a = default_argument_name_primary_and_secondary();
-    const auto arg_name_b = argument_name{primary_name, other_primary_name};
-
-    REQUIRE_NE(arg_name_a, arg_name_b);
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "operator==(argument_name) should return false if secondary names are not equal"
+) {
+    CHECK_NE(arg_name_full_1, argument_name{primary_name_1, secondary_name_2});
+    CHECK_NE(argument_name{primary_name_1, secondary_name_2}, arg_name_full_1);
 }
 
-TEST_CASE("argument_name::operator==(argument_name) should return true if primary names are equal "
-          "and secondary names are null") {
-    const auto arg_name_a = default_argument_name_primary();
-    const auto arg_name_b = default_argument_name_primary();
-
-    REQUIRE_EQ(arg_name_a, arg_name_b);
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "operator==(argument_name) should return true if primary names are equal and both secondary "
+    "names are null"
+) {
+    CHECK_EQ(arg_name_primary_1, arg_name_primary_1);
 }
 
-TEST_CASE("argument_name::operator==(argument_name) should return true if both primary and "
-          "secondary names are equal") {
-    const auto arg_name_a = default_argument_name_primary_and_secondary();
-    const auto arg_name_b = default_argument_name_primary_and_secondary();
-
-    REQUIRE_EQ(arg_name_a, arg_name_b);
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "operator==(argument_name) should return true if both primary and secondary names are equal"
+) {
+    CHECK_EQ(arg_name_full_1, arg_name_full_1);
 }
 
-TEST_CASE("argument_name::match(string_view) should return true if the given string matches at "
-          "least one name") {
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "match(string_view) should return true if the given string matches at least one name"
+) {
     SUBCASE("argument_name with primary name only") {
-        const auto arg_name = default_argument_name_primary();
-
-        REQUIRE(arg_name.match(primary_name));
+        CHECK(arg_name_primary_1.match(primary_name_1));
     }
 
     SUBCASE("argument_name with both names") {
-        const auto arg_name = default_argument_name_primary_and_secondary();
-
-        REQUIRE(arg_name.match(primary_name));
-        REQUIRE(arg_name.match(secondary_name));
+        CHECK(arg_name_full_1.match(primary_name_1));
+        CHECK(arg_name_full_1.match(secondary_name_1));
     }
 }
 
-TEST_CASE("argument_name::match(string_view) should return false if the given string dosn't match "
-          "any name") {
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "match(string_view) should return false if the given string dosn't match any name"
+) {
     SUBCASE("argument_name with primary name only") {
-        const auto arg_name = default_argument_name_primary();
-
-        REQUIRE_FALSE(arg_name.match(other_primary_name));
-        REQUIRE_FALSE(arg_name.match(other_secondary_name));
+        CHECK_FALSE(arg_name_primary_1.match(primary_name_2));
+        CHECK_FALSE(arg_name_primary_1.match(secondary_name_2));
     }
 
     SUBCASE("argument_name with both names") {
-        const auto arg_name = default_argument_name_primary_and_secondary();
-
-        REQUIRE_FALSE(arg_name.match(other_primary_name));
-        REQUIRE_FALSE(arg_name.match(other_secondary_name));
+        CHECK_FALSE(arg_name_full_1.match(primary_name_2));
+        CHECK_FALSE(arg_name_full_1.match(secondary_name_2));
     }
 }
 
-TEST_CASE("argument_name::match(argument_name) should return true if either the primary or the "
-          "secondary name "
-          "of the passed argument_name matches at least one name") {
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "match(argument_name) should return true if either the primary or the secondary name of the "
+    "passed argument_name matches at least one name"
+) {
     SUBCASE("argument_name with primary name only") {
-        const auto arg_name = default_argument_name_primary();
-
-        SUBCASE("matching primary to primary") {
-            const auto arg_name_to_match = argument_name{primary_name};
-            REQUIRE(arg_name.match(arg_name_to_match));
-        }
-
-        SUBCASE("matching secondary to primary") {
-            const auto arg_name_to_match = argument_name{other_primary_name, primary_name};
-            REQUIRE(arg_name.match(arg_name_to_match));
-        }
+        CHECK(arg_name_primary_1.match(arg_name_primary_1));
+        CHECK(arg_name_primary_1.match(argument_name{primary_name_2, primary_name_1}));
     }
 
     SUBCASE("argument_name with both names") {
-        const auto arg_name = default_argument_name_primary_and_secondary();
-
-        SUBCASE("matching primary to primary") {
-            const auto arg_name_to_match = argument_name{primary_name, other_secondary_name};
-            REQUIRE(arg_name.match(arg_name_to_match));
-        }
-
-        SUBCASE("matching primary to secondary") {
-            const auto arg_name_to_match = argument_name{secondary_name, primary_name};
-            REQUIRE(arg_name.match(arg_name_to_match));
-        }
-
-        SUBCASE("matching secondary to primary") {
-            const auto arg_name_to_match = argument_name{other_primary_name, primary_name};
-            REQUIRE(arg_name.match(arg_name_to_match));
-        }
-
-        SUBCASE("matching secondary to secondary") {
-            const auto arg_name_to_match = argument_name{other_primary_name, secondary_name};
-            REQUIRE(arg_name.match(arg_name_to_match));
-        }
+        CHECK(arg_name_full_1.match(argument_name{primary_name_1, secondary_name_2}));
+        CHECK(arg_name_full_1.match(argument_name{secondary_name_1, primary_name_1}));
+        CHECK(arg_name_full_1.match(argument_name{primary_name_2, primary_name_1}));
+        CHECK(arg_name_full_1.match(argument_name{primary_name_2, secondary_name_1}));
     }
 }
 
-TEST_CASE("argument_name::match(argument_name) should return false if neither the primary nor the "
-          "secondary name "
-          "of the passed argument_name matches at least one name") {
-    const auto arg_name_to_match = argument_name{other_primary_name, other_secondary_name};
-
-    SUBCASE("argument_name with primary name only") {
-        const auto arg_name = default_argument_name_primary();
-        REQUIRE_FALSE(arg_name.match(arg_name_to_match));
-    }
-
-    SUBCASE("argument_name with both names") {
-        const auto arg_name = default_argument_name_primary_and_secondary();
-        REQUIRE_FALSE(arg_name.match(arg_name_to_match));
-    }
+TEST_CASE_FIXTURE(
+    test_argument_name,
+    "match(argument_name) should return false if neither the primary nor the secondary name of the "
+    "passed argument_name matches at least one name"
+) {
+    CHECK_FALSE(arg_name_primary_1.match(arg_name_full_2));
+    CHECK_FALSE(arg_name_full_1.match(arg_name_full_2));
 }
 
-TEST_CASE("operator<< should push correct data to the output stream") {
+TEST_CASE_FIXTURE(test_argument_name, "operator<< should push correct data to the output stream") {
     std::stringstream ss, expected_ss;
 
     SUBCASE("argument_name with primary name only") {
-        ss << default_argument_name_primary();
-        expected_ss << "[" << primary_name << "]";
+        ss << arg_name_primary_1;
+        expected_ss << "[" << primary_name_1 << "]";
     }
 
     SUBCASE("argument_name with both names") {
-        ss << default_argument_name_primary_and_secondary();
-        expected_ss << "[" << primary_name << "," << secondary_name << "]";
+        ss << arg_name_full_1;
+        expected_ss << "[" << primary_name_1 << "," << secondary_name_1 << "]";
     }
 
     CAPTURE(ss);

--- a/tests/source/test_argument_name.cpp
+++ b/tests/source/test_argument_name.cpp
@@ -13,14 +13,14 @@ using namespace ap::argument::detail;
 TEST_SUITE_BEGIN("test_argument_name");
 
 struct test_argument_name {
-    const std::string_view primary_name_1 = "test";
-    const std::string_view secondary_name_1 = "t";
+    const std::string_view primary_name_1 = "primary_name_1";
+    const std::string_view secondary_name_1 = "s1";
 
     const argument_name arg_name_primary_1{primary_name_1};
     const argument_name arg_name_full_1{primary_name_1, secondary_name_1};
 
-    const std::string_view primary_name_2 = "other";
-    const std::string_view secondary_name_2 = "o";
+    const std::string_view primary_name_2 = "primary_name_2";
+    const std::string_view secondary_name_2 = "s2";
 
     const argument_name arg_name_primary_2{primary_name_2};
     const argument_name arg_name_full_2{primary_name_2, secondary_name_2};

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -9,20 +9,19 @@
 using namespace ap_testing;
 using namespace ap::argument;
 
-namespace {
-
-constexpr std::string_view primary_name = "test";
-constexpr std::string_view secondary_name = "t";
-
-constexpr std::string_view other_primary_name = "other";
-constexpr std::string_view other_secondary_name = "o";
-
-} // namespace
-
 TEST_SUITE_BEGIN("test_argument_parser_add_argument");
 
+struct test_argument_parser_add_argument : argument_parser_test_fixture {
+    const std::string_view primary_name_1 = "primary_name_1";
+    const std::string_view secondary_name_1 = "s1";
+
+    const std::string_view primary_name_2 = "primary_name_2";
+    const std::string_view secondary_name_2 = "s2";
+};
+
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "default_positional_arguments should add the specified arguments"
+    test_argument_parser_add_argument,
+    "default_positional_arguments should add the specified arguments"
 ) {
     sut.default_positional_arguments({ap::default_posarg::input, ap::default_posarg::output});
 
@@ -36,7 +35,8 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "default_optional_arguments should add the specified arguments"
+    test_argument_parser_add_argument,
+    "default_optional_arguments should add the specified arguments"
 ) {
     sut.default_optional_arguments(
         {ap::default_optarg::help, ap::default_optarg::input, ap::default_optarg::output}
@@ -64,131 +64,131 @@ TEST_CASE_FIXTURE(
 
     const auto help_arg = sut_get_argument(help_flag);
     REQUIRE(help_arg);
-    REQUIRE(help_arg->get().is_optional());
+    CHECK(help_arg->get().is_optional());
 
     const auto input_arg = sut_get_argument(input_flag);
     REQUIRE(input_arg);
-    REQUIRE(input_arg->get().is_optional());
+    CHECK(input_arg->get().is_optional());
 
     const auto output_arg = sut_get_argument(output_flag);
     REQUIRE(output_arg);
-    REQUIRE(output_arg->get().is_optional());
+    CHECK(output_arg->get().is_optional());
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_add_argument,
     "add_positional_argument should return a positional argument reference"
 ) {
-    const auto& argument = sut.add_positional_argument(primary_name, secondary_name);
-    REQUIRE_FALSE(argument.is_optional());
+    const auto& argument = sut.add_positional_argument(primary_name_1, secondary_name_1);
+    CHECK_FALSE(argument.is_optional());
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_add_argument,
     "add_positional_argument should throw only when adding an"
     "argument with a previously used name"
 ) {
-    sut.add_positional_argument(primary_name, secondary_name);
+    sut.add_positional_argument(primary_name_1, secondary_name_1);
 
     SUBCASE("adding argument with a unique name") {
-        REQUIRE_NOTHROW(sut.add_positional_argument(other_primary_name, other_secondary_name));
+        CHECK_NOTHROW(sut.add_positional_argument(primary_name_2, secondary_name_2));
     }
 
     SUBCASE("adding argument with a previously used primary name") {
-        REQUIRE_THROWS_AS(
-            sut.add_positional_argument(primary_name, other_secondary_name),
+        CHECK_THROWS_AS(
+            sut.add_positional_argument(primary_name_1, secondary_name_2),
             ap::error::argument_name_used_error
         );
     }
 
     SUBCASE("adding argument with a previously used secondary name") {
-        REQUIRE_THROWS_AS(
-            sut.add_positional_argument(other_primary_name, secondary_name),
+        CHECK_THROWS_AS(
+            sut.add_positional_argument(primary_name_2, secondary_name_1),
             ap::error::argument_name_used_error
         );
     }
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_add_argument,
     "add_optional_argument should return an optional argument reference"
 ) {
-    const auto& argument = sut.add_optional_argument(primary_name, secondary_name);
-    REQUIRE(argument.is_optional());
+    const auto& argument = sut.add_optional_argument(primary_name_1, secondary_name_1);
+    CHECK(argument.is_optional());
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_add_argument,
     "add_optional_argument should throw only when adding an"
     "argument with a previously used name"
 ) {
-    sut.add_optional_argument(primary_name, secondary_name);
+    sut.add_optional_argument(primary_name_1, secondary_name_1);
 
     SUBCASE("adding argument with a unique name") {
-        REQUIRE_NOTHROW(sut.add_optional_argument(other_primary_name, other_secondary_name));
+        CHECK_NOTHROW(sut.add_optional_argument(primary_name_2, secondary_name_2));
     }
 
     SUBCASE("adding argument with a previously used primary name") {
-        REQUIRE_THROWS_AS(
-            sut.add_optional_argument(primary_name, other_secondary_name),
+        CHECK_THROWS_AS(
+            sut.add_optional_argument(primary_name_1, secondary_name_2),
             ap::error::argument_name_used_error
         );
     }
 
     SUBCASE("adding argument with a previously used secondary name") {
-        REQUIRE_THROWS_AS(
-            sut.add_optional_argument(other_primary_name, secondary_name),
+        CHECK_THROWS_AS(
+            sut.add_optional_argument(primary_name_2, secondary_name_1),
             ap::error::argument_name_used_error
         );
     }
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_add_argument,
     "add_flag should return an optional argument reference with flag parameters"
 ) {
     const optional_argument_test_fixture opt_arg_fixture;
 
     SUBCASE("StoreImplicitly = true") {
-        auto& argument = sut.add_flag(primary_name, secondary_name);
+        auto& argument = sut.add_flag(primary_name_1, secondary_name_1);
 
         REQUIRE(argument.is_optional());
-        REQUIRE_FALSE(sut.value<bool>(primary_name));
+        CHECK_FALSE(sut.value<bool>(primary_name_1));
 
         opt_arg_fixture.sut_set_used(argument);
-        REQUIRE(sut.value<bool>(primary_name));
+        CHECK(sut.value<bool>(primary_name_1));
     }
 
     SUBCASE("StoreImplicitly = false") {
-        auto& argument = sut.add_flag<false>(primary_name, secondary_name);
+        auto& argument = sut.add_flag<false>(primary_name_1, secondary_name_1);
 
         REQUIRE(argument.is_optional());
-        REQUIRE(sut.value<bool>(primary_name));
+        CHECK(sut.value<bool>(primary_name_1));
 
         opt_arg_fixture.sut_set_used(argument);
-        REQUIRE_FALSE(sut.value<bool>(primary_name));
+        CHECK_FALSE(sut.value<bool>(primary_name_1));
     }
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_add_argument,
     "add_flag should throw only when adding and argument with a previously used name"
 ) {
-    sut.add_flag(primary_name, secondary_name);
+    sut.add_flag(primary_name_1, secondary_name_1);
 
     SUBCASE("adding argument with a unique name") {
-        REQUIRE_NOTHROW(sut.add_flag(other_primary_name, other_secondary_name));
+        CHECK_NOTHROW(sut.add_flag(primary_name_2, secondary_name_2));
     }
 
     SUBCASE("adding argument with a previously used primary name") {
-        REQUIRE_THROWS_AS(
-            sut.add_flag(primary_name, other_secondary_name), ap::error::argument_name_used_error
+        CHECK_THROWS_AS(
+            sut.add_flag(primary_name_1, secondary_name_2), ap::error::argument_name_used_error
         );
     }
 
     SUBCASE("adding argument with a previously used secondary name") {
-        REQUIRE_THROWS_AS(
-            sut.add_flag(other_primary_name, secondary_name), ap::error::argument_name_used_error
+        CHECK_THROWS_AS(
+            sut.add_flag(primary_name_2, secondary_name_1), ap::error::argument_name_used_error
         );
     }
 }

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -11,7 +11,7 @@ using namespace ap::argument;
 
 TEST_SUITE_BEGIN("test_argument_parser_add_argument");
 
-struct test_argument_parser_add_argument : argument_parser_test_fixture {
+struct test_argument_parser_add_argument : public argument_parser_test_fixture {
     const std::string_view primary_name_1 = "primary_name_1";
     const std::string_view secondary_name_1 = "s1";
 

--- a/tests/source/test_argument_parser_info.cpp
+++ b/tests/source/test_argument_parser_info.cpp
@@ -7,45 +7,43 @@
 
 using namespace ap_testing;
 
-namespace {
-const std::string test_name = "test program name";
-const std::string test_description = "test program description";
-} // namespace
-
 TEST_SUITE_BEGIN("test_argument_parser_info");
 
+struct test_argument_parser_info : public argument_parser_test_fixture {
+    const std::string test_name = "test program name";
+    const std::string test_description = "test program description";
+};
+
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "parser's program name member should be nullopt by default"
+    test_argument_parser_info, "parser's program name member should be nullopt by default"
 ) {
     const auto stored_program_name = sut_get_program_name();
-
-    REQUIRE_FALSE(stored_program_name);
+    CHECK_FALSE(stored_program_name);
 }
 
-TEST_CASE_FIXTURE(argument_parser_test_fixture, "name() should set the program name member") {
+TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name member") {
     sut.program_name(test_name);
 
     const auto stored_program_name = sut_get_program_name();
 
     REQUIRE(stored_program_name);
-    REQUIRE_EQ(stored_program_name.value(), test_name);
+    CHECK_EQ(stored_program_name.value(), test_name);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "parser's program description member should be nullopt by default"
+    test_argument_parser_info, "parser's program description member should be nullopt by default"
 ) {
     const auto stored_program_description = sut_get_program_description();
-
-    REQUIRE_FALSE(stored_program_description);
+    CHECK_FALSE(stored_program_description);
 }
 
-TEST_CASE_FIXTURE(argument_parser_test_fixture, "name() should set the program name member") {
+TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name member") {
     sut.program_description(test_description);
 
     const auto stored_program_description = sut_get_program_description();
 
     REQUIRE(stored_program_description);
-    REQUIRE_EQ(stored_program_description.value(), test_description);
+    CHECK_EQ(stored_program_description.value(), test_description);
 }
 
 TEST_SUITE_END();

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -9,29 +9,27 @@ using namespace ap_testing;
 using namespace ap::argument;
 using namespace ap::nargs;
 
-namespace {
-
-constexpr std::string_view test_program_name = "test program name";
-
-constexpr std::size_t default_num_args = 0;
-constexpr std::size_t non_default_num_args = 10;
-constexpr std::size_t non_default_args_split = non_default_num_args / 2;
-
-const std::string invalid_arg_name = "invalid_arg";
-
-const std::string positional_primary_name = "positional_arg";
-const std::string positional_secondary_name = "pa";
-const std::string optional_primary_name = "optional_arg";
-const std::string optional_secondary_name = "oa";
-
-} // namespace
-
 TEST_SUITE_BEGIN("test_argument_parser_parse_args");
+
+struct test_argument_parser_parse_args : public argument_parser_test_fixture {
+    const std::string_view test_program_name = "test program name";
+
+    const std::size_t default_num_args = 0ull;
+    const std::size_t non_default_num_args = 10ull;
+    const std::size_t non_default_args_split = non_default_num_args / 2ull;
+
+    const std::string invalid_arg_name = "invalid_arg";
+
+    const std::string positional_primary_name = "positional_arg";
+    const std::string positional_secondary_name = "pa";
+    const std::string optional_primary_name = "optional_arg";
+    const std::string optional_secondary_name = "oa";
+};
 
 // _preprocess_input
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "_preprocess_input should return an empty vector for no command-line arguments"
 ) {
     const auto argc = get_argc(default_num_args, default_num_args);
@@ -39,13 +37,13 @@ TEST_CASE_FIXTURE(
 
     const auto args = sut_process_input(argc, argv);
 
-    REQUIRE(args.empty());
+    CHECK(args.empty());
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "_preprocess_input should return a vector of correct arguments"
+    test_argument_parser_parse_args, "_preprocess_input should return a vector of correct arguments"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
@@ -58,15 +56,17 @@ TEST_CASE_FIXTURE(
 
     for (std::size_t i = 0; i < non_default_args_split; i++) { // positional args
         REQUIRE_EQ(cmd_args.at(i).discriminator, cmd_argument::type_discriminator::value);
-        REQUIRE_EQ(cmd_args.at(i).value, prepare_arg_value(i));
+        CHECK_EQ(cmd_args.at(i).value, prepare_arg_value(i));
     }
 
     std::size_t opt_arg_idx = non_default_args_split;
     for (std::size_t i = non_default_args_split; i < cmd_args.size(); i += 2) { // optional args
         REQUIRE_EQ(cmd_args.at(i).discriminator, cmd_argument::type_discriminator::flag);
-        REQUIRE(prepare_arg_name(opt_arg_idx).match(cmd_args.at(i).value));
+        CHECK(prepare_arg_name(opt_arg_idx).match(cmd_args.at(i).value));
+
         REQUIRE_EQ(cmd_args.at(i + 1).discriminator, cmd_argument::type_discriminator::value);
-        REQUIRE_EQ(cmd_args.at(i + 1).value, prepare_arg_value(opt_arg_idx));
+        CHECK_EQ(cmd_args.at(i + 1).value, prepare_arg_value(opt_arg_idx));
+
         opt_arg_idx++;
     }
 
@@ -76,7 +76,7 @@ TEST_CASE_FIXTURE(
 // _parse_args_impl
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "_parse_args_impl should throw when there is a non-positional value specified "
     "without an argument flag present before the value"
 ) {
@@ -85,33 +85,31 @@ TEST_CASE_FIXTURE(
     auto cmd_args = prepare_cmd_arg_list(non_default_num_args, non_default_args_split);
     cmd_args.erase(std::next(cmd_args.begin(), non_default_args_split));
 
-    REQUIRE_THROWS_AS(sut_parse_args_impl(cmd_args), ap::error::free_value_error);
+    CHECK_THROWS_AS(sut_parse_args_impl(cmd_args), ap::error::free_value_error);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "_parse_args_impl should not throw when the arguments are correct"
+    test_argument_parser_parse_args,
+    "_parse_args_impl should not throw when the arguments are correct"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
-
     const auto cmd_args = prepare_cmd_arg_list(non_default_num_args, non_default_args_split);
-
-    REQUIRE_NOTHROW(sut_parse_args_impl(cmd_args));
+    CHECK_NOTHROW(sut_parse_args_impl(cmd_args));
 }
 
 // _get_argument
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "_get_argument should return nullopt if "
     "there is no argument with given name present"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
-
-    REQUIRE_FALSE(sut_get_argument(invalid_arg_name));
+    CHECK_FALSE(sut_get_argument(invalid_arg_name));
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "_get_argument should return valid argument "
     "if there is an argument with the given name"
 ) {
@@ -119,15 +117,15 @@ TEST_CASE_FIXTURE(
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE(sut_get_argument(arg_name.primary));
-        REQUIRE(sut_get_argument(arg_name.secondary.value()));
+        CHECK(sut_get_argument(arg_name.primary));
+        CHECK(sut_get_argument(arg_name.secondary.value()));
     }
 }
 
 // parse_args
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "parse_args should throw when there is no value specified for a required optional argument"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -139,13 +137,13 @@ TEST_CASE_FIXTURE(
     const auto argc = get_argc(non_default_num_args, non_default_args_split);
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
-    REQUIRE_THROWS_AS(sut.parse_args(argc, argv), ap::error::required_argument_not_parsed_error);
+    CHECK_THROWS_AS(sut.parse_args(argc, argv), ap::error::required_argument_not_parsed_error);
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "parse_args should throw when an optional argument's nvalues is not in a specified range"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -157,13 +155,13 @@ TEST_CASE_FIXTURE(
     sut.add_optional_argument(range_arg_name.primary, range_arg_name.secondary.value())
         .nargs(at_least(1));
 
-    REQUIRE_THROWS_AS(sut.parse_args(argc, argv), ap::error::invalid_nvalues_error);
+    CHECK_THROWS_AS(sut.parse_args(argc, argv), ap::error::invalid_nvalues_error);
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "parse_args should not throw if input and numer of positional argument"
     "values are correct and all required optional arguments have values"
 ) {
@@ -194,13 +192,13 @@ TEST_CASE_FIXTURE(
     CAPTURE(argc);
     CAPTURE(argv);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+    CHECK_NOTHROW(sut.parse_args(argc, argv));
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "parse_args should not throw if there is an argument which has bypass_required "
     "option enabled and is used"
 ) {
@@ -236,7 +234,7 @@ TEST_CASE_FIXTURE(
     std::strcpy(argv[1], arg_flag.c_str());
 
     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    REQUIRE(sut.value<bool>(bypass_required_arg_name.primary));
+    CHECK(sut.value<bool>(bypass_required_arg_name.primary));
 
     free_argv(argc, argv);
 }
@@ -244,7 +242,7 @@ TEST_CASE_FIXTURE(
 // has_value
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "has_value should return false if there is no argument with given name present"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -253,13 +251,13 @@ TEST_CASE_FIXTURE(
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    REQUIRE_FALSE(sut.has_value(invalid_arg_name));
+    CHECK_FALSE(sut.has_value(invalid_arg_name));
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "has_value should return false when an argument has no values"
+    test_argument_parser_parse_args, "has_value should return false when an argument has no values"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
@@ -282,8 +280,8 @@ TEST_CASE_FIXTURE(
 
         for (std::size_t i = 0; i < non_default_num_args; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE(sut.has_value(arg_name.primary));
-            REQUIRE(sut.has_value(arg_name.secondary.value()));
+            CHECK(sut.has_value(arg_name.primary));
+            CHECK(sut.has_value(arg_name.secondary.value()));
         }
     }
     SUBCASE("only the necessary arguments have values") {
@@ -299,18 +297,18 @@ TEST_CASE_FIXTURE(
 
         for (std::size_t i = 0; i < non_default_args_split; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE(sut.has_value(arg_name.primary));
-            REQUIRE(sut.has_value(arg_name.secondary.value()));
+            CHECK(sut.has_value(arg_name.primary));
+            CHECK(sut.has_value(arg_name.secondary.value()));
         }
         for (std::size_t i = non_default_args_split; i < non_default_num_args; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE_FALSE(sut.has_value(arg_name.primary));
-            REQUIRE_FALSE(sut.has_value(arg_name.secondary.value()));
+            CHECK_FALSE(sut.has_value(arg_name.primary));
+            CHECK_FALSE(sut.has_value(arg_name.secondary.value()));
         }
         for (std::size_t i = non_default_num_args; i < num_args; i++) {
             const auto arg_name = prepare_arg_name(i);
-            REQUIRE(sut.has_value(arg_name.primary));
-            REQUIRE(sut.has_value(arg_name.secondary.value()));
+            CHECK(sut.has_value(arg_name.primary));
+            CHECK(sut.has_value(arg_name.secondary.value()));
         }
     }
 
@@ -323,7 +321,7 @@ TEST_CASE_FIXTURE(
 // value
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "value() should throw if there is no argument with given name present"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -332,26 +330,26 @@ TEST_CASE_FIXTURE(
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-
-    REQUIRE_THROWS_AS(sut.value(invalid_arg_name), ap::error::argument_not_found_error);
+    CHECK_THROWS_AS(sut.value(invalid_arg_name), ap::error::argument_not_found_error);
 
     free_argv(argc, argv);
 }
 
-TEST_CASE_FIXTURE(argument_parser_test_fixture, "value() should throw before calling parse_args") {
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "value() should throw before calling parse_args"
+) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
-        REQUIRE_THROWS_AS(
-            sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error
-        );
+        CHECK_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
+        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error);
     }
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "value() should throw if the given argument doesn't have a value"
+    test_argument_parser_parse_args,
+    "value() should throw if the given argument doesn't have a value"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
@@ -374,27 +372,25 @@ TEST_CASE_FIXTURE(
 
     for (std::size_t i = 0; i < non_default_args_split; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_NOTHROW(sut.value(arg_name.primary));
-        REQUIRE_NOTHROW(sut.value(arg_name.secondary.value()));
+        CHECK_NOTHROW(sut.value(arg_name.primary));
+        CHECK_NOTHROW(sut.value(arg_name.secondary.value()));
     }
     for (std::size_t i = non_default_args_split; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
-        REQUIRE_THROWS_AS(
-            sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error
-        );
+        CHECK_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
+        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error);
     }
     for (std::size_t i = non_default_num_args; i < num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_NOTHROW(sut.value(arg_name.primary));
-        REQUIRE_NOTHROW(sut.value(arg_name.secondary.value()));
+        CHECK_NOTHROW(sut.value(arg_name.primary));
+        CHECK_NOTHROW(sut.value(arg_name.secondary.value()));
     }
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "value() should throw if an argument has a value but the given type is invalid"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -412,7 +408,7 @@ TEST_CASE_FIXTURE(
         const auto arg_name = prepare_arg_name(i);
 
         REQUIRE(sut.has_value(arg_name.primary));
-        REQUIRE_THROWS_AS(
+        CHECK_THROWS_AS(
             sut.value<invalid_value_type>(arg_name.primary), ap::error::invalid_value_type_error
         );
     }
@@ -421,7 +417,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "value() should return a correct value when there is an argument"
     "with the given name and a parsed value present"
 ) {
@@ -444,8 +440,8 @@ TEST_CASE_FIXTURE(
         const auto arg_value = prepare_arg_value(i);
 
         REQUIRE(sut.has_value(arg_name.primary));
-        REQUIRE_EQ(sut.value(arg_name.primary), arg_value);
-        REQUIRE_EQ(sut.value(arg_name.secondary.value()), arg_value);
+        CHECK_EQ(sut.value(arg_name.primary), arg_value);
+        CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
     }
 
     free_argv(argc, argv);
@@ -453,18 +449,20 @@ TEST_CASE_FIXTURE(
 
 // count
 
-TEST_CASE_FIXTURE(argument_parser_test_fixture, "count should return 0 before calling parse_args") {
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "count should return 0 before calling parse_args"
+) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        REQUIRE_EQ(sut.count(arg_name.primary), 0u);
-        REQUIRE_EQ(sut.count(arg_name.secondary.value()), 0u);
+        CHECK_EQ(sut.count(arg_name.primary), 0u);
+        CHECK_EQ(sut.count(arg_name.secondary.value()), 0u);
     }
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "count should return 0 if there is no argument with given name present"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
@@ -473,13 +471,13 @@ TEST_CASE_FIXTURE(
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    REQUIRE_EQ(sut.count(invalid_arg_name), 0u);
+    CHECK_EQ(sut.count(invalid_arg_name), 0u);
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture, "count should return the number of argument's flag usage"
+    test_argument_parser_parse_args, "count should return the number of argument's flag usage"
 ) {
     // prepare sut
     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
@@ -521,8 +519,8 @@ TEST_CASE_FIXTURE(
     sut.parse_args(argc, argv);
 
     // test count
-    REQUIRE_EQ(sut.count(positional_primary_name), positional_count);
-    REQUIRE_EQ(sut.count(optional_primary_name), optional_count);
+    CHECK_EQ(sut.count(positional_primary_name), positional_count);
+    CHECK_EQ(sut.count(optional_primary_name), optional_count);
 
     // free argv
     free_argv(argc, argv);
@@ -531,34 +529,34 @@ TEST_CASE_FIXTURE(
 // values
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "values() should throw when calling with a positional argument's name"
 ) {
     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
 
-    REQUIRE_THROWS_AS(sut.values(positional_primary_name), std::logic_error);
-    REQUIRE_THROWS_AS(sut.values(positional_secondary_name), std::logic_error);
+    CHECK_THROWS_AS(sut.values(positional_primary_name), std::logic_error);
+    CHECK_THROWS_AS(sut.values(positional_secondary_name), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "values() should return an empty vector if an argument has no values"
 ) {
     sut.add_optional_argument(optional_primary_name, optional_secondary_name);
 
     SUBCASE("calling with argument's primary name") {
         const auto& values = sut.values(optional_primary_name);
-        REQUIRE(values.empty());
+        CHECK(values.empty());
     }
 
     SUBCASE("calling with argument's secondary name") {
         const auto& values = sut.values(optional_secondary_name);
-        REQUIRE(values.empty());
+        CHECK(values.empty());
     }
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "values() should throw when an argument has values but the given type is invalid"
 ) {
     sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
@@ -595,7 +593,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "values() should return a vector containing a predefined value if no values "
     "for an argument have been parsed"
 ) {
@@ -640,13 +638,13 @@ TEST_CASE_FIXTURE(
     const auto& stored_values = sut.values(optional_primary_name);
 
     REQUIRE_EQ(stored_values.size(), 1);
-    REQUIRE_EQ(stored_values.front(), expected_value);
+    CHECK_EQ(stored_values.front(), expected_value);
 
     free_argv(argc, argv);
 }
 
 TEST_CASE_FIXTURE(
-    argument_parser_test_fixture,
+    test_argument_parser_parse_args,
     "values() should return a correct vector of values when there is an argument with "
     "a given name and parsed values present"
 ) {
@@ -679,7 +677,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_EQ(stored_values.size(), values.size());
     for (std::size_t i = 0; i < stored_values.size(); i++)
-        REQUIRE_EQ(stored_values[i], values[i]);
+        CHECK_EQ(stored_values[i], values[i]);
 
     free_argv(argc, argv);
 }

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -50,8 +50,7 @@ TEST_SUITE_BEGIN("test_optional_argument");
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_optional() should return true") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE(sut.is_optional());
+    CHECK(sut.is_optional());
 }
 
 TEST_CASE_FIXTURE(
@@ -61,8 +60,8 @@ TEST_CASE_FIXTURE(
     const auto sut = prepare_argument(primary_name);
     const auto name = sut_get_name(sut);
 
-    REQUIRE(name.match(primary_name));
-    REQUIRE_FALSE(name.match(secondary_name));
+    CHECK(name.match(primary_name));
+    CHECK_FALSE(name.match(secondary_name));
 }
 
 TEST_CASE_FIXTURE(
@@ -73,14 +72,13 @@ TEST_CASE_FIXTURE(
     const auto sut = prepare_argument(primary_name, secondary_name);
     const auto name = sut_get_name(sut);
 
-    REQUIRE(name.match(primary_name));
-    REQUIRE(name.match(secondary_name));
+    CHECK(name.match(primary_name));
+    CHECK(name.match(secondary_name));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "help() should return nullopt by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_get_help(sut));
+    CHECK_FALSE(sut_get_help(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -94,13 +92,12 @@ TEST_CASE_FIXTURE(
     const auto stored_help_msg = sut_get_help(sut);
 
     REQUIRE(stored_help_msg);
-    REQUIRE_EQ(stored_help_msg, help_msg);
+    CHECK_EQ(stored_help_msg, help_msg);
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_required() should return false by default") {
     auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_is_required(sut));
+    CHECK_FALSE(sut_is_required(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -108,16 +105,13 @@ TEST_CASE_FIXTURE(
     "is_required() should return true is argument is set to be required"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut.required();
-
-    REQUIRE(sut_is_required(sut));
+    CHECK(sut_is_required(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_used() should return false by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_is_used(sut));
+    CHECK_FALSE(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -126,13 +120,12 @@ TEST_CASE_FIXTURE(
     auto sut = prepare_argument(primary_name);
     sut_set_value(sut, std::to_string(value_1));
 
-    REQUIRE(sut_is_used(sut));
+    CHECK(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "nused() should return 0 by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_EQ(sut_get_nused(sut), 0u);
+    CHECK_EQ(sut_get_nused(sut), 0u);
 }
 
 TEST_CASE_FIXTURE(
@@ -146,21 +139,18 @@ TEST_CASE_FIXTURE(
     for (std::size_t n = 0; n < nused; n++)
         sut_set_used(sut);
 
-    REQUIRE_EQ(sut_get_nused(sut), nused);
+    CHECK_EQ(sut_get_nused(sut), nused);
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return false by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_has_value(sut));
+    CHECK_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return true if value is set") {
     auto sut = prepare_argument(primary_name);
-
     sut_set_value(sut, std::to_string(value_1));
-
-    REQUIRE(sut_has_value(sut));
+    CHECK(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -170,7 +160,7 @@ TEST_CASE_FIXTURE(
     sut.default_value(default_value);
 
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), default_value);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), default_value);
 }
 
 TEST_CASE_FIXTURE(
@@ -180,7 +170,7 @@ TEST_CASE_FIXTURE(
     auto sut = prepare_argument(primary_name);
     sut.implicit_value(implicit_value);
 
-    REQUIRE_FALSE(sut_has_value(sut));
+    CHECK_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -193,15 +183,14 @@ TEST_CASE_FIXTURE(
     sut_set_used(sut);
 
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), implicit_value);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), implicit_value);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "has_parsed_values() should return false by default"
 ) {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_has_parsed_values(sut));
+    CHECK_FALSE(sut_has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -213,18 +202,18 @@ TEST_CASE_FIXTURE(
 
     SUBCASE("default_value") {
         sut.default_value(default_value);
-        REQUIRE_FALSE(sut_has_parsed_values(sut));
+        CHECK_FALSE(sut_has_parsed_values(sut));
     }
 
     SUBCASE("implicit_value") {
         sut.implicit_value(implicit_value);
-        REQUIRE_FALSE(sut_has_parsed_values(sut));
+        CHECK_FALSE(sut_has_parsed_values(sut));
     }
 
     SUBCASE("default_value & implicit_value") {
         sut.default_value(default_value);
         sut.implicit_value(implicit_value);
-        REQUIRE_FALSE(sut_has_parsed_values(sut));
+        CHECK_FALSE(sut_has_parsed_values(sut));
     }
 }
 
@@ -232,10 +221,8 @@ TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut_set_value(sut, std::to_string(value_1));
-
-    REQUIRE(sut_has_parsed_values(sut));
+    CHECK(sut_has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -243,8 +230,7 @@ TEST_CASE_FIXTURE(
     "value() should return default any object if argument's value has not been set"
 ) {
     auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_get_value(sut).has_value());
+    CHECK_FALSE(sut_get_value(sut).has_value());
 }
 
 TEST_CASE_FIXTURE(
@@ -255,7 +241,7 @@ TEST_CASE_FIXTURE(
     sut_set_value(sut, std::to_string(value_1));
 
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(
@@ -266,7 +252,7 @@ TEST_CASE_FIXTURE(
     sut.default_value(value_1);
 
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(
@@ -279,7 +265,7 @@ TEST_CASE_FIXTURE(
     sut_set_used(sut);
 
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), implicit_value);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), implicit_value);
 }
 
 TEST_CASE_FIXTURE(
@@ -290,13 +276,11 @@ TEST_CASE_FIXTURE(
 
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_AS(sut_set_value(sut, empty_str), ap::error::invalid_value_error);
-
-        REQUIRE_FALSE(sut_has_value(sut));
+        CHECK_FALSE(sut_has_value(sut));
     }
     SUBCASE("given string is non-convertible to value_type") {
         REQUIRE_THROWS_AS(sut_set_value(sut, invalid_value_str), ap::error::invalid_value_error);
-
-        REQUIRE_FALSE(sut_has_value(sut));
+        CHECK_FALSE(sut_has_value(sut));
     }
 }
 
@@ -305,14 +289,12 @@ TEST_CASE_FIXTURE(
     "set_value(any) should throw when parameter passed to value() is not present in the choices set"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut_set_choices(sut, default_choices);
 
     REQUIRE_THROWS_AS(
         sut_set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice_error
     );
-
-    REQUIRE_FALSE(sut_has_value(sut));
+    CHECK_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -335,7 +317,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value);
 }
 
 TEST_CASE_FIXTURE(
@@ -346,8 +328,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value_1)));
     REQUIRE(sut_has_value(sut));
-
-    REQUIRE_THROWS_AS(
+    CHECK_THROWS_AS(
         sut_set_value(sut, std::to_string(value_2)), ap::error::value_already_set_error
     );
 }
@@ -382,9 +363,7 @@ TEST_CASE_FIXTURE(
 
         sut_set_value(sut, std::to_string(value_1));
 
-        REQUIRE_EQ(
-            std::any_cast<test_value_type>(sut_get_value(sut)), double_valued_action(value_1)
-        );
+        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), double_valued_action(value_1));
     }
 
     SUBCASE("void action") {
@@ -396,7 +375,7 @@ TEST_CASE_FIXTURE(
         sut_set_value(sut, std::to_string(test_value));
 
         double_void_action(test_value);
-        REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), test_value);
+        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), test_value);
     }
 }
 
@@ -405,8 +384,7 @@ TEST_CASE_FIXTURE(
     "nvalues_in_range() should return equivalent if nargs has not been set"
 ) {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE(std::is_eq(sut_nvalues_in_range(sut)));
+    CHECK(std::is_eq(sut_nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(
@@ -418,7 +396,7 @@ TEST_CASE_FIXTURE(
 
     sut.default_value(default_value);
 
-    REQUIRE(std::is_eq(sut_nvalues_in_range(sut)));
+    CHECK(std::is_eq(sut_nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(
@@ -433,11 +411,11 @@ TEST_CASE_FIXTURE(
 
     for (const auto value : default_choices) {
         REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
-        REQUIRE(std::is_eq(sut_nvalues_in_range(sut)));
+        CHECK(std::is_eq(sut_nvalues_in_range(sut)));
     }
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(invalid_choice)));
-    REQUIRE(std::is_gt(sut_nvalues_in_range(sut)));
+    CHECK(std::is_gt(sut_nvalues_in_range(sut)));
 }
 
 TEST_SUITE_END();

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -43,8 +43,7 @@ TEST_SUITE_BEGIN("test_positional_argument");
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_optional() should return false") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut.is_optional());
+    CHECK_FALSE(sut.is_optional());
 }
 
 TEST_CASE_FIXTURE(
@@ -54,8 +53,8 @@ TEST_CASE_FIXTURE(
     const auto sut = prepare_argument(primary_name);
     const auto name = sut_get_name(sut);
 
-    REQUIRE(name.match(primary_name));
-    REQUIRE_FALSE(name.match(secondary_name));
+    CHECK(name.match(primary_name));
+    CHECK_FALSE(name.match(secondary_name));
 }
 
 TEST_CASE_FIXTURE(
@@ -66,14 +65,13 @@ TEST_CASE_FIXTURE(
     const auto sut = prepare_argument(primary_name, secondary_name);
     const auto name = sut_get_name(sut);
 
-    REQUIRE(name.match(primary_name));
-    REQUIRE(name.match(secondary_name));
+    CHECK(name.match(primary_name));
+    CHECK(name.match(secondary_name));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "help() should return nullopt by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_get_help(sut));
+    CHECK_FALSE(sut_get_help(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -87,19 +85,17 @@ TEST_CASE_FIXTURE(
     const auto stored_help_msg = sut_get_help(sut);
 
     REQUIRE(stored_help_msg);
-    REQUIRE_EQ(stored_help_msg, help_msg);
+    CHECK_EQ(stored_help_msg, help_msg);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_required() should return true") {
     auto sut = prepare_argument(primary_name);
-
-    REQUIRE(sut_is_required(sut));
+    CHECK(sut_is_required(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_used() should return false by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_is_used(sut));
+    CHECK_FALSE(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -108,13 +104,12 @@ TEST_CASE_FIXTURE(
     auto sut = prepare_argument(primary_name);
     sut_set_value(sut, std::to_string(value_1));
 
-    REQUIRE(sut_is_used(sut));
+    CHECK(sut_is_used(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "nused() should return 0 by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_EQ(sut_get_nused(sut), 0u);
+    CHECK_EQ(sut_get_nused(sut), 0u);
 }
 
 TEST_CASE_FIXTURE(
@@ -123,41 +118,37 @@ TEST_CASE_FIXTURE(
     auto sut = prepare_argument(primary_name);
     sut_set_value(sut, std::to_string(value_1));
 
-    REQUIRE_EQ(sut_get_nused(sut), 1u);
+    CHECK_EQ(sut_get_nused(sut), 1u);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return false by default") {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_has_value(sut));
+    CHECK_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_value() should return true is value is set"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut_set_value(sut, std::to_string(value_1));
 
-    REQUIRE(sut_has_value(sut));
+    CHECK(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should return false by default"
 ) {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE_FALSE(sut_has_parsed_values(sut));
+    CHECK_FALSE(sut_has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut_set_value(sut, std::to_string(value_1));
 
-    REQUIRE(sut_has_parsed_values(sut));
+    CHECK(sut_has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -168,8 +159,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value_1)));
     REQUIRE(sut_has_value(sut));
-
-    REQUIRE_THROWS_AS(
+    CHECK_THROWS_AS(
         sut_set_value(sut, std::to_string(value_2)), ap::error::value_already_set_error
     );
 }
@@ -182,13 +172,11 @@ TEST_CASE_FIXTURE(
 
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_AS(sut_set_value(sut, empty_str), ap::error::invalid_value_error);
-
-        REQUIRE_FALSE(sut_has_value(sut));
+        CHECK_FALSE(sut_has_value(sut));
     }
     SUBCASE("given string is non-convertible to value_type") {
         REQUIRE_THROWS_AS(sut_set_value(sut, invalid_value_str), ap::error::invalid_value_error);
-
-        REQUIRE_FALSE(sut_has_value(sut));
+        CHECK_FALSE(sut_has_value(sut));
     }
 }
 
@@ -197,14 +185,12 @@ TEST_CASE_FIXTURE(
     "set_value(any) should throw when parameter passed to value() is not present in the choices set"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut_set_choices(sut, default_choices);
 
     REQUIRE_THROWS_AS(
         sut_set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice_error
     );
-
-    REQUIRE_FALSE(sut_has_value(sut));
+    CHECK_FALSE(sut_has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -228,7 +214,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value);
 }
 
 TEST_CASE_FIXTURE(
@@ -242,9 +228,7 @@ TEST_CASE_FIXTURE(
 
         sut_set_value(sut, std::to_string(value_1));
 
-        REQUIRE_EQ(
-            std::any_cast<test_value_type>(sut_get_value(sut)), double_valued_action(value_1)
-        );
+        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), double_valued_action(value_1));
     }
 
     SUBCASE("void action") {
@@ -256,7 +240,7 @@ TEST_CASE_FIXTURE(
         sut_set_value(sut, std::to_string(test_value));
 
         double_void_action(test_value);
-        REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), test_value);
+        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), test_value);
     }
 }
 
@@ -267,7 +251,7 @@ TEST_CASE_FIXTURE(
     auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_value(sut));
-    REQUIRE_THROWS_AS(std::any_cast<test_value_type>(sut_get_value(sut)), std::bad_any_cast);
+    CHECK_THROWS_AS(std::any_cast<test_value_type>(sut_get_value(sut)), std::bad_any_cast);
 }
 
 TEST_CASE_FIXTURE(
@@ -279,21 +263,19 @@ TEST_CASE_FIXTURE(
     sut_set_value(sut, std::to_string(value_1));
 
     REQUIRE(sut_has_value(sut));
-    REQUIRE_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
+    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "values() should throw logic_error") {
     auto sut = prepare_argument(primary_name);
-
-    REQUIRE_THROWS_AS(sut_get_values(sut), std::logic_error);
+    CHECK_THROWS_AS(sut_get_values(sut), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "nvalues_in_range() should return less by default"
 ) {
     const auto sut = prepare_argument(primary_name);
-
-    REQUIRE(std::is_lt(sut_nvalues_in_range(sut)));
+    CHECK(std::is_lt(sut_nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(
@@ -301,10 +283,9 @@ TEST_CASE_FIXTURE(
     "nvalues_in_range() should return equivalent if a value has been set"
 ) {
     auto sut = prepare_argument(primary_name);
-
     sut_set_value(sut, std::to_string(value_1));
 
-    REQUIRE(std::is_eq(sut_nvalues_in_range(sut)));
+    CHECK(std::is_eq(sut_nvalues_in_range(sut)));
 }
 
 TEST_SUITE_END();


### PR DESCRIPTION
Aligned the unit tests to use fixtures and CHECK macros (instead of REQUIRE) where it is appropriate and/or necessary