### PR TITLE
YT-CPPG-22: Add the demo workflow

### DIFF
--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -20,6 +20,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
+      - name: Sync submodules to HTTPS
+        run: git submodule sync --recursive
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+
       - name: Determine Current Branch
         id: branch-name
         run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -1,12 +1,14 @@
 name: demo
-
 on:
   push:
     branches:
       - '*'
-  pull_request:
-    branches:
-      - '*'
+    paths:
+      - .github/workflows/demo.yaml
+      - .gitmodules
+      - cpp-ap-demo
+      - include/**
+
 
 jobs:
   build-demo:

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -1,0 +1,32 @@
+name: demo
+
+on:
+  push:
+    branches:
+      - '*'
+  pull_request:
+    branches:
+      - '*'
+
+jobs:
+  build-demo:
+    name: Build cpp-ap-demo
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Check out current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Determine Current Branch
+        id: branch-name
+        run: echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
+
+      - name: Build cpp-ap-demo
+        run: |
+          cd cpp-ap-demo
+          cmake -B build -DAP_TAG=${{ steps.branch-name.outputs.branch }}
+          cd build
+          make -j 4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "cpp-ap-demo"]
 	path = cpp-ap-demo
-	url = git@github.com:SpectraL519/cpp-ap-demo.git
+	url = https://github.com/SpectraL519/cpp-ap-demo.git

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Command-line argument parser for C++20
 [![g++](https://github.com/SpectraL519/cpp-ap/actions/workflows/gpp.yaml/badge.svg)](https://github.com/SpectraL519/cpp-ap/actions/workflows/g++)
 [![clang++](https://github.com/SpectraL519/cpp-ap/actions/workflows/clang.yaml/badge.svg)](https://github.com/SpectraL519/cpp-ap/actions/workflows/clang++)
 [![format](https://github.com/SpectraL519/cpp-ap/actions/workflows/format.yaml/badge.svg)](https://github.com/SpectraL519/cpp-ap/actions/workflows/format)
+[![demo](https://github.com/SpectraL519/cpp-ap/actions/workflows/demo.yaml/badge.svg)](https://github.com/SpectraL519/cpp-ap/actions/workflows/demo)
 
 <br />
 


### PR DESCRIPTION
Added:
- the demo workflow, which builds the `cpp-ap-demo` submodule using the current cpp-ap branch
- the workflow badge in readme