### PR TITLE
YT-CPPGL-23: Fix the invalid_value_type_error crash when there is no parsed or predefined values for an optional argument

### DIFF
--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1079,7 +1079,16 @@ private:
 
     /// @return Reference to the stored value of the optional argument.
     [[nodiscard]] const std::any& value() const override {
-        return this->_values.empty() ? this->_predefined_value() : this->_values.front();
+        if (not this->_values.empty())
+            return this->_values.front();
+
+        if (not this->_has_predefined_value())
+            throw std::logic_error(std::format(
+                "No value parsed and no predefined value for the `{}` optional argument.",
+                this->_name.str()
+            ));
+
+        return this->_predefined_value();
     }
 
     /// @return Reference to the vector of parsed values for the optional argument.
@@ -1095,14 +1104,7 @@ private:
 
     /// @return Reference to the predefined value of the optional argument.
     [[nodiscard]] const std::any& _predefined_value() const {
-        const auto& predefined_value =
-            this->is_used() ? this->_implicit_value : this->_default_value;
-        if (not predefined_value.has_value())
-            throw std::logic_error(std::format(
-                "No value parsed and no predefined value for the `{}` optional argument.",
-                this->_name.str()
-            ));
-        return predefined_value;
+        return this->is_used() ? this->_implicit_value : this->_default_value;
     }
 
     /**

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -18,6 +18,7 @@
 #include <compare>
 #include <concepts>
 #include <filesystem>
+#include <format>
 #include <functional>
 #include <iostream>
 #include <memory>
@@ -247,7 +248,7 @@ protected:
     virtual std::weak_ordering nvalues_in_range() const noexcept = 0;
 
     /// @return Reference to the stored value of the argument.
-    virtual const std::any& value() const noexcept = 0;
+    virtual const std::any& value() const = 0;
 
     /// @return Reference to the vector of parsed values of the argument.
     virtual const std::vector<std::any>& values() const = 0;
@@ -281,7 +282,9 @@ public:
      * @param arg_name The name of the argument that already has a value set.
      */
     explicit value_already_set_error(const argument::detail::argument_name& arg_name)
-    : argument_parser_error("Value for argument " + arg_name.str() + " has already been set") {}
+    : argument_parser_error(
+          std::format("Value for argument {} has already been set.", arg_name.str())
+      ) {}
 };
 
 /// @brief Exception thrown when the value provided for an argument cannot be parsed.
@@ -295,7 +298,9 @@ public:
     explicit invalid_value_error(
         const argument::detail::argument_name& arg_name, const std::string& value
     )
-    : argument_parser_error("Cannot parse value `" + value + "` for argument " + arg_name.str()) {}
+    : argument_parser_error(
+          std::format("Cannot parse value `{}` for argument {}.", value, arg_name.str())
+      ) {}
 };
 
 /// @brief Exception thrown when the provided value is not in the choices for an argument.
@@ -310,7 +315,7 @@ public:
         const argument::detail::argument_name& arg_name, const std::string& value
     )
     : argument_parser_error(
-          "Value `" + value + "` is not a valid choice for argument " + arg_name.str()
+          std::format("Value `{}` is not a valid choice for argument {}.", value, arg_name.str())
       ) {}
 };
 
@@ -322,7 +327,7 @@ public:
      * @param arg_name The name of the argument causing the collision.
      */
     explicit argument_name_used_error(const argument::detail::argument_name& arg_name)
-    : argument_parser_error("Given name `" + arg_name.str() + "` already used") {}
+    : argument_parser_error(std::format("Given name `{}` already used.", arg_name.str())) {}
 };
 
 /// @brief Exception thrown when an argument with a specific name is not found.
@@ -333,8 +338,7 @@ public:
      * @param arg_name The name of the argument that was not found.
      */
     explicit argument_not_found_error(const std::string_view& arg_name)
-    : argument_parser_error("Argument with given name `" + std::string(arg_name) + "` not found.") {
-    }
+    : argument_parser_error(std::format("Argument with given name `{}` not found.", arg_name)) {}
 };
 
 /// @brief Exception thrown when there is an attempt to cast to an invalid type.
@@ -348,9 +352,9 @@ public:
     explicit invalid_value_type_error(
         const argument::detail::argument_name& arg_name, const std::type_info& value_type
     )
-    : argument_parser_error(
-          "Invalid value type specified for argument " + arg_name.str() + " - " + value_type.name()
-      ) {}
+    : argument_parser_error(std::format(
+          "Invalid value type specified for argument {} = {}.", arg_name.str(), value_type.name()
+      )) {}
 };
 
 /// @brief Exception thrown when a required argument is not parsed.
@@ -372,7 +376,9 @@ public:
      * @param value The value for which the argument deduction failed.
      */
     explicit free_value_error(const std::string& value)
-    : argument_parser_error("Failed to deduce the argument for the given value `" + value + "`") {}
+    : argument_parser_error(
+          std::format("Failed to deduce the argument for the given value `{}`", value)
+      ) {}
 };
 
 /// @brief Exception thrown when an invalid number of values is provided for an argument.
@@ -610,7 +616,7 @@ detail::callable_type<ap::void_action, T> default_action() noexcept {
 inline detail::callable_type<ap::void_action, std::string> check_file_exists() noexcept {
     return [](std::string& file_path) {
         if (not std::filesystem::exists(file_path))
-            throw argument_parser_error("[ERROR] : File " + file_path + " does not exists!");
+            throw argument_parser_error(std::format("File `{}` does not exists!", file_path));
     };
 }
 
@@ -780,13 +786,19 @@ private:
     }
 
     /// @brief Get the stored value of the positional argument.
-    [[nodiscard]] const std::any& value() const noexcept override {
+    [[nodiscard]] const std::any& value() const override {
+        if (not this->_value.has_value())
+            throw std::logic_error(
+                std::format("No value parsed for the `{}` positional argument.", this->_name.str())
+            );
         return this->_value;
     }
 
     /// @return Reference to the vector of parsed values for the positional argument.
     [[nodiscard]] const std::vector<std::any>& values() const override {
-        throw std::logic_error("Positional argument " + this->_name.primary + "has only 1 value.");
+        throw std::logic_error(
+            std::format("Positional argument `{}` has only 1 value.", this->_name.primary)
+        );
     }
 
     /**
@@ -1066,8 +1078,7 @@ private:
     }
 
     /// @return Reference to the stored value of the optional argument.
-    [[nodiscard]] const std::any& value() const noexcept override {
-        std::cout << "> optional_argument::value()" << std::endl;
+    [[nodiscard]] const std::any& value() const override {
         return this->_values.empty() ? this->_predefined_value() : this->_values.front();
     }
 
@@ -1084,11 +1095,13 @@ private:
 
     /// @return Reference to the predefined value of the optional argument.
     [[nodiscard]] const std::any& _predefined_value() const {
-        std::cout << "> optional_argument::_predefined_value()" << std::endl;
         const auto& predefined_value =
             this->is_used() ? this->_implicit_value : this->_default_value;
         if (not predefined_value.has_value())
-            throw std::logic_error("no prefefined value");
+            throw std::logic_error(std::format(
+                "No value parsed and no predefined value for the `{}` optional argument.",
+                this->_name.str()
+            ));
         return predefined_value;
     }
 
@@ -1367,14 +1380,11 @@ public:
      */
     template <std::copy_constructible T = std::string>
     T value(std::string_view arg_name) const {
-        std::cout << "> parser::value(" << arg_name << ")" << std::endl;
         const auto arg_opt = this->_get_argument(arg_name);
         if (not arg_opt)
             throw error::argument_not_found_error(arg_name);
 
-
         try {
-            std::cout << "\t> trying to cast the value" << std::endl;
             T value = std::any_cast<T>(arg_opt->get().value());
             return value;
         }

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1079,23 +1079,7 @@ private:
 
     /// @return Reference to the stored value of the optional argument.
     [[nodiscard]] const std::any& value() const override {
-        std::cout << "> value - " << this->_name << std::endl;
-
-        if (not this->_values.empty()) {
-            std::cout << "> returning _values.front()" << std::endl;
-            return this->_values.front();
-        }
-
-        if (not this->_has_predefined_value()) {
-            std::cout << "> throwing no predefined value" << std::endl;
-            throw std::logic_error(std::format(
-                "No value parsed and no predefined value for the `{}` optional argument.",
-                this->_name.str()
-            ));
-        }
-
-        std::cout << "> returning _predefined_value()\n\n" << std::endl;
-        return this->_predefined_value();
+        return this->_values.empty() ? this->_predefined_value() : this->_values.front();
     }
 
     /// @return Reference to the vector of parsed values for the optional argument.
@@ -1105,24 +1089,27 @@ private:
 
     /// @return True if the optional argument has a predefined value, false otherwise.
     [[nodiscard]] bool _has_predefined_value() const noexcept {
-        std::cout
-            << std::boolalpha << "_has_predefined_value(): " << this->_name << "\n"
-            << "> dv = " << this->_default_value.has_value() << "\n"
-            << "> iu = " << this->is_used() << "\n"
-            << "> iv = " << this->_implicit_value.has_value() << "\n"
-            << "> (iu and iv) = " << (this->is_used() and this->_implicit_value.has_value()) << "\n"
-            << "> dv or (iu and iv) = "
-            << (this->_default_value.has_value()
-                or (this->is_used() and this->_implicit_value.has_value()))
-            << std::endl;
-
         return this->_default_value.has_value()
             or (this->is_used() and this->_implicit_value.has_value());
     }
 
     /// @return Reference to the predefined value of the optional argument.
-    [[nodiscard]] const std::any& _predefined_value() const noexcept {
-        return this->is_used() ? this->_implicit_value : this->_default_value;
+    [[nodiscard]] const std::any& _predefined_value() const {
+        if (this->is_used()) {
+            if (not this->_implicit_value.has_value())
+                throw(std::logic_error(
+                    std::format("No implicit value specified for argument `{}`.", this->_name.str())
+                ));
+
+            return this->_implicit_value;
+        }
+
+        if (not this->_default_value.has_value())
+            throw(std::logic_error(
+                std::format("No default value specified for argument `{}`.", this->_name.str())
+            ));
+
+        return this->_default_value;
     }
 
     /**

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1646,7 +1646,6 @@ private:
     void _parse_positional_args(
         const cmd_argument_list& cmd_args, cmd_argument_list_iterator& cmd_it
     ) noexcept {
-        // TODO: align tests
         for (const auto& pos_arg : this->_positional_args) {
             if (cmd_it == cmd_args.end())
                 return;

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1083,9 +1083,13 @@ private:
     }
 
     /// @return Reference to the predefined value of the optional argument.
-    [[nodiscard]] const std::any& _predefined_value() const noexcept {
+    [[nodiscard]] const std::any& _predefined_value() const {
         std::cout << "> optional_argument::_predefined_value()" << std::endl;
-        return this->is_used() ? this->_implicit_value : this->_default_value;
+        const auto& predefined_value =
+            this->is_used() ? this->_implicit_value : this->_default_value;
+        if (not predefined_value.has_value())
+            throw std::logic_error("no prefefined value");
+        return predefined_value;
     }
 
     /**
@@ -1686,8 +1690,6 @@ private:
                 curr_opt_arg->get()->mark_used();
             }
             else {
-
-
                 if (not curr_opt_arg)
                     throw error::free_value_error(cmd_it->value);
 

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -43,35 +43,38 @@ struct argument_parser_test_fixture {
         return static_cast<int>(get_args_length(num_args, args_split) + 1);
     }
 
-    [[nodiscard]] char** prepare_argv(std::size_t num_args, std::size_t args_split) const {
-        char** argv = new char*[get_argc(num_args, args_split)];
+    [[nodiscard]] char** to_char_2d_array(const std::vector<std::string>& argv_vec) const {
+        char** argv = new char*[argv_vec.size()];
 
-        argv[0] = new char[8];
-        std::strcpy(argv[0], "program");
-
-        for (std::size_t i = 0; i < args_split; i++) { // positional args
-            std::string arg_v = prepare_arg_value(i);
-
-            const auto arg_i = i + 1;
-            argv[arg_i] = new char[arg_v.length() + 1];
-            std::strcpy(argv[arg_i], arg_v.c_str());
-        }
-
-        for (std::size_t i = args_split; i < num_args; i++) { // optional args
-            std::string arg = prepare_arg_flag_primary(i);
-            std::string arg_v = prepare_arg_value(i);
-
-            const std::size_t arg_i = 2 * i - args_split + 1;
-            const std::size_t arg_v_i = arg_i + 1;
-
-            argv[arg_i] = new char[arg.length() + 1];
-            argv[arg_v_i] = new char[arg_v.length() + 1];
-
-            std::strcpy(argv[arg_i], arg.c_str());
-            std::strcpy(argv[arg_v_i], arg_v.c_str());
+        for (size_t i = 0; i < argv_vec.size(); ++i) {
+            argv[i] = new char[argv_vec[i].size() + 1];
+            std::strcpy(argv[i], argv_vec[i].c_str());
         }
 
         return argv;
+    }
+
+    [[nodiscard]] std::vector<std::string> prepare_argv_vec(
+        std::size_t num_args, std::size_t args_split
+    ) const {
+        std::vector<std::string> argv_vec;
+        argv_vec.reserve(get_argc(num_args, args_split));
+
+        argv_vec.emplace_back("program");
+
+        for (std::size_t i = 0; i < args_split; i++) // positional args
+            argv_vec.emplace_back(prepare_arg_value(i));
+
+        for (std::size_t i = args_split; i < num_args; i++) { // optional args
+            argv_vec.emplace_back(prepare_arg_flag_primary(i));
+            argv_vec.emplace_back(prepare_arg_value(i));
+        }
+
+        return argv_vec;
+    }
+
+    [[nodiscard]] char** prepare_argv(std::size_t num_args, std::size_t args_split) const {
+        return to_char_2d_array(prepare_argv_vec(num_args, args_split));
     }
 
     void free_argv(std::size_t argc, char** argv) const {

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -21,7 +21,7 @@ struct optional_argument_test_fixture {
 
     template <valid_argument_value_type T>
     void sut_set_used(optional_argument<T>& sut) const {
-        return sut.set_used();
+        return sut.mark_used();
     }
 
     template <valid_argument_value_type T>
@@ -37,7 +37,7 @@ struct optional_argument_test_fixture {
     template <valid_argument_value_type T>
     optional_argument<T>& sut_set_value(optional_argument<T>& sut, const std::string& str_value)
         const {
-        sut.set_used();
+        sut.mark_used();
         return sut.set_value(str_value);
     }
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -382,8 +382,8 @@ TEST_CASE_FIXTURE(
 
     for (std::size_t i = 0; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        CHECK_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
-        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error);
+        CHECK_THROWS_AS(sut.value(arg_name.primary), std::logic_error);
+        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), std::logic_error);
     }
 }
 
@@ -417,8 +417,8 @@ TEST_CASE_FIXTURE(
     }
     for (std::size_t i = non_default_args_split; i < non_default_num_args; i++) {
         const auto arg_name = prepare_arg_name(i);
-        CHECK_THROWS_AS(sut.value(arg_name.primary), ap::error::invalid_value_type_error);
-        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), ap::error::invalid_value_type_error);
+        CHECK_THROWS_AS(sut.value(arg_name.primary), std::logic_error);
+        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), std::logic_error);
     }
     for (std::size_t i = non_default_num_args; i < num_args; i++) {
         const auto arg_name = prepare_arg_name(i);

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -126,6 +126,46 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
+    "parse_args should throw when there is less input values than positional arguments"
+) {
+    add_arguments(sut, non_default_num_args, non_default_num_args);
+
+    auto argc = get_argc(non_default_num_args, non_default_num_args);
+    auto argv_vec = prepare_argv_vec(non_default_num_args, non_default_num_args);
+
+    // remove the last positional value
+    --argc;
+    argv_vec.pop_back();
+
+    auto argv = to_char_2d_array(argv_vec);
+
+    CHECK_THROWS_AS(sut.parse_args(argc, argv), ap::error::required_argument_not_parsed_error);
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when there is not enough positional values"
+) {
+    add_arguments(sut, non_default_num_args, non_default_args_split);
+
+    auto argc = get_argc(non_default_num_args, non_default_args_split);
+    auto argv_vec = prepare_argv_vec(non_default_num_args, non_default_args_split);
+
+    // remove the last positional value
+    --argc;
+    argv_vec.erase(std::next(argv_vec.begin(), non_default_args_split - 1ull));
+
+    auto argv = to_char_2d_array(argv_vec);
+
+    CHECK_THROWS_AS(sut.parse_args(argc, argv), ap::error::required_argument_not_parsed_error);
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
     "parse_args should throw when there is no value specified for a required optional argument"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -226,11 +226,12 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    optional_argument_test_fixture,
-    "value() should return default any object if argument's value has not been set"
+    optional_argument_test_fixture, "value() should throw if argument's value has not been set"
 ) {
     auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_get_value(sut).has_value());
+
+    REQUIRE_FALSE(sut_has_value(sut));
+    CHECK_THROWS_AS(static_cast<void>(sut_get_value(sut)), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -131,7 +131,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "nused() should return 0 by de
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
     "is_used() should return the number of times the argument's flag has been used "
-    "[number of set_used() function calls]"
+    "[number of mark_used() function calls]"
 ) {
     auto sut = prepare_argument(primary_name);
 

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -245,13 +245,12 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture,
-    "value() should return default any object if argument's value has not been set"
+    positional_argument_test_fixture, "value() should throw if argument's value has not been set"
 ) {
     auto sut = prepare_argument(primary_name);
 
     REQUIRE_FALSE(sut_has_value(sut));
-    CHECK_THROWS_AS(std::any_cast<test_value_type>(sut_get_value(sut)), std::bad_any_cast);
+    CHECK_THROWS_AS(static_cast<void>(sut_get_value(sut)), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(


### PR DESCRIPTION
In the demo project `numbers_converter` there was a crash:
```
./numbers_converter/run -n 2 10 15 -b
terminate called after throwing an instance of 'ap::error::invalid_value_type_error'
  what():  Invalid value type specified for argument [base,b] - NSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE
Aborted (core dumped)
```

ANALYSIS:
The crash/error is valid, but the error message does not suggest the root cause.

FIX:
Improved the error throwing and handling to provide a more descriptive message.