### PR TITLE
YT-CPPAP-25: Rename the cmd_argument struct to token

### DIFF
--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1542,8 +1542,7 @@ private:
          * @param type Type type of the token (flag or value).
          * @param value The value of the argument.
          */
-        arg_token(const token_type type, const std::string& value)
-        : type(type), value(value) {}
+        arg_token(const token_type type, const std::string& value) : type(type), value(value) {}
 
         ~arg_token() = default;
 
@@ -1698,9 +1697,7 @@ private:
      * @param cmd_args The list of command-line arguments.
      * @param cmd_it Iterator for iterating through command-line arguments.
      */
-    void _parse_optional_args(
-        const arg_token_list& cmd_args, arg_token_list_iterator& cmd_it
-    ) {
+    void _parse_optional_args(const arg_token_list& cmd_args, arg_token_list_iterator& cmd_it) {
         std::optional<std::reference_wrapper<argument_ptr_type>> curr_opt_arg;
 
         while (cmd_it != cmd_args.end()) {

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1548,7 +1548,7 @@ private:
 
         /**
          * @brief Equality operator for comparing arg_token instances.
-         * @param other Another arg_token to compare with.
+         * @param other An arg_token instance to compare with.
          * @return Boolean statement of equality comparison.
          */
         bool operator==(const arg_token& other) const noexcept {

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -100,24 +100,17 @@ struct argument_parser_test_fixture {
         }
     }
 
-    [[nodiscard]] arg_token_list prepare_cmd_arg_list(
-        std::size_t num_args, std::size_t args_split
-    ) const {
+    [[nodiscard]] arg_token_list prepare_cmd_arg_list(std::size_t num_args, std::size_t args_split)
+        const {
         arg_token_list cmd_args;
         cmd_args.reserve(get_args_length(num_args, args_split));
 
         for (std::size_t i = 0; i < args_split; ++i) { // positional args
-            cmd_args.push_back(
-                arg_token{arg_token::token_type::value, prepare_arg_value(i)}
-            );
+            cmd_args.push_back(arg_token{arg_token::token_type::value, prepare_arg_value(i)});
         }
         for (std::size_t i = args_split; i < num_args; ++i) { // optional args
-            cmd_args.push_back(
-                arg_token{arg_token::token_type::flag, prepare_arg_name(i).primary}
-            );
-            cmd_args.push_back(
-                arg_token{arg_token::token_type::value, prepare_arg_value(i)}
-            );
+            cmd_args.push_back(arg_token{arg_token::token_type::flag, prepare_arg_name(i).primary});
+            cmd_args.push_back(arg_token{arg_token::token_type::value, prepare_arg_value(i)});
         }
 
         return cmd_args;

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -100,20 +100,22 @@ struct argument_parser_test_fixture {
         }
     }
 
-    [[nodiscard]] arg_token_list prepare_cmd_arg_list(std::size_t num_args, std::size_t args_split)
-        const {
-        arg_token_list cmd_args;
-        cmd_args.reserve(get_args_length(num_args, args_split));
+    [[nodiscard]] arg_token_list prepare_arg_token_list(
+        std::size_t num_args, std::size_t args_split
+    ) const {
+        arg_token_list arg_tokens;
+        arg_tokens.reserve(get_args_length(num_args, args_split));
 
         for (std::size_t i = 0; i < args_split; ++i) { // positional args
-            cmd_args.push_back(arg_token{arg_token::token_type::value, prepare_arg_value(i)});
+            arg_tokens.push_back(arg_token{arg_token::token_type::value, prepare_arg_value(i)});
         }
         for (std::size_t i = args_split; i < num_args; ++i) { // optional args
-            cmd_args.push_back(arg_token{arg_token::token_type::flag, prepare_arg_name(i).primary});
-            cmd_args.push_back(arg_token{arg_token::token_type::value, prepare_arg_value(i)});
+            arg_tokens.push_back(arg_token{arg_token::token_type::flag, prepare_arg_name(i).primary}
+            );
+            arg_tokens.push_back(arg_token{arg_token::token_type::value, prepare_arg_value(i)});
         }
 
-        return cmd_args;
+        return arg_tokens;
     }
 
     // argument_parser private function accessors
@@ -129,8 +131,8 @@ struct argument_parser_test_fixture {
         return sut._tokenize(argc, argv);
     }
 
-    void sut_parse_args_impl(const arg_token_list& cmd_args) {
-        sut._parse_args_impl(cmd_args);
+    void sut_parse_args_impl(const arg_token_list& arg_tokens) {
+        sut._parse_args_impl(arg_tokens);
     }
 
     [[nodiscard]] argument_opt_type sut_get_argument(std::string_view arg_name) const {

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -125,8 +125,8 @@ struct argument_parser_test_fixture {
         return sut._program_description;
     }
 
-    [[nodiscard]] arg_token_list sut_process_input(int argc, char* argv[]) const {
-        return sut._preprocess_input(argc, argv);
+    [[nodiscard]] arg_token_list sut_tokenize(int argc, char* argv[]) const {
+        return sut._tokenize(argc, argv);
     }
 
     void sut_parse_args_impl(const arg_token_list& cmd_args) {

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -14,8 +14,8 @@ struct argument_parser_test_fixture {
     argument_parser_test_fixture() = default;
     ~argument_parser_test_fixture() = default;
 
-    using cmd_argument = ap::argument_parser::cmd_argument;
-    using cmd_argument_list = ap::argument_parser::cmd_argument_list;
+    using arg_token = ap::argument_parser::arg_token;
+    using arg_token_list = ap::argument_parser::arg_token_list;
     using argument_list_type = ap::argument_parser::argument_list_type;
     using argument_opt_type = ap::argument_parser::argument_opt_type;
 
@@ -100,23 +100,23 @@ struct argument_parser_test_fixture {
         }
     }
 
-    [[nodiscard]] cmd_argument_list prepare_cmd_arg_list(
+    [[nodiscard]] arg_token_list prepare_cmd_arg_list(
         std::size_t num_args, std::size_t args_split
     ) const {
-        cmd_argument_list cmd_args;
+        arg_token_list cmd_args;
         cmd_args.reserve(get_args_length(num_args, args_split));
 
         for (std::size_t i = 0; i < args_split; ++i) { // positional args
             cmd_args.push_back(
-                cmd_argument{cmd_argument::type_discriminator::value, prepare_arg_value(i)}
+                arg_token{arg_token::token_type::value, prepare_arg_value(i)}
             );
         }
         for (std::size_t i = args_split; i < num_args; ++i) { // optional args
             cmd_args.push_back(
-                cmd_argument{cmd_argument::type_discriminator::flag, prepare_arg_name(i).primary}
+                arg_token{arg_token::token_type::flag, prepare_arg_name(i).primary}
             );
             cmd_args.push_back(
-                cmd_argument{cmd_argument::type_discriminator::value, prepare_arg_value(i)}
+                arg_token{arg_token::token_type::value, prepare_arg_value(i)}
             );
         }
 
@@ -132,11 +132,11 @@ struct argument_parser_test_fixture {
         return sut._program_description;
     }
 
-    [[nodiscard]] cmd_argument_list sut_process_input(int argc, char* argv[]) const {
+    [[nodiscard]] arg_token_list sut_process_input(int argc, char* argv[]) const {
         return sut._preprocess_input(argc, argv);
     }
 
-    void sut_parse_args_impl(const cmd_argument_list& cmd_args) {
+    void sut_parse_args_impl(const arg_token_list& cmd_args) {
         sut._parse_args_impl(cmd_args);
     }
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -55,16 +55,16 @@ TEST_CASE_FIXTURE(
     REQUIRE_EQ(cmd_args.size(), get_args_length(non_default_num_args, non_default_args_split));
 
     for (std::size_t i = 0; i < non_default_args_split; ++i) { // positional args
-        REQUIRE_EQ(cmd_args.at(i).discriminator, cmd_argument::type_discriminator::value);
+        REQUIRE_EQ(cmd_args.at(i).type, arg_token::token_type::value);
         CHECK_EQ(cmd_args.at(i).value, prepare_arg_value(i));
     }
 
     std::size_t opt_arg_idx = non_default_args_split;
     for (std::size_t i = non_default_args_split; i < cmd_args.size(); i += 2) { // optional args
-        REQUIRE_EQ(cmd_args.at(i).discriminator, cmd_argument::type_discriminator::flag);
+        REQUIRE_EQ(cmd_args.at(i).type, arg_token::token_type::flag);
         CHECK(prepare_arg_name(opt_arg_idx).match(cmd_args.at(i).value));
 
-        REQUIRE_EQ(cmd_args.at(i + 1).discriminator, cmd_argument::type_discriminator::value);
+        REQUIRE_EQ(cmd_args.at(i + 1).type, arg_token::token_type::value);
         CHECK_EQ(cmd_args.at(i + 1).value, prepare_arg_value(opt_arg_idx));
 
         ++opt_arg_idx;

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -26,16 +26,16 @@ struct test_argument_parser_parse_args : public argument_parser_test_fixture {
     const std::string optional_secondary_name = "oa";
 };
 
-// _preprocess_input
+// _tokenize
 
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
-    "_preprocess_input should return an empty vector for no command-line arguments"
+    "_tokenize should return an empty vector for no command-line arguments"
 ) {
     const auto argc = get_argc(default_num_args, default_num_args);
     auto argv = prepare_argv(default_num_args, default_num_args);
 
-    const auto args = sut_process_input(argc, argv);
+    const auto args = sut_tokenize(argc, argv);
 
     CHECK(args.empty());
 
@@ -43,14 +43,14 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args, "_preprocess_input should return a vector of correct arguments"
+    test_argument_parser_parse_args, "_tokenize should return a vector of correct arguments"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
     const auto argc = get_argc(non_default_num_args, non_default_args_split);
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
-    const auto cmd_args = sut_process_input(argc, argv);
+    const auto cmd_args = sut_tokenize(argc, argv);
 
     REQUIRE_EQ(cmd_args.size(), get_args_length(non_default_num_args, non_default_args_split));
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -50,22 +50,22 @@ TEST_CASE_FIXTURE(
     const auto argc = get_argc(non_default_num_args, non_default_args_split);
     auto argv = prepare_argv(non_default_num_args, non_default_args_split);
 
-    const auto cmd_args = sut_tokenize(argc, argv);
+    const auto arg_tokens = sut_tokenize(argc, argv);
 
-    REQUIRE_EQ(cmd_args.size(), get_args_length(non_default_num_args, non_default_args_split));
+    REQUIRE_EQ(arg_tokens.size(), get_args_length(non_default_num_args, non_default_args_split));
 
     for (std::size_t i = 0; i < non_default_args_split; ++i) { // positional args
-        REQUIRE_EQ(cmd_args.at(i).type, arg_token::token_type::value);
-        CHECK_EQ(cmd_args.at(i).value, prepare_arg_value(i));
+        REQUIRE_EQ(arg_tokens.at(i).type, arg_token::token_type::value);
+        CHECK_EQ(arg_tokens.at(i).value, prepare_arg_value(i));
     }
 
     std::size_t opt_arg_idx = non_default_args_split;
-    for (std::size_t i = non_default_args_split; i < cmd_args.size(); i += 2) { // optional args
-        REQUIRE_EQ(cmd_args.at(i).type, arg_token::token_type::flag);
-        CHECK(prepare_arg_name(opt_arg_idx).match(cmd_args.at(i).value));
+    for (std::size_t i = non_default_args_split; i < arg_tokens.size(); i += 2) { // optional args
+        REQUIRE_EQ(arg_tokens.at(i).type, arg_token::token_type::flag);
+        CHECK(prepare_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
 
-        REQUIRE_EQ(cmd_args.at(i + 1).type, arg_token::token_type::value);
-        CHECK_EQ(cmd_args.at(i + 1).value, prepare_arg_value(opt_arg_idx));
+        REQUIRE_EQ(arg_tokens.at(i + 1).type, arg_token::token_type::value);
+        CHECK_EQ(arg_tokens.at(i + 1).value, prepare_arg_value(opt_arg_idx));
 
         ++opt_arg_idx;
     }
@@ -82,10 +82,10 @@ TEST_CASE_FIXTURE(
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
 
-    auto cmd_args = prepare_cmd_arg_list(non_default_num_args, non_default_args_split);
-    cmd_args.erase(std::next(cmd_args.begin(), non_default_args_split));
+    auto arg_tokens = prepare_arg_token_list(non_default_num_args, non_default_args_split);
+    arg_tokens.erase(std::next(arg_tokens.begin(), non_default_args_split));
 
-    CHECK_THROWS_AS(sut_parse_args_impl(cmd_args), ap::error::free_value_error);
+    CHECK_THROWS_AS(sut_parse_args_impl(arg_tokens), ap::error::free_value_error);
 }
 
 TEST_CASE_FIXTURE(
@@ -93,8 +93,8 @@ TEST_CASE_FIXTURE(
     "_parse_args_impl should not throw when the arguments are correct"
 ) {
     add_arguments(sut, non_default_num_args, non_default_args_split);
-    const auto cmd_args = prepare_cmd_arg_list(non_default_num_args, non_default_args_split);
-    CHECK_NOTHROW(sut_parse_args_impl(cmd_args));
+    const auto arg_tokens = prepare_arg_token_list(non_default_num_args, non_default_args_split);
+    CHECK_NOTHROW(sut_parse_args_impl(arg_tokens));
 }
 
 // _get_argument


### PR DESCRIPTION
Changed the name of the `argument_parser::cmd_argument` struct to `arg_token` and aligned related elements