### PR TITLE
YT-CPPAP-27: Clean up the unit tests

### DIFF
--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -250,7 +250,7 @@ private:
         if (this->_values.empty() and this->_has_predefined_value())
             return std::weak_ordering::equivalent;
 
-        return this->_nargs_range->contains(this->_values.size());
+        return this->_nargs_range->ordering(this->_values.size());
     }
 
     /// @return Reference to the stored value of the optional argument.

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -294,6 +294,7 @@ private:
      * @return True if choice is valid, false otherwise.
      */
     [[nodiscard]] bool _is_valid_choice(const value_type& choice) const noexcept {
+        // TODO: replace with `std::ranges::contains` after transition to C++23
         return this->_choices.empty()
             or std::ranges::find(this->_choices, choice) != this->_choices.end();
     }

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -200,6 +200,7 @@ private:
      * @return True if the choice valid, false otherwise.
      */
     [[nodiscard]] bool _is_valid_choice(const value_type& choice) const noexcept {
+        // TODO: replace with `std::ranges::contains` after transition to C++23
         return this->_choices.empty()
             or std::ranges::find(this->_choices, choice) != this->_choices.end();
     }

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -124,7 +124,7 @@ private:
 
     /**
      * @brief Mark the positional argument as used.
-     * @note Not required for positional arguments.
+     * @note No logic is performed for positional arguments
      */
     void mark_used() noexcept override {}
 

--- a/include/ap/detail/argument_name.hpp
+++ b/include/ap/detail/argument_name.hpp
@@ -10,15 +10,15 @@
 
 namespace ap::detail {
 
-/// @brief Structure holding the argument name.
+/// @brief Structure holding the argument's name.
 struct argument_name {
     argument_name() = delete;
 
-    argument_name(const argument_name&) = default;
-    argument_name(argument_name&&) = default;
-
     argument_name& operator=(const argument_name&) = delete;
     argument_name& operator=(argument_name&&) = delete;
+
+    argument_name(const argument_name&) = default;
+    argument_name(argument_name&&) = default;
 
     /**
      * @brief Primary name constructor.

--- a/include/ap/nargs/range.hpp
+++ b/include/ap/nargs/range.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <iostream>
 #include <optional>
 
 namespace ap::nargs {
@@ -38,11 +39,19 @@ public:
     ~range() = default;
 
     /**
-     * @brief Checks if a given value count is within the range.
-     * @param n The value count to check.
+     * @brief Determines the ordering of the count against a range instance.
+     *
+     * For a `[low, high]` range and the count `n` the returned value is:
+     * - `less` if `n < low`,
+     * - `equivalent` if `n >= low` and `n <= high`,
+     * - `greater` if `n > high`.
+     * If either `low` or `high` limits are not set (std::nullopt),
+     * then the corresponding conditions are dropped.
+     *
+     * @param n The value count to order.
      * @return Ordering relationship between the count and the range.
      */
-    [[nodiscard]] std::weak_ordering contains(const range::count_type n) const noexcept {
+    [[nodiscard]] std::weak_ordering ordering(const range::count_type n) const noexcept {
         if (not (this->_nlow.has_value() or this->_nhigh.has_value()))
             return std::weak_ordering::equivalent;
 

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -32,10 +32,13 @@ struct optional_argument_test_fixture {
         return arg.nused();
     }
 
-    // TODO: const T& instead of const std::string&
+    template <c_argument_value_type T>
+    optional<T>& set_value(optional<T>& arg, const T& value) const {
+        return arg.set_value(std::to_string(value));
+    }
+
     template <c_argument_value_type T>
     optional<T>& set_value(optional<T>& arg, const std::string& str_value) const {
-        arg.mark_used();
         return arg.set_value(str_value);
     }
 

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -18,70 +18,70 @@ struct optional_argument_test_fixture {
     using value_type = typename optional<T>::value_type;
 
     template <c_argument_value_type T>
-    void sut_set_used(optional<T>& sut) const {
-        return sut.mark_used();
+    void mark_used(optional<T>& arg) const {
+        return arg.mark_used();
     }
 
     template <c_argument_value_type T>
-    bool sut_is_used(const optional<T>& sut) const {
-        return sut.is_used();
+    bool is_used(const optional<T>& arg) const {
+        return arg.is_used();
     }
 
     template <c_argument_value_type T>
-    std::size_t sut_get_nused(const optional<T>& sut) const {
-        return sut.nused();
+    std::size_t get_nused(const optional<T>& arg) const {
+        return arg.nused();
+    }
+
+    // TODO: const T& instead of const std::string&
+    template <c_argument_value_type T>
+    optional<T>& set_value(optional<T>& arg, const std::string& str_value) const {
+        arg.mark_used();
+        return arg.set_value(str_value);
     }
 
     template <c_argument_value_type T>
-    optional<T>& sut_set_value(optional<T>& sut, const std::string& str_value) const {
-        sut.mark_used();
-        return sut.set_value(str_value);
+    optional<T>& set_choices(optional<T>& arg, const std::vector<value_type<T>>& choices) const {
+        return arg.choices(choices);
     }
 
     template <c_argument_value_type T>
-    optional<T>& sut_set_choices(optional<T>& sut, const std::vector<value_type<T>>& choices)
-        const {
-        return sut.choices(choices);
+    [[nodiscard]] bool has_value(const optional<T>& arg) const {
+        return arg.has_value();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_has_value(const optional<T>& sut) const {
-        return sut.has_value();
+    [[nodiscard]] bool has_parsed_values(const optional<T>& arg) const {
+        return arg.has_parsed_values();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_has_parsed_values(const optional<T>& sut) const {
-        return sut.has_parsed_values();
+    [[nodiscard]] std::weak_ordering nvalues_in_range(const optional<T>& arg) const {
+        return arg.nvalues_in_range();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::weak_ordering sut_nvalues_in_range(const optional<T>& sut) const {
-        return sut.nvalues_in_range();
+    [[nodiscard]] const std::any& get_value(const optional<T>& arg) const {
+        return arg.value();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const std::any& sut_get_value(const optional<T>& sut) const {
-        return sut.value();
+    [[nodiscard]] const std::vector<std::any>& get_values(const optional<T>& arg) const {
+        return arg.values();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const std::vector<std::any>& sut_get_values(const optional<T>& sut) const {
-        return sut.values();
+    [[nodiscard]] const argument_name& get_name(const optional<T>& arg) const {
+        return arg.name();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const argument_name& sut_get_name(const optional<T>& sut) const {
-        return sut.name();
+    [[nodiscard]] bool is_required(const optional<T>& arg) const {
+        return arg.is_required();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_is_required(const optional<T>& sut) const {
-        return sut.is_required();
-    }
-
-    template <c_argument_value_type T>
-    [[nodiscard]] const std::optional<std::string>& sut_get_help(const optional<T>& sut) const {
-        return sut.help();
+    [[nodiscard]] const std::optional<std::string>& get_help(const optional<T>& arg) const {
+        return arg.help();
     }
 };
 

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -52,6 +52,7 @@ struct positional_argument_test_fixture {
         return arg.has_parsed_values();
     }
 
+    // TODO: const T& instead of const std::string&
     template <c_argument_value_type T>
     positional<T>& set_value(positional<T>& arg, const std::string& str_value) const {
         return arg.set_value(str_value);

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -18,64 +18,64 @@ struct positional_argument_test_fixture {
     using value_type = typename positional<T>::value_type;
 
     template <c_argument_value_type T>
-    [[nodiscard]] const argument_name& get_name(const positional<T>& sut) const {
-        return sut.name();
+    [[nodiscard]] const argument_name& get_name(const positional<T>& arg) const {
+        return arg.name();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool is_required(const positional<T>& sut) const {
-        return sut.is_required();
+    [[nodiscard]] bool is_required(const positional<T>& arg) const {
+        return arg.is_required();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const std::optional<std::string>& get_help(const positional<T>& sut) const {
-        return sut.help();
+    [[nodiscard]] const std::optional<std::string>& get_help(const positional<T>& arg) const {
+        return arg.help();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool is_used(const positional<T>& sut) const {
-        return sut.is_used();
+    [[nodiscard]] bool is_used(const positional<T>& arg) const {
+        return arg.is_used();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::size_t get_nused(const positional<T>& sut) const {
-        return sut.nused();
+    [[nodiscard]] std::size_t get_nused(const positional<T>& arg) const {
+        return arg.nused();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool has_value(const positional<T>& sut) const {
-        return sut.has_value();
+    [[nodiscard]] bool has_value(const positional<T>& arg) const {
+        return arg.has_value();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool has_parsed_values(const positional<T>& sut) const {
-        return sut.has_parsed_values();
+    [[nodiscard]] bool has_parsed_values(const positional<T>& arg) const {
+        return arg.has_parsed_values();
     }
 
     template <c_argument_value_type T>
-    positional<T>& set_value(positional<T>& sut, const std::string& str_value) const {
-        return sut.set_value(str_value);
+    positional<T>& set_value(positional<T>& arg, const std::string& str_value) const {
+        return arg.set_value(str_value);
     }
 
     template <c_argument_value_type T>
-    positional<T>& set_choices(positional<T>& sut, const std::vector<value_type<T>>& choices)
+    positional<T>& set_choices(positional<T>& arg, const std::vector<value_type<T>>& choices)
         const {
-        return sut.choices(choices);
+        return arg.choices(choices);
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::weak_ordering nvalues_in_range(const positional<T>& sut) const {
-        return sut.nvalues_in_range();
+    [[nodiscard]] std::weak_ordering nvalues_in_range(const positional<T>& arg) const {
+        return arg.nvalues_in_range();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const std::any& get_value(const positional<T>& sut) const {
-        return sut.value();
+    [[nodiscard]] const std::any& get_value(const positional<T>& arg) const {
+        return arg.value();
     }
 
     template <c_argument_value_type T>
-    const std::vector<std::any>& get_values(const positional<T>& sut) const {
-        return sut.values();
+    const std::vector<std::any>& get_values(const positional<T>& arg) const {
+        return arg.values();
     }
 };
 

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -18,63 +18,63 @@ struct positional_argument_test_fixture {
     using value_type = typename positional<T>::value_type;
 
     template <c_argument_value_type T>
-    [[nodiscard]] const argument_name& sut_get_name(const positional<T>& sut) const {
+    [[nodiscard]] const argument_name& get_name(const positional<T>& sut) const {
         return sut.name();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_is_required(const positional<T>& sut) const {
+    [[nodiscard]] bool is_required(const positional<T>& sut) const {
         return sut.is_required();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const std::optional<std::string>& sut_get_help(const positional<T>& sut) const {
+    [[nodiscard]] const std::optional<std::string>& get_help(const positional<T>& sut) const {
         return sut.help();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_is_used(const positional<T>& sut) const {
+    [[nodiscard]] bool is_used(const positional<T>& sut) const {
         return sut.is_used();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::size_t sut_get_nused(const positional<T>& sut) const {
+    [[nodiscard]] std::size_t get_nused(const positional<T>& sut) const {
         return sut.nused();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_has_value(const positional<T>& sut) const {
+    [[nodiscard]] bool has_value(const positional<T>& sut) const {
         return sut.has_value();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] bool sut_has_parsed_values(const positional<T>& sut) const {
+    [[nodiscard]] bool has_parsed_values(const positional<T>& sut) const {
         return sut.has_parsed_values();
     }
 
     template <c_argument_value_type T>
-    positional<T>& sut_set_value(positional<T>& sut, const std::string& str_value) const {
+    positional<T>& set_value(positional<T>& sut, const std::string& str_value) const {
         return sut.set_value(str_value);
     }
 
     template <c_argument_value_type T>
-    positional<T>& sut_set_choices(positional<T>& sut, const std::vector<value_type<T>>& choices)
+    positional<T>& set_choices(positional<T>& sut, const std::vector<value_type<T>>& choices)
         const {
         return sut.choices(choices);
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::weak_ordering sut_nvalues_in_range(const positional<T>& sut) const {
+    [[nodiscard]] std::weak_ordering nvalues_in_range(const positional<T>& sut) const {
         return sut.nvalues_in_range();
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] const std::any& sut_get_value(const positional<T>& sut) const {
+    [[nodiscard]] const std::any& get_value(const positional<T>& sut) const {
         return sut.value();
     }
 
     template <c_argument_value_type T>
-    const std::vector<std::any>& sut_get_values(const positional<T>& sut) const {
+    const std::vector<std::any>& get_values(const positional<T>& sut) const {
         return sut.values();
     }
 };

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -52,7 +52,11 @@ struct positional_argument_test_fixture {
         return arg.has_parsed_values();
     }
 
-    // TODO: const T& instead of const std::string&
+    template <c_argument_value_type T>
+    positional<T>& set_value(positional<T>& arg, const T& value) const {
+        return arg.set_value(std::to_string(value));
+    }
+
     template <c_argument_value_type T>
     positional<T>& set_value(positional<T>& arg, const std::string& str_value) const {
         return arg.set_value(str_value);

--- a/tests/source/test_argument_name.cpp
+++ b/tests/source/test_argument_name.cpp
@@ -8,143 +8,117 @@
 
 using namespace ap::detail;
 
+namespace {
+
+constexpr std::string_view primary_1 = "primary_1";
+constexpr std::string_view secondary_1 = "s1";
+
+const argument_name arg_name_primary_1{primary_1};
+const argument_name arg_name_full_1{primary_1, secondary_1};
+
+constexpr std::string_view primary_2 = "primary_2";
+constexpr std::string_view secondary_2 = "s2";
+
+const argument_name arg_name_primary_2{primary_2};
+const argument_name arg_name_full_2{primary_2, secondary_2};
+
+} // namespace
+
 TEST_SUITE_BEGIN("test_argument_name");
 
-struct test_argument_name {
-    const std::string_view primary_name_1 = "primary_name_1";
-    const std::string_view secondary_name_1 = "s1";
-
-    const argument_name arg_name_primary_1{primary_name_1};
-    const argument_name arg_name_full_1{primary_name_1, secondary_name_1};
-
-    const std::string_view primary_name_2 = "primary_name_2";
-    const std::string_view secondary_name_2 = "s2";
-
-    const argument_name arg_name_primary_2{primary_name_2};
-    const argument_name arg_name_full_2{primary_name_2, secondary_name_2};
-};
-
-TEST_CASE_FIXTURE(
-    test_argument_name, "argument_name.primary member should be correctly initialized"
-) {
-    CHECK_EQ(arg_name_primary_1.primary, primary_name_1);
-    CHECK_EQ(arg_name_primary_2.primary, primary_name_2);
+TEST_CASE("argument_name.primary member should be correctly initialized") {
+    CHECK_EQ(arg_name_primary_1.primary, primary_1);
+    CHECK_EQ(arg_name_primary_2.primary, primary_2);
 }
 
-TEST_CASE_FIXTURE(test_argument_name, "argument_name members should be correctly initialized") {
-    REQUIRE_EQ(arg_name_full_1.primary, primary_name_1);
+TEST_CASE("argument_name members should be correctly initialized") {
+    REQUIRE_EQ(arg_name_full_1.primary, primary_1);
 
     REQUIRE(arg_name_full_1.secondary);
-    CHECK_EQ(arg_name_full_1.secondary.value(), secondary_name_1);
+    CHECK_EQ(arg_name_full_1.secondary.value(), secondary_1);
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "operator==(argument_name) should return false if only one argument has both primary and "
-    "secondary values"
-) {
+TEST_CASE("operator==(argument_name) should return false if only one argument has both primary and "
+          "secondary values") {
     CHECK_NE(arg_name_primary_1, arg_name_full_1);
     CHECK_NE(arg_name_full_1, arg_name_primary_1);
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "operator==(argument_name) should return false if primary names are not equal"
-) {
+TEST_CASE("operator==(argument_name) should return false if primary names are not equal") {
     CHECK_NE(arg_name_primary_1, arg_name_primary_2);
     CHECK_NE(arg_name_full_1, arg_name_full_2);
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "operator==(argument_name) should return false if secondary names are not equal"
-) {
-    CHECK_NE(arg_name_full_1, argument_name{primary_name_1, secondary_name_2});
-    CHECK_NE(argument_name{primary_name_1, secondary_name_2}, arg_name_full_1);
+TEST_CASE("operator==(argument_name) should return false if secondary names are not equal") {
+    CHECK_NE(arg_name_full_1, argument_name{primary_1, secondary_2});
+    CHECK_NE(argument_name{primary_1, secondary_2}, arg_name_full_1);
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "operator==(argument_name) should return true if primary names are equal and both secondary "
-    "names are null"
-) {
+TEST_CASE("operator==(argument_name) should return true if primary names are equal and both "
+          "secondary names are null") {
     CHECK_EQ(arg_name_primary_1, arg_name_primary_1);
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "operator==(argument_name) should return true if both primary and secondary names are equal"
-) {
+TEST_CASE("operator==(argument_name) should return true if both primary and secondary names are "
+          "equal") {
     CHECK_EQ(arg_name_full_1, arg_name_full_1);
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "match(string_view) should return true if the given string matches at least one name"
-) {
+TEST_CASE("match(string_view) should return true if the given string matches at least one name") {
     SUBCASE("argument_name with primary name only") {
-        CHECK(arg_name_primary_1.match(primary_name_1));
+        CHECK(arg_name_primary_1.match(primary_1));
     }
 
     SUBCASE("argument_name with both names") {
-        CHECK(arg_name_full_1.match(primary_name_1));
-        CHECK(arg_name_full_1.match(secondary_name_1));
+        CHECK(arg_name_full_1.match(primary_1));
+        CHECK(arg_name_full_1.match(secondary_1));
     }
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "match(string_view) should return false if the given string dosn't match any name"
-) {
+TEST_CASE("match(string_view) should return false if the given string dosn't match any name") {
     SUBCASE("argument_name with primary name only") {
-        CHECK_FALSE(arg_name_primary_1.match(primary_name_2));
-        CHECK_FALSE(arg_name_primary_1.match(secondary_name_2));
+        CHECK_FALSE(arg_name_primary_1.match(primary_2));
+        CHECK_FALSE(arg_name_primary_1.match(secondary_2));
     }
 
     SUBCASE("argument_name with both names") {
-        CHECK_FALSE(arg_name_full_1.match(primary_name_2));
-        CHECK_FALSE(arg_name_full_1.match(secondary_name_2));
+        CHECK_FALSE(arg_name_full_1.match(primary_2));
+        CHECK_FALSE(arg_name_full_1.match(secondary_2));
     }
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "match(argument_name) should return true if either the primary or the secondary name of the "
-    "passed argument_name matches at least one name"
-) {
+TEST_CASE("match(argument_name) should return true if either the primary or the secondary name of "
+          "the passed argument_name matches at least one name") {
     SUBCASE("argument_name with primary name only") {
         CHECK(arg_name_primary_1.match(arg_name_primary_1));
-        CHECK(arg_name_primary_1.match(argument_name{primary_name_2, primary_name_1}));
+        CHECK(arg_name_primary_1.match(argument_name{primary_2, primary_1}));
     }
 
     SUBCASE("argument_name with both names") {
-        CHECK(arg_name_full_1.match(argument_name{primary_name_1, secondary_name_2}));
-        CHECK(arg_name_full_1.match(argument_name{secondary_name_1, primary_name_1}));
-        CHECK(arg_name_full_1.match(argument_name{primary_name_2, primary_name_1}));
-        CHECK(arg_name_full_1.match(argument_name{primary_name_2, secondary_name_1}));
+        CHECK(arg_name_full_1.match(argument_name{primary_1, secondary_2}));
+        CHECK(arg_name_full_1.match(argument_name{secondary_1, primary_1}));
+        CHECK(arg_name_full_1.match(argument_name{primary_2, primary_1}));
+        CHECK(arg_name_full_1.match(argument_name{primary_2, secondary_1}));
     }
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_name,
-    "match(argument_name) should return false if neither the primary nor the secondary name of the "
-    "passed argument_name matches at least one name"
-) {
+TEST_CASE("match(argument_name) should return false if neither the primary nor the secondary name "
+          "of the passed argument_name matches at least one name") {
     CHECK_FALSE(arg_name_primary_1.match(arg_name_full_2));
     CHECK_FALSE(arg_name_full_1.match(arg_name_full_2));
 }
 
-TEST_CASE_FIXTURE(test_argument_name, "operator<< should push correct data to the output stream") {
+TEST_CASE("operator<< should push correct data to the output stream") {
     std::stringstream ss, expected_ss;
 
     SUBCASE("argument_name with primary name only") {
         ss << arg_name_primary_1;
-        expected_ss << "[" << primary_name_1 << "]";
+        expected_ss << "[" << primary_1 << "]";
     }
 
     SUBCASE("argument_name with both names") {
         ss << arg_name_full_1;
-        expected_ss << "[" << primary_name_1 << "," << secondary_name_1 << "]";
+        expected_ss << "[" << primary_1 << "," << secondary_1 << "]";
     }
 
     CAPTURE(ss);

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -153,7 +153,7 @@ TEST_CASE_FIXTURE(
         REQUIRE(argument.is_optional());
         CHECK_FALSE(sut.value<bool>(primary_name_1));
 
-        opt_arg_fixture.sut_set_used(argument);
+        opt_arg_fixture.mark_used(argument);
         CHECK(sut.value<bool>(primary_name_1));
     }
 
@@ -163,7 +163,7 @@ TEST_CASE_FIXTURE(
         REQUIRE(argument.is_optional());
         CHECK(sut.value<bool>(primary_name_1));
 
-        opt_arg_fixture.sut_set_used(argument);
+        opt_arg_fixture.mark_used(argument);
         CHECK_FALSE(sut.value<bool>(primary_name_1));
     }
 }

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -23,11 +23,11 @@ TEST_CASE_FIXTURE(
 ) {
     sut.default_positional_arguments({default_positional::input, default_positional::output});
 
-    const auto input_arg = sut_get_argument("input");
+    const auto input_arg = get_argument("input");
     REQUIRE(input_arg);
     REQUIRE_FALSE(input_arg->get().is_optional());
 
-    const auto output_arg = sut_get_argument("output");
+    const auto output_arg = get_argument("output");
     REQUIRE(output_arg);
     REQUIRE_FALSE(output_arg->get().is_optional());
 }
@@ -60,15 +60,15 @@ TEST_CASE_FIXTURE(
     CAPTURE(input_flag);
     CAPTURE(output_flag);
 
-    const auto help_arg = sut_get_argument(help_flag);
+    const auto help_arg = get_argument(help_flag);
     REQUIRE(help_arg);
     CHECK(help_arg->get().is_optional());
 
-    const auto input_arg = sut_get_argument(input_flag);
+    const auto input_arg = get_argument(input_flag);
     REQUIRE(input_arg);
     CHECK(input_arg->get().is_optional());
 
-    const auto output_arg = sut_get_argument(output_flag);
+    const auto output_arg = get_argument(output_flag);
     REQUIRE(output_arg);
     CHECK(output_arg->get().is_optional());
 }

--- a/tests/source/test_argument_parser_info.cpp
+++ b/tests/source/test_argument_parser_info.cpp
@@ -15,14 +15,14 @@ struct test_argument_parser_info : public argument_parser_test_fixture {
 TEST_CASE_FIXTURE(
     test_argument_parser_info, "parser's program name member should be nullopt by default"
 ) {
-    const auto stored_program_name = sut_get_program_name();
+    const auto stored_program_name = get_program_name();
     CHECK_FALSE(stored_program_name);
 }
 
 TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name member") {
     sut.program_name(test_name);
 
-    const auto stored_program_name = sut_get_program_name();
+    const auto stored_program_name = get_program_name();
 
     REQUIRE(stored_program_name);
     CHECK_EQ(stored_program_name.value(), test_name);
@@ -31,14 +31,14 @@ TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name
 TEST_CASE_FIXTURE(
     test_argument_parser_info, "parser's program description member should be nullopt by default"
 ) {
-    const auto stored_program_description = sut_get_program_description();
+    const auto stored_program_description = get_program_description();
     CHECK_FALSE(stored_program_description);
 }
 
 TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name member") {
     sut.program_description(test_description);
 
-    const auto stored_program_description = sut_get_program_description();
+    const auto stored_program_description = get_program_description();
 
     REQUIRE(stored_program_description);
     CHECK_EQ(stored_program_description.value(), test_description);

--- a/tests/source/test_nargs_range.cpp
+++ b/tests/source/test_nargs_range.cpp
@@ -10,10 +10,10 @@ using namespace ap::nargs;
 
 namespace {
 
-constexpr range::count_type ndefault = 1;
-constexpr range::count_type nlow = 3;
-constexpr range::count_type nhigh = 9;
-constexpr range::count_type nmid = (nlow + nhigh) / 2;
+constexpr range::count_type ndefault = 1ull;
+constexpr range::count_type nlow = 3ull;
+constexpr range::count_type nhigh = 9ull;
+constexpr range::count_type nmid = (nlow + nhigh) / 2ull;
 
 constexpr range::count_type nmin = std::numeric_limits<range::count_type>::min();
 constexpr range::count_type nmax = std::numeric_limits<range::count_type>::max();
@@ -22,34 +22,34 @@ constexpr range::count_type nmax = std::numeric_limits<range::count_type>::max()
 
 TEST_SUITE_BEGIN("test_nargs_range");
 
-TEST_CASE("in_range should return true for default range only when n is 1") {
+TEST_CASE("ordering should return true for default range only when n is 1") {
     const auto sut = range();
 
-    REQUIRE(std::is_eq(sut.contains(ndefault)));
+    REQUIRE(std::is_eq(sut.ordering(ndefault)));
 
-    REQUIRE(std::is_lt(sut.contains(ndefault - 1)));
-    REQUIRE(std::is_gt(sut.contains(ndefault + 1)));
+    REQUIRE(std::is_lt(sut.ordering(ndefault - 1)));
+    REQUIRE(std::is_gt(sut.ordering(ndefault + 1)));
 }
 
-TEST_CASE("in_range should return true if n is in range") {
+TEST_CASE("ordering should return true if n is in range") {
     SUBCASE("range is [n]") {
         const auto sut = range(nmid);
 
-        REQUIRE(std::is_eq(sut.contains(nmid)));
+        REQUIRE(std::is_eq(sut.ordering(nmid)));
 
-        REQUIRE(std::is_lt(sut.contains(nmid - 1)));
-        REQUIRE(std::is_gt(sut.contains(nmid + 1)));
+        REQUIRE(std::is_lt(sut.ordering(nmid - 1)));
+        REQUIRE(std::is_gt(sut.ordering(nmid + 1)));
     }
 
     SUBCASE("range is [low, high]") {
         const auto sut = range(nlow, nhigh);
 
-        REQUIRE(std::is_eq(sut.contains(nlow)));
-        REQUIRE(std::is_eq(sut.contains(nhigh)));
-        REQUIRE(std::is_eq(sut.contains(nmid)));
+        REQUIRE(std::is_eq(sut.ordering(nlow)));
+        REQUIRE(std::is_eq(sut.ordering(nhigh)));
+        REQUIRE(std::is_eq(sut.ordering(nmid)));
 
-        REQUIRE(std::is_lt(sut.contains(nlow - 1)));
-        REQUIRE(std::is_gt(sut.contains(nhigh + 1)));
+        REQUIRE(std::is_lt(sut.ordering(nlow - 1)));
+        REQUIRE(std::is_gt(sut.ordering(nhigh + 1)));
     }
 }
 
@@ -57,56 +57,56 @@ TEST_CASE("range builders should return correct range objects") {
     SUBCASE("at_least") {
         const auto sut = at_least(nlow);
 
-        REQUIRE(std::is_eq(sut.contains(nlow)));
-        REQUIRE(std::is_eq(sut.contains(nhigh)));
-        REQUIRE(std::is_eq(sut.contains(nmax)));
+        REQUIRE(std::is_eq(sut.ordering(nlow)));
+        REQUIRE(std::is_eq(sut.ordering(nhigh)));
+        REQUIRE(std::is_eq(sut.ordering(nmax)));
 
-        REQUIRE(std::is_lt(sut.contains(nlow - 1)));
-        REQUIRE(std::is_lt(sut.contains(nmin)));
+        REQUIRE(std::is_lt(sut.ordering(nlow - 1)));
+        REQUIRE(std::is_lt(sut.ordering(nmin)));
     }
 
     SUBCASE("more_than") {
         const auto sut = more_than(nlow);
 
-        REQUIRE(std::is_eq(sut.contains(nlow + 1)));
-        REQUIRE(std::is_eq(sut.contains(nhigh)));
-        REQUIRE(std::is_eq(sut.contains(nmax)));
+        REQUIRE(std::is_eq(sut.ordering(nlow + 1)));
+        REQUIRE(std::is_eq(sut.ordering(nhigh)));
+        REQUIRE(std::is_eq(sut.ordering(nmax)));
 
-        REQUIRE(std::is_lt(sut.contains(nlow)));
-        REQUIRE(std::is_lt(sut.contains(nmin)));
+        REQUIRE(std::is_lt(sut.ordering(nlow)));
+        REQUIRE(std::is_lt(sut.ordering(nmin)));
     }
 
     SUBCASE("less_than") {
         const auto sut = less_than(nhigh);
 
-        REQUIRE(std::is_eq(sut.contains(nhigh - 1)));
-        REQUIRE(std::is_eq(sut.contains(nlow)));
-        REQUIRE(std::is_eq(sut.contains(nmin)));
+        REQUIRE(std::is_eq(sut.ordering(nhigh - 1)));
+        REQUIRE(std::is_eq(sut.ordering(nlow)));
+        REQUIRE(std::is_eq(sut.ordering(nmin)));
 
-        REQUIRE(std::is_gt(sut.contains(nhigh)));
-        REQUIRE(std::is_gt(sut.contains(nmax)));
+        REQUIRE(std::is_gt(sut.ordering(nhigh)));
+        REQUIRE(std::is_gt(sut.ordering(nmax)));
     }
 
     SUBCASE("up_to") {
         const auto sut = up_to(nhigh);
 
-        REQUIRE(std::is_eq(sut.contains(nhigh)));
-        REQUIRE(std::is_eq(sut.contains(nlow)));
-        REQUIRE(std::is_eq(sut.contains(nmin)));
+        REQUIRE(std::is_eq(sut.ordering(nhigh)));
+        REQUIRE(std::is_eq(sut.ordering(nlow)));
+        REQUIRE(std::is_eq(sut.ordering(nmin)));
 
-        REQUIRE(std::is_gt(sut.contains(nhigh + 1)));
-        REQUIRE(std::is_gt(sut.contains(nmax)));
+        REQUIRE(std::is_gt(sut.ordering(nhigh + 1)));
+        REQUIRE(std::is_gt(sut.ordering(nmax)));
     }
 
     SUBCASE("any") {
         const auto sut = any();
 
-        REQUIRE(std::is_eq(sut.contains(nmin)));
-        REQUIRE(std::is_eq(sut.contains(ndefault)));
-        REQUIRE(std::is_eq(sut.contains(nlow)));
-        REQUIRE(std::is_eq(sut.contains(nmid)));
-        REQUIRE(std::is_eq(sut.contains(nhigh)));
-        REQUIRE(std::is_eq(sut.contains(nmax)));
+        REQUIRE(std::is_eq(sut.ordering(nmin)));
+        REQUIRE(std::is_eq(sut.ordering(ndefault)));
+        REQUIRE(std::is_eq(sut.ordering(nlow)));
+        REQUIRE(std::is_eq(sut.ordering(nmid)));
+        REQUIRE(std::is_eq(sut.ordering(nhigh)));
+        REQUIRE(std::is_eq(sut.ordering(nmax)));
     }
 }
 

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -143,7 +143,7 @@ TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return fal
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return true if value is set") {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
     CHECK(has_value(sut));
 }
 
@@ -217,7 +217,7 @@ TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
     CHECK(has_parsed_values(sut));
 }
 
@@ -234,7 +234,7 @@ TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "value() should return the argument's value if it has been set"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
 
     REQUIRE(has_value(sut));
     CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value_1);
@@ -288,7 +288,7 @@ TEST_CASE_FIXTURE(
     auto sut = init_arg(primary_name);
     set_choices(sut, default_choices);
 
-    REQUIRE_THROWS_AS(set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice);
+    REQUIRE_THROWS_AS(set_value(sut, invalid_choice), ap::error::invalid_choice);
     CHECK_FALSE(has_value(sut));
 }
 
@@ -311,7 +311,7 @@ TEST_CASE_FIXTURE(
 
     CAPTURE(value);
 
-    REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+    REQUIRE_NOTHROW(set_value(sut, value));
     REQUIRE(has_value(sut));
     CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value);
 }
@@ -322,9 +322,9 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = init_arg(primary_name);
 
-    REQUIRE_NOTHROW(set_value(sut, std::to_string(value_1)));
+    REQUIRE_NOTHROW(set_value(sut, value_1));
     REQUIRE(has_value(sut));
-    CHECK_THROWS_AS(set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
+    CHECK_THROWS_AS(set_value(sut, value_2), ap::error::value_already_set);
 }
 
 TEST_CASE_FIXTURE(
@@ -335,7 +335,7 @@ TEST_CASE_FIXTURE(
     sut.nargs(non_default_range);
 
     for (const auto value : default_choices) {
-        REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+        REQUIRE_NOTHROW(set_value(sut, value));
     }
 
     const auto stored_values = get_values(sut);
@@ -355,7 +355,7 @@ TEST_CASE_FIXTURE(
         const auto double_valued_action = [](const sut_value_type& value) { return 2 * value; };
         sut.action<ap::action_type::transform>(double_valued_action);
 
-        set_value(sut, std::to_string(value_1));
+        set_value(sut, value_1);
 
         CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), double_valued_action(value_1));
     }
@@ -366,7 +366,7 @@ TEST_CASE_FIXTURE(
 
         auto test_value = value_1;
 
-        set_value(sut, std::to_string(test_value));
+        set_value(sut, test_value);
 
         double_void_action(test_value);
         CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), test_value);
@@ -404,11 +404,11 @@ TEST_CASE_FIXTURE(
     REQUIRE(std::is_lt(nvalues_in_range(sut)));
 
     for (const auto value : default_choices) {
-        REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+        REQUIRE_NOTHROW(set_value(sut, value));
         CHECK(std::is_eq(nvalues_in_range(sut)));
     }
 
-    REQUIRE_NOTHROW(set_value(sut, std::to_string(invalid_choice)));
+    REQUIRE_NOTHROW(set_value(sut, invalid_choice));
     CHECK(std::is_gt(nvalues_in_range(sut)));
 }
 

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -14,113 +14,112 @@ namespace {
 constexpr std::string_view primary_name = "test";
 constexpr std::string_view secondary_name = "t";
 
-using test_value_type = int;
+using sut_value_type = int;
 using invalid_value_type = double;
-using sut_type = optional<test_value_type>;
+using sut_type = optional<sut_value_type>;
 
-sut_type prepare_argument(std::string_view primary_name) {
+sut_type init_arg(std::string_view primary_name) {
     return sut_type(argument_name{primary_name});
 }
 
-sut_type prepare_argument(std::string_view primary_name, std::string_view secondary_name) {
+sut_type init_arg(std::string_view primary_name, std::string_view secondary_name) {
     return sut_type(argument_name{primary_name, secondary_name});
 }
 
-const std::string empty_str = "";
-const std::string invalid_value_str = "invalid_value";
+constexpr std::string empty_str = "";
+constexpr std::string invalid_value_str = "invalid_value";
 
-constexpr test_value_type value_1 = 1;
-constexpr test_value_type value_2 = 2;
-constexpr test_value_type default_value = 0;
-constexpr test_value_type implicit_value = -1;
+constexpr sut_value_type value_1 = 1;
+constexpr sut_value_type value_2 = 2;
+constexpr sut_value_type default_value = 0;
+constexpr sut_value_type implicit_value = -1;
 
-const std::vector<test_value_type> default_choices{1, 2, 3};
-constexpr test_value_type invalid_choice = 4;
+const std::vector<sut_value_type> default_choices{1, 2, 3};
+constexpr sut_value_type invalid_choice = 4;
 
-const range non_default_range = range(1u, default_choices.size());
+const range non_default_range = range{1ull, default_choices.size()};
 
 } // namespace
 
 TEST_SUITE_BEGIN("test_optional_argument");
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_optional() should return true") {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK(sut.is_optional());
 }
 
 TEST_CASE_FIXTURE(
-    optional_argument_test_fixture,
-    "name() should return value passed to the optional argument constructor for primary name"
+    optional_argument_test_fixture, "name() should return the proper argument_name instance"
 ) {
-    const auto sut = prepare_argument(primary_name);
-    const auto name = sut_get_name(sut);
+    SUBCASE("initialized with the primary name only") {
+        const auto sut = init_arg(primary_name);
+        const auto name = get_name(sut);
 
-    CHECK(name.match(primary_name));
-    CHECK_FALSE(name.match(secondary_name));
-}
+        CHECK(name.match(primary_name));
+        CHECK_FALSE(name.match(secondary_name));
+    }
 
-TEST_CASE_FIXTURE(
-    optional_argument_test_fixture,
-    "name() and secondary_name() should return value passed to the optional"
-    "argument constructor for both primary and secondary names"
-) {
-    const auto sut = prepare_argument(primary_name, secondary_name);
-    const auto name = sut_get_name(sut);
+    SUBCASE("initialized with the primary and secondary names") {
+        const auto sut = init_arg(primary_name, secondary_name);
+        const auto name = get_name(sut);
 
-    CHECK(name.match(primary_name));
-    CHECK(name.match(secondary_name));
+        CHECK(name.match(primary_name));
+        CHECK(name.match(secondary_name));
+    }
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "help() should return nullopt by default") {
-    const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_get_help(sut));
+    const auto sut = init_arg(primary_name);
+    CHECK_FALSE(get_help(sut));
 }
 
 TEST_CASE_FIXTURE(
-    optional_argument_test_fixture, "help() should return message if one has been provided"
+    optional_argument_test_fixture, "help() should return a massage set for the argument"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     constexpr std::string_view help_msg = "test help msg";
     sut.help(help_msg);
 
-    const auto stored_help_msg = sut_get_help(sut);
+    const auto stored_help_msg = get_help(sut);
 
     REQUIRE(stored_help_msg);
     CHECK_EQ(stored_help_msg, help_msg);
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_required() should return false by default") {
-    auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_is_required(sut));
+    auto sut = init_arg(primary_name);
+    CHECK_FALSE(is_required(sut));
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "is_required() should return true is argument is set to be required"
+    "is_required() should return true if the argument is set to be required"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.required();
-    CHECK(sut_is_required(sut));
+    CHECK(is_required(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_used() should return false by default") {
-    const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_is_used(sut));
+    const auto sut = init_arg(primary_name);
+    CHECK_FALSE(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(
-    optional_argument_test_fixture, "is_used() should return true when argument contains value"
+    optional_argument_test_fixture,
+    "is_used() should return true if the argument's flag has been used"
 ) {
-    auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
+    auto sut = init_arg(primary_name);
+    REQUIRE_FALSE(is_used(sut));
 
-    CHECK(sut_is_used(sut));
+    mark_used(sut);
+    CHECK(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "nused() should return 0 by default") {
-    const auto sut = prepare_argument(primary_name);
-    CHECK_EQ(sut_get_nused(sut), 0u);
+    const auto sut = init_arg(primary_name);
+    CHECK_EQ(get_nused(sut), 0ull);
 }
 
 TEST_CASE_FIXTURE(
@@ -128,64 +127,66 @@ TEST_CASE_FIXTURE(
     "is_used() should return the number of times the argument's flag has been used "
     "[number of mark_used() function calls]"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
-    constexpr std::size_t nused = 5u;
-    for (std::size_t n = 0; n < nused; ++n)
-        sut_set_used(sut);
+    constexpr std::size_t nused = 5ull;
+    for (std::size_t n = 0ull; n < nused; ++n)
+        mark_used(sut);
 
-    CHECK_EQ(sut_get_nused(sut), nused);
+    CHECK_EQ(get_nused(sut), nused);
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return false by default") {
-    const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_has_value(sut));
+    const auto sut = init_arg(primary_name);
+    CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "has_value() should return true if value is set") {
-    auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
-    CHECK(sut_has_value(sut));
+    auto sut = init_arg(primary_name);
+    set_value(sut, std::to_string(value_1));
+    CHECK(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
-    optional_argument_test_fixture, "has_value() should return true if a default value is set"
+    optional_argument_test_fixture,
+    "has_value() should return true if a default value is set and value() should return the "
+    "default value"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.default_value(default_value);
 
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), default_value);
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), default_value);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "has_value() should return false if an implicit value is set but the argument is not used"
+    "has_value() should return false if only the implicit value is set but the argument is not used"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.implicit_value(implicit_value);
 
-    CHECK_FALSE(sut_has_value(sut));
+    CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "has_value() should return true if an implicit value is set and the agument is used"
+    "has_value() should return true if the implicit value is set and the agument is used"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.implicit_value(implicit_value);
 
-    sut_set_used(sut);
+    mark_used(sut);
 
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), implicit_value);
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), implicit_value);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "has_parsed_values() should return false by default"
 ) {
-    const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_has_parsed_values(sut));
+    const auto sut = init_arg(primary_name);
+    CHECK_FALSE(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -193,115 +194,114 @@ TEST_CASE_FIXTURE(
     "has_parsed_values() should return false regardles of the "
     "default_value and implicit_value parameters"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     SUBCASE("default_value") {
         sut.default_value(default_value);
-        CHECK_FALSE(sut_has_parsed_values(sut));
+        CHECK_FALSE(has_parsed_values(sut));
     }
 
     SUBCASE("implicit_value") {
         sut.implicit_value(implicit_value);
-        CHECK_FALSE(sut_has_parsed_values(sut));
+        CHECK_FALSE(has_parsed_values(sut));
     }
 
-    SUBCASE("default_value & implicit_value") {
+    SUBCASE("default_value and implicit_value") {
         sut.default_value(default_value);
         sut.implicit_value(implicit_value);
-        CHECK_FALSE(sut_has_parsed_values(sut));
+        CHECK_FALSE(has_parsed_values(sut));
     }
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
-    auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
-    CHECK(sut_has_parsed_values(sut));
+    auto sut = init_arg(primary_name);
+    set_value(sut, std::to_string(value_1));
+    CHECK(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
-    optional_argument_test_fixture, "value() should throw if argument's value has not been set"
+    optional_argument_test_fixture, "value() should throw if the argument's value has not been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
-    REQUIRE_FALSE(sut_has_value(sut));
-    CHECK_THROWS_AS(static_cast<void>(sut_get_value(sut)), std::logic_error);
+    REQUIRE_FALSE(has_value(sut));
+    CHECK_THROWS_AS(static_cast<void>(get_value(sut)), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "value() should return the argument's value if it has been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
+    set_value(sut, std::to_string(value_1));
 
-    sut_set_value(sut, std::to_string(value_1));
-
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
     "value() should return the default value if one has been provided and argument is not used"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.default_value(value_1);
 
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
     "value() should return the implicit value if one has been provided and argument is used"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.implicit_value(implicit_value);
 
-    sut_set_used(sut);
+    mark_used(sut);
 
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), implicit_value);
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), implicit_value);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "set_value(any) should throw when value_type cannot be obtained from given string"
+    "set_value(any) should throw when the given string cannot be converted to an instance of "
+    "value_type"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     SUBCASE("given string is empty") {
-        REQUIRE_THROWS_AS(sut_set_value(sut, empty_str), ap::error::invalid_value);
-        CHECK_FALSE(sut_has_value(sut));
+        REQUIRE_THROWS_AS(set_value(sut, empty_str), ap::error::invalid_value);
+        CHECK_FALSE(has_value(sut));
     }
     SUBCASE("given string is non-convertible to value_type") {
-        REQUIRE_THROWS_AS(sut_set_value(sut, invalid_value_str), ap::error::invalid_value);
-        CHECK_FALSE(sut_has_value(sut));
+        REQUIRE_THROWS_AS(set_value(sut, invalid_value_str), ap::error::invalid_value);
+        CHECK_FALSE(has_value(sut));
     }
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "set_value(any) should throw when parameter passed to value() is not present in the choices set"
+    "set_value(any) should throw when the choices set does not contain the parsed value"
 ) {
-    auto sut = prepare_argument(primary_name);
-    sut_set_choices(sut, default_choices);
+    auto sut = init_arg(primary_name);
+    set_choices(sut, default_choices);
 
-    REQUIRE_THROWS_AS(
-        sut_set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice
-    );
-    CHECK_FALSE(sut_has_value(sut));
+    REQUIRE_THROWS_AS(set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice);
+    CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "set_value(any) should accept the given value when it's present in the choices set"
+    "set_value(any) should accept the given value only when no value has been set yet "
+    "and if the given value is present in the choices set"
 ) {
-    auto sut = prepare_argument(primary_name);
-    sut_set_choices(sut, default_choices);
+    auto sut = init_arg(primary_name);
+    set_choices(sut, default_choices);
 
-    const std::vector<test_value_type> correct_values = default_choices;
-    test_value_type value;
+    const std::vector<sut_value_type> correct_values = default_choices;
+    sut_value_type value;
 
     for (const auto& v : correct_values) {
         SUBCASE("correct value") {
@@ -311,65 +311,65 @@ TEST_CASE_FIXTURE(
 
     CAPTURE(value);
 
-    REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value);
+    REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
-    "set_value(any) should throw when a value has already been set when nargs is default"
+    "set_value(any) should throw when a value has already been set (when nargs is default)"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
-    REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value_1)));
-    REQUIRE(sut_has_value(sut));
-    CHECK_THROWS_AS(sut_set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
+    REQUIRE_NOTHROW(set_value(sut, std::to_string(value_1)));
+    REQUIRE(has_value(sut));
+    CHECK_THROWS_AS(set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
     "set_value(any) should accept multiple values if nargs is not detault"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.nargs(non_default_range);
 
     for (const auto value : default_choices) {
-        REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
+        REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
     }
 
-    const auto stored_values = sut_get_values(sut);
+    const auto stored_values = get_values(sut);
 
     REQUIRE_EQ(stored_values.size(), default_choices.size());
     for (std::size_t i = 0; i < stored_values.size(); ++i) {
-        REQUIRE_EQ(std::any_cast<test_value_type>(stored_values[i]), default_choices[i]);
+        REQUIRE_EQ(std::any_cast<sut_value_type>(stored_values[i]), default_choices[i]);
     }
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "set_value(any) should perform the specified action"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     SUBCASE("valued action") {
-        const auto double_valued_action = [](const test_value_type& value) { return 2 * value; };
+        const auto double_valued_action = [](const sut_value_type& value) { return 2 * value; };
         sut.action<ap::action_type::transform>(double_valued_action);
 
-        sut_set_value(sut, std::to_string(value_1));
+        set_value(sut, std::to_string(value_1));
 
-        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), double_valued_action(value_1));
+        CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), double_valued_action(value_1));
     }
 
     SUBCASE("void action") {
-        const auto double_void_action = [](test_value_type& value) { value *= 2; };
+        const auto double_void_action = [](sut_value_type& value) { value *= 2; };
         sut.action<ap::action_type::modify>(double_void_action);
 
         auto test_value = value_1;
 
-        sut_set_value(sut, std::to_string(test_value));
+        set_value(sut, std::to_string(test_value));
 
         double_void_action(test_value);
-        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), test_value);
+        CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), test_value);
     }
 }
 
@@ -377,20 +377,20 @@ TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
     "nvalues_in_range() should return equivalent if nargs has not been set"
 ) {
-    const auto sut = prepare_argument(primary_name);
-    CHECK(std::is_eq(sut_nvalues_in_range(sut)));
+    const auto sut = init_arg(primary_name);
+    CHECK(std::is_eq(nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture,
     "nvalues_in_range() should return equivalent if a default value has been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.nargs(non_default_range);
 
     sut.default_value(default_value);
 
-    CHECK(std::is_eq(sut_nvalues_in_range(sut)));
+    CHECK(std::is_eq(nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(
@@ -398,18 +398,18 @@ TEST_CASE_FIXTURE(
     "nvalues_in_range() should return equivalent only when the number of values "
     "is in the specified range"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     sut.nargs(non_default_range);
 
-    REQUIRE(std::is_lt(sut_nvalues_in_range(sut)));
+    REQUIRE(std::is_lt(nvalues_in_range(sut)));
 
     for (const auto value : default_choices) {
-        REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
-        CHECK(std::is_eq(sut_nvalues_in_range(sut)));
+        REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+        CHECK(std::is_eq(nvalues_in_range(sut)));
     }
 
-    REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(invalid_choice)));
-    CHECK(std::is_gt(sut_nvalues_in_range(sut)));
+    REQUIRE_NOTHROW(set_value(sut, std::to_string(invalid_choice)));
+    CHECK(std::is_gt(nvalues_in_range(sut)));
 }
 
 TEST_SUITE_END();

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -97,8 +97,9 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "is_used() should return true when argument contains a value"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    REQUIRE_FALSE(is_used(sut));
 
+    set_value(sut, std::to_string(value_1));
     CHECK(is_used(sut));
 }
 

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -47,7 +47,7 @@ TEST_CASE_FIXTURE(
     "name() should return value passed to the optional argument constructor for primary name"
 ) {
     const auto sut = prepare_argument(primary_name);
-    const auto name = sut_get_name(sut);
+    const auto name = get_name(sut);
 
     CHECK(name.match(primary_name));
     CHECK_FALSE(name.match(secondary_name));
@@ -59,7 +59,7 @@ TEST_CASE_FIXTURE(
     "argument constructor for both primary and secondary names"
 ) {
     const auto sut = prepare_argument(primary_name, secondary_name);
-    const auto name = sut_get_name(sut);
+    const auto name = get_name(sut);
 
     CHECK(name.match(primary_name));
     CHECK(name.match(secondary_name));
@@ -67,7 +67,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "help() should return nullopt by default") {
     const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_get_help(sut));
+    CHECK_FALSE(get_help(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -78,7 +78,7 @@ TEST_CASE_FIXTURE(
     constexpr std::string_view help_msg = "test help msg";
     sut.help(help_msg);
 
-    const auto stored_help_msg = sut_get_help(sut);
+    const auto stored_help_msg = get_help(sut);
 
     REQUIRE(stored_help_msg);
     CHECK_EQ(stored_help_msg, help_msg);
@@ -86,65 +86,65 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_required() should return true") {
     auto sut = prepare_argument(primary_name);
-    CHECK(sut_is_required(sut));
+    CHECK(is_required(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_used() should return false by default") {
     const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_is_used(sut));
+    CHECK_FALSE(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "is_used() should return true when argument contains value"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
+    set_value(sut, std::to_string(value_1));
 
-    CHECK(sut_is_used(sut));
+    CHECK(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "nused() should return 0 by default") {
     const auto sut = prepare_argument(primary_name);
-    CHECK_EQ(sut_get_nused(sut), 0u);
+    CHECK_EQ(get_nused(sut), 0u);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "is_used() should return 1 when argument contains value"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
+    set_value(sut, std::to_string(value_1));
 
-    CHECK_EQ(sut_get_nused(sut), 1u);
+    CHECK_EQ(get_nused(sut), 1u);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return false by default") {
     const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_has_value(sut));
+    CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_value() should return true is value is set"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
+    set_value(sut, std::to_string(value_1));
 
-    CHECK(sut_has_value(sut));
+    CHECK(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should return false by default"
 ) {
     const auto sut = prepare_argument(primary_name);
-    CHECK_FALSE(sut_has_parsed_values(sut));
+    CHECK_FALSE(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
+    set_value(sut, std::to_string(value_1));
 
-    CHECK(sut_has_parsed_values(sut));
+    CHECK(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -153,9 +153,9 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = prepare_argument(primary_name);
 
-    REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value_1)));
-    REQUIRE(sut_has_value(sut));
-    CHECK_THROWS_AS(sut_set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
+    REQUIRE_NOTHROW(set_value(sut, std::to_string(value_1)));
+    REQUIRE(has_value(sut));
+    CHECK_THROWS_AS(set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
 }
 
 TEST_CASE_FIXTURE(
@@ -165,12 +165,12 @@ TEST_CASE_FIXTURE(
     auto sut = prepare_argument(primary_name);
 
     SUBCASE("given string is empty") {
-        REQUIRE_THROWS_AS(sut_set_value(sut, empty_str), ap::error::invalid_value);
-        CHECK_FALSE(sut_has_value(sut));
+        REQUIRE_THROWS_AS(set_value(sut, empty_str), ap::error::invalid_value);
+        CHECK_FALSE(has_value(sut));
     }
     SUBCASE("given string is non-convertible to value_type") {
-        REQUIRE_THROWS_AS(sut_set_value(sut, invalid_value_str), ap::error::invalid_value);
-        CHECK_FALSE(sut_has_value(sut));
+        REQUIRE_THROWS_AS(set_value(sut, invalid_value_str), ap::error::invalid_value);
+        CHECK_FALSE(has_value(sut));
     }
 }
 
@@ -179,12 +179,10 @@ TEST_CASE_FIXTURE(
     "set_value(any) should throw when parameter passed to value() is not present in the choices set"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_choices(sut, default_choices);
+    set_choices(sut, default_choices);
 
-    REQUIRE_THROWS_AS(
-        sut_set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice
-    );
-    CHECK_FALSE(sut_has_value(sut));
+    REQUIRE_THROWS_AS(set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice);
+    CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
@@ -193,7 +191,7 @@ TEST_CASE_FIXTURE(
     "and if the given value is present in the choices set"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_choices(sut, default_choices);
+    set_choices(sut, default_choices);
 
     const std::vector<test_value_type> correct_values = default_choices;
     test_value_type value;
@@ -206,9 +204,9 @@ TEST_CASE_FIXTURE(
 
     CAPTURE(value);
 
-    REQUIRE_NOTHROW(sut_set_value(sut, std::to_string(value)));
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value);
+    REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), value);
 }
 
 TEST_CASE_FIXTURE(
@@ -220,9 +218,9 @@ TEST_CASE_FIXTURE(
         const auto double_valued_action = [](const test_value_type& value) { return 2 * value; };
         sut.action<ap::action_type::transform>(double_valued_action);
 
-        sut_set_value(sut, std::to_string(value_1));
+        set_value(sut, std::to_string(value_1));
 
-        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), double_valued_action(value_1));
+        CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), double_valued_action(value_1));
     }
 
     SUBCASE("void action") {
@@ -231,10 +229,10 @@ TEST_CASE_FIXTURE(
 
         auto test_value = value_1;
 
-        sut_set_value(sut, std::to_string(test_value));
+        set_value(sut, std::to_string(test_value));
 
         double_void_action(test_value);
-        CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), test_value);
+        CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), test_value);
     }
 }
 
@@ -243,8 +241,8 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = prepare_argument(primary_name);
 
-    REQUIRE_FALSE(sut_has_value(sut));
-    CHECK_THROWS_AS(static_cast<void>(sut_get_value(sut)), std::logic_error);
+    REQUIRE_FALSE(has_value(sut));
+    CHECK_THROWS_AS(static_cast<void>(get_value(sut)), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
@@ -253,22 +251,22 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = prepare_argument(primary_name);
 
-    sut_set_value(sut, std::to_string(value_1));
+    set_value(sut, std::to_string(value_1));
 
-    REQUIRE(sut_has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(sut_get_value(sut)), value_1);
+    REQUIRE(has_value(sut));
+    CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "values() should throw logic_error") {
     auto sut = prepare_argument(primary_name);
-    CHECK_THROWS_AS(sut_get_values(sut), std::logic_error);
+    CHECK_THROWS_AS(get_values(sut), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "nvalues_in_range() should return less by default"
 ) {
     const auto sut = prepare_argument(primary_name);
-    CHECK(std::is_lt(sut_nvalues_in_range(sut)));
+    CHECK(std::is_lt(nvalues_in_range(sut)));
 }
 
 TEST_CASE_FIXTURE(
@@ -276,9 +274,9 @@ TEST_CASE_FIXTURE(
     "nvalues_in_range() should return equivalent if a value has been set"
 ) {
     auto sut = prepare_argument(primary_name);
-    sut_set_value(sut, std::to_string(value_1));
+    set_value(sut, std::to_string(value_1));
 
-    CHECK(std::is_eq(sut_nvalues_in_range(sut)));
+    CHECK(std::is_eq(nvalues_in_range(sut)));
 }
 
 TEST_SUITE_END();

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -99,7 +99,7 @@ TEST_CASE_FIXTURE(
     auto sut = init_arg(primary_name);
     REQUIRE_FALSE(is_used(sut));
 
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
     CHECK(is_used(sut));
 }
 
@@ -112,7 +112,7 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "nused() should return 1 when argument contains a value"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
 
     CHECK_EQ(get_nused(sut), 1ull);
 }
@@ -126,7 +126,7 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_value() should return true if the value is set"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
 
     CHECK(has_value(sut));
 }
@@ -142,7 +142,7 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
 
     CHECK(has_parsed_values(sut));
 }
@@ -153,10 +153,10 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = init_arg(primary_name);
 
-    REQUIRE_NOTHROW(set_value(sut, std::to_string(value_1)));
+    REQUIRE_NOTHROW(set_value(sut, value_1));
     REQUIRE(has_value(sut));
 
-    CHECK_THROWS_AS(set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
+    CHECK_THROWS_AS(set_value(sut, value_2), ap::error::value_already_set);
 }
 
 TEST_CASE_FIXTURE(
@@ -184,7 +184,7 @@ TEST_CASE_FIXTURE(
     auto sut = init_arg(primary_name);
     set_choices(sut, default_choices);
 
-    REQUIRE_THROWS_AS(set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice);
+    REQUIRE_THROWS_AS(set_value(sut, invalid_choice), ap::error::invalid_choice);
     CHECK_FALSE(has_value(sut));
 }
 
@@ -206,7 +206,7 @@ TEST_CASE_FIXTURE(
 
     CAPTURE(value);
 
-    REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
+    REQUIRE_NOTHROW(set_value(sut, value));
     REQUIRE(has_value(sut));
     CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value);
 }
@@ -220,7 +220,7 @@ TEST_CASE_FIXTURE(
         const auto double_action = [](const sut_value_type& value) { return 2 * value; };
         sut.action<ap::action_type::transform>(double_action);
 
-        set_value(sut, std::to_string(value_1));
+        set_value(sut, value_1);
 
         CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), double_action(value_1));
     }
@@ -231,7 +231,7 @@ TEST_CASE_FIXTURE(
 
         auto test_value = value_1;
 
-        set_value(sut, std::to_string(test_value));
+        set_value(sut, test_value);
 
         double_action(test_value);
         CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), test_value);
@@ -254,7 +254,7 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = init_arg(primary_name);
 
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
 
     REQUIRE(has_value(sut));
     CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value_1);
@@ -277,7 +277,7 @@ TEST_CASE_FIXTURE(
     "nvalues_in_range() should return equivalent if a value has been set"
 ) {
     auto sut = init_arg(primary_name);
-    set_value(sut, std::to_string(value_1));
+    set_value(sut, value_1);
 
     CHECK(std::is_eq(nvalues_in_range(sut)));
 }

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -13,67 +13,66 @@ namespace {
 constexpr std::string_view primary_name = "test";
 constexpr std::string_view secondary_name = "t";
 
-using test_value_type = int;
-using sut_type = positional<test_value_type>;
+using sut_value_type = int;
+using sut_type = positional<sut_value_type>;
 
-sut_type prepare_argument(std::string_view primary_name) {
-    return sut_type(argument_name{primary_name});
+sut_type init_arg(std::string_view primary_name) {
+    return sut_type{argument_name{primary_name}};
 }
 
-sut_type prepare_argument(std::string_view primary_name, std::string_view secondary_name) {
-    return sut_type(argument_name{primary_name, secondary_name});
+sut_type init_arg(std::string_view primary_name, std::string_view secondary_name) {
+    return sut_type{
+        argument_name{primary_name, secondary_name}
+    };
 }
 
-const std::string empty_str = "";
-const std::string invalid_value_str = "invalid_value";
+constexpr std::string empty_str = "";
+constexpr std::string invalid_value_str = "invalid value";
 
-constexpr test_value_type value_1 = 1;
-constexpr test_value_type value_2 = 2;
+constexpr sut_value_type value_1 = 1;
+constexpr sut_value_type value_2 = 2;
 
-const std::vector<test_value_type> default_choices{1, 2, 3};
-constexpr test_value_type invalid_choice = 4;
+const std::vector<sut_value_type> default_choices{1, 2, 3};
+constexpr sut_value_type invalid_choice = 4;
 
 } // namespace
 
 TEST_SUITE_BEGIN("test_positional_argument");
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_optional() should return false") {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK_FALSE(sut.is_optional());
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture,
-    "name() should return value passed to the optional argument constructor for primary name"
+    positional_argument_test_fixture, "name() should return the proper argument_name instance"
 ) {
-    const auto sut = prepare_argument(primary_name);
-    const auto name = get_name(sut);
+    SUBCASE("initialized with the primary name only") {
+        const auto sut = init_arg(primary_name);
+        const auto name = get_name(sut);
 
-    CHECK(name.match(primary_name));
-    CHECK_FALSE(name.match(secondary_name));
-}
+        CHECK(name.match(primary_name));
+        CHECK_FALSE(name.match(secondary_name));
+    }
 
-TEST_CASE_FIXTURE(
-    positional_argument_test_fixture,
-    "name() and secondary_name() should return value passed to the optional"
-    "argument constructor for both primary and secondary names"
-) {
-    const auto sut = prepare_argument(primary_name, secondary_name);
-    const auto name = get_name(sut);
+    SUBCASE("initialized with the primary and secondary names") {
+        const auto sut = init_arg(primary_name, secondary_name);
+        const auto name = get_name(sut);
 
-    CHECK(name.match(primary_name));
-    CHECK(name.match(secondary_name));
+        CHECK(name.match(primary_name));
+        CHECK(name.match(secondary_name));
+    }
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "help() should return nullopt by default") {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK_FALSE(get_help(sut));
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "help() should return message if one has been provided"
+    positional_argument_test_fixture, "help() should return a massage set for the argument"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     constexpr std::string_view help_msg = "test help msg";
     sut.help(help_msg);
@@ -85,47 +84,47 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_required() should return true") {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     CHECK(is_required(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_used() should return false by default") {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK_FALSE(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "is_used() should return true when argument contains value"
+    positional_argument_test_fixture, "is_used() should return true when argument contains a value"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_value(sut, std::to_string(value_1));
 
     CHECK(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "nused() should return 0 by default") {
-    const auto sut = prepare_argument(primary_name);
-    CHECK_EQ(get_nused(sut), 0u);
+    const auto sut = init_arg(primary_name);
+    CHECK_EQ(get_nused(sut), 0ull);
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "is_used() should return 1 when argument contains value"
+    positional_argument_test_fixture, "nused() should return 1 when argument contains a value"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_value(sut, std::to_string(value_1));
 
-    CHECK_EQ(get_nused(sut), 1u);
+    CHECK_EQ(get_nused(sut), 1ull);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return false by default") {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "has_value() should return true is value is set"
+    positional_argument_test_fixture, "has_value() should return true if the value is set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_value(sut, std::to_string(value_1));
 
     CHECK(has_value(sut));
@@ -134,14 +133,14 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should return false by default"
 ) {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK_FALSE(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "has_parsed_values() should true if the value is set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_value(sut, std::to_string(value_1));
 
     CHECK(has_parsed_values(sut));
@@ -151,23 +150,26 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
     "set_value(any) should throw when a value has already been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     REQUIRE_NOTHROW(set_value(sut, std::to_string(value_1)));
     REQUIRE(has_value(sut));
+
     CHECK_THROWS_AS(set_value(sut, std::to_string(value_2)), ap::error::value_already_set);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
-    "set_value(any) should throw when value_type cannot be obtained from given string"
+    "set_value(any) should throw when the given string cannot be converted to an instance of "
+    "value_type"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_AS(set_value(sut, empty_str), ap::error::invalid_value);
         CHECK_FALSE(has_value(sut));
     }
+
     SUBCASE("given string is non-convertible to value_type") {
         REQUIRE_THROWS_AS(set_value(sut, invalid_value_str), ap::error::invalid_value);
         CHECK_FALSE(has_value(sut));
@@ -176,9 +178,9 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
-    "set_value(any) should throw when parameter passed to value() is not present in the choices set"
+    "set_value(any) should throw when the choices set does not contain the parsed value"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_choices(sut, default_choices);
 
     REQUIRE_THROWS_AS(set_value(sut, std::to_string(invalid_choice)), ap::error::invalid_choice);
@@ -190,13 +192,12 @@ TEST_CASE_FIXTURE(
     "set_value(any) should accept the given value only when no value has been set yet "
     "and if the given value is present in the choices set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_choices(sut, default_choices);
 
-    const std::vector<test_value_type> correct_values = default_choices;
-    test_value_type value;
+    sut_value_type value;
 
-    for (const auto& v : correct_values) {
+    for (const auto& v : default_choices) {
         SUBCASE("correct value") {
             value = v;
         }
@@ -206,40 +207,41 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_NOTHROW(set_value(sut, std::to_string(value)));
     REQUIRE(has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), value);
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "set_value(any) should perform the specified action"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
-    SUBCASE("valued action") {
-        const auto double_valued_action = [](const test_value_type& value) { return 2 * value; };
-        sut.action<ap::action_type::transform>(double_valued_action);
+    SUBCASE("transform action") {
+        const auto double_action = [](const sut_value_type& value) { return 2 * value; };
+        sut.action<ap::action_type::transform>(double_action);
 
         set_value(sut, std::to_string(value_1));
 
-        CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), double_valued_action(value_1));
+        CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), double_action(value_1));
     }
 
-    SUBCASE("void action") {
-        const auto double_void_action = [](test_value_type& value) { value *= 2; };
-        sut.action<ap::action_type::modify>(double_void_action);
+    SUBCASE("modify action") {
+        const auto double_action = [](sut_value_type& value) { value *= 2; };
+        sut.action<ap::action_type::modify>(double_action);
 
         auto test_value = value_1;
 
         set_value(sut, std::to_string(test_value));
 
-        double_void_action(test_value);
-        CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), test_value);
+        double_action(test_value);
+        CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), test_value);
     }
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "value() should throw if argument's value has not been set"
+    positional_argument_test_fixture,
+    "value() should throw if the argument's value has not been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     REQUIRE_FALSE(has_value(sut));
     CHECK_THROWS_AS(static_cast<void>(get_value(sut)), std::logic_error);
@@ -249,23 +251,23 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
     "value() should return the argument's value if it has been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
 
     set_value(sut, std::to_string(value_1));
 
     REQUIRE(has_value(sut));
-    CHECK_EQ(std::any_cast<test_value_type>(get_value(sut)), value_1);
+    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value_1);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "values() should throw logic_error") {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     CHECK_THROWS_AS(get_values(sut), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "nvalues_in_range() should return less by default"
 ) {
-    const auto sut = prepare_argument(primary_name);
+    const auto sut = init_arg(primary_name);
     CHECK(std::is_lt(nvalues_in_range(sut)));
 }
 
@@ -273,7 +275,7 @@ TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
     "nvalues_in_range() should return equivalent if a value has been set"
 ) {
-    auto sut = prepare_argument(primary_name);
+    auto sut = init_arg(primary_name);
     set_value(sut, std::to_string(value_1));
 
     CHECK(std::is_eq(nvalues_in_range(sut)));


### PR DESCRIPTION
- Aligned the test case names
- Renamed the fixture methods
- Simplified complex test cases
- Changed the logic of initializing the `argc` and `argv` parameters