### PR TITLE
YT-CPPAP-33: Extend the choices initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,19 +282,20 @@ Parameters which can be specified for both positional and optional arguments inc
 
 ### Default arguments
 
-The `CPP-AP` library has a few default arguments defined. To add a default argument to the parser use the following:
+The `CPP-AP` library defines several default arguments, which can be added to the parser's configuration as follows.
 
 ```c++
-// add positional arguments - pass a std::vector of default positional arguments
 parser.default_positional_arguments({...});
-// here `...` represents a list of ap::argument::default_positional values
+// here `...` represents a collection of ap::argument::default_positional values
 
-// add optional arguments - pass a std::vector of default optional arguments
 parser.default_positional_arguments({...});
-// here `...` represents a list of ap::argument::default_optional values
+// here `...` represents a collection of ap::argument::default_optional values
 ```
 
-The supported default arguments are:
+> [!NOTE]
+> These functions work with `std::initializer_list` and all other `std::ranges::range` types with the correct value type - `ap::argument::default_{positional/optional}`
+
+The available default arguments are:
 
 - `default_positional::input`:
 

--- a/README.md
+++ b/README.md
@@ -179,14 +179,14 @@ Parameters which can be specified for both positional and optional arguments inc
     ```
 
 - `choices` - a list of valid argument values.
-    The `choices` parameter takes a `const std::vector<value_type>&` as an argument.
+    The `choices` parameter takes as an argument an instance of `std::initializer_list` or any `std::ranges::range` type such that its value type is convertible to the argument's `value_type`.
 
     ```c++
     parser.add_optional_argument<char>("method", "m").choices({'a', 'b', 'c'});
     ```
 
 > [!IMPORTANT]
-> To use the `choices` the `value_type` must overload the equaility comparison operator: `==`;
+> The `choices` function can be used only if the argument's `value_type` is equality comparable (defines the `==` operator).
 
 - `action` - a function performed after reading an argument's value.
   Actions are represented as functions, which take the argument's value as an argument. There are two types of actions:

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -125,15 +125,31 @@ public:
 
     /**
      * @brief Set the choices for the optional argument.
-     * @param choices The vector of valid choices for the argument.
+     * @tparam CR The choices range type.
+     * @param choices The range of valid choices for the argument.
      * @return Reference to the optional argument.
-     * @note Requires T to be equality comparable.
+     * @note `value_type` must be equality comparable.
+     * @note `CR` must be a range such that its value type is convertible to `value_type`.
      */
-    optional& choices(const std::vector<value_type>& choices) noexcept
+    template <detail::c_range_of<value_type, detail::type_validator::convertible> CR>
+    optional& choices(const CR& choices) noexcept
     requires(std::equality_comparable<value_type>)
     {
-        this->_choices = choices;
+        for (const auto& choice : choices)
+            this->_choices.emplace_back(choice);
         return *this;
+    }
+
+    /**
+     * @brief Set the choices for the optional argument.
+     * @param choices The list of valid choices for the argument.
+     * @return Reference to the optional argument.
+     * @note `value_type` must be equality comparable.
+     */
+    optional& choices(std::initializer_list<value_type> choices) noexcept
+    requires(std::equality_comparable<value_type>)
+    {
+        return this->choices<>(choices);
     }
 
     /**

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -60,15 +60,31 @@ public:
 
     /**
      * @brief Set the choices for the positional argument.
-     * @param choices The vector of valid choices for the argument.
+     * @tparam CR The choices range type.
+     * @param choices The range of valid choices for the argument.
      * @return Reference to the positional argument.
-     * @note Requires T to be equality comparable.
+     * @note `value_type` must be equality comparable.
+     * @note `CR` must be a range such that its value type is convertible to `value_type`.
      */
-    positional& choices(const std::vector<value_type>& choices) noexcept
+    template <detail::c_range_of<value_type, detail::type_validator::convertible> CR>
+    positional& choices(const CR& choices) noexcept
     requires(std::equality_comparable<value_type>)
     {
-        this->_choices = choices;
+        for (const auto& choice : choices)
+            this->_choices.emplace_back(choice);
         return *this;
+    }
+
+    /**
+     * @brief Set the choices for the positional argument.
+     * @param choices The list of valid choices for the argument.
+     * @return Reference to the positional argument.
+     * @note `value_type` must be equality comparable.
+     */
+    positional& choices(std::initializer_list<value_type> choices) noexcept
+    requires(std::equality_comparable<value_type>)
+    {
+        return this->choices<>(choices);
     }
 
     /**
@@ -85,7 +101,7 @@ public:
         return *this;
     }
 
-    /// @return True if the positional argument is optional., false if required.
+    /// @return True if argument is optional, false otherwise.
     [[nodiscard]] bool is_optional() const noexcept override {
         return this->_optional;
     }

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -89,9 +89,7 @@ public:
     argument_parser& default_positional_arguments(
         std::initializer_list<argument::default_positional> arg_discriminator_list
     ) noexcept {
-        for (const auto arg_discriminator : arg_discriminator_list)
-            detail::add_default_argument(arg_discriminator, *this);
-        return *this;
+        return this->default_positional_arguments<>(arg_discriminator_list);
     }
 
     /**
@@ -115,9 +113,7 @@ public:
     argument_parser& default_optional_arguments(
         std::initializer_list<argument::default_optional> arg_discriminator_list
     ) noexcept {
-        for (const auto arg_discriminator : arg_discriminator_list)
-            detail::add_default_argument(arg_discriminator, *this);
-        return *this;
+        return this->default_optional_arguments<>(arg_discriminator_list);
     }
 
     /**

--- a/include/ap/detail/concepts.hpp
+++ b/include/ap/detail/concepts.hpp
@@ -41,7 +41,7 @@ concept c_one_of = std::disjunction_v<std::is_same<T, Types>...>;
 /**
  * @brief Specifies the type validation rule.
  */
-enum class type_validator : bool {
+enum class type_validator {
     same, ///< Exact type match.
     convertible ///< Implicit conversion allowed.
 };
@@ -52,8 +52,8 @@ enum class type_validator : bool {
  * The primary template of the `is_valid_type_v` helper variable,
  * which does not perform any logic and defaults to `false`.
  *
- * @tparam T The first type.
- * @tparam U The second type.
+ * @tparam T The type to check.
+ * @tparam U The type to check agains.
  * @tparam TV The validation rule.
  */
 template <typename T, typename U, type_validator TV>
@@ -61,16 +61,16 @@ inline constexpr bool is_valid_type_v = false;
 
 /**
  * @brief Checks if `T` and `U` are the same type.
- * @tparam T The first type.
- * @tparam U The second type.
+ * @tparam T The type to check.
+ * @tparam U The type to check agains.
  */
 template <typename T, typename U>
 inline constexpr bool is_valid_type_v<T, U, type_validator::same> = std::same_as<T, U>;
 
 /**
  * @brief Checks if `T` is convertible to `U`.
- * @tparam T The first type.
- * @tparam U The second type.
+ * @tparam T The type to check.
+ * @tparam U The type to check agains.
  */
 template <typename T, typename U>
 inline constexpr bool is_valid_type_v<T, U, type_validator::convertible> =
@@ -78,8 +78,8 @@ inline constexpr bool is_valid_type_v<T, U, type_validator::convertible> =
 
 /**
  * @brief Concept that enforces `is_valid_type_v`.
- * @tparam T The first type.
- * @tparam U The second type.
+ * @tparam T The type to check.
+ * @tparam U The type to check agains.
  * @tparam TV The validation rule (`same` or `convertible`).
  */
 template <typename T, typename U, type_validator TV = type_validator::same>
@@ -94,7 +94,7 @@ concept c_valid_type = is_valid_type_v<T, U, TV>;
 template <typename R, typename V, type_validator TV = type_validator::same>
 concept c_range_of =
     std::ranges::range<R>
-    and c_valid_type<V, std::remove_cvref_t<std::ranges::range_value_t<R>>, TV>;
+    and c_valid_type<std::remove_cvref_t<std::ranges::range_value_t<R>>, V, TV>;
 
 /**
  * @brief Validates that R is a sized range of type T (ignoring the cvref attributes).

--- a/include/ap/detail/concepts.hpp
+++ b/include/ap/detail/concepts.hpp
@@ -41,7 +41,7 @@ concept c_one_of = std::disjunction_v<std::is_same<T, Types>...>;
 /**
  * @brief Specifies the type validation rule.
  */
-enum class type_validator {
+enum class type_validator : bool {
     same, ///< Exact type match.
     convertible ///< Implicit conversion allowed.
 };

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -43,8 +43,8 @@ struct optional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    optional<T>& set_choices(optional<T>& arg, const std::vector<value_type<T>>& choices) const {
-        return arg.choices(choices);
+    void reset_value(optional<T>& arg) const {
+        arg._values.clear();
     }
 
     template <c_argument_value_type T>

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -63,9 +63,8 @@ struct positional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    positional<T>& set_choices(positional<T>& arg, const std::vector<value_type<T>>& choices)
-        const {
-        return arg.choices(choices);
+    void reset_value(positional<T>& arg) const {
+        arg._value.reset();
     }
 
     template <c_argument_value_type T>

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -32,7 +32,7 @@ constexpr std::string invalid_value_str = "invalid value";
 constexpr sut_value_type value_1 = 1;
 constexpr sut_value_type value_2 = 2;
 
-const std::vector<sut_value_type> default_choices{1, 2, 3};
+const std::vector<sut_value_type> choices{1, 2, 3};
 constexpr sut_value_type invalid_choice = 4;
 
 } // namespace
@@ -182,7 +182,7 @@ TEST_CASE_FIXTURE(
     "set_value(any) should throw when the choices set does not contain the parsed value"
 ) {
     auto sut = init_arg(primary_name);
-    set_choices(sut, default_choices);
+    sut.choices(choices);
 
     REQUIRE_THROWS_AS(set_value(sut, invalid_choice), ap::error::invalid_choice);
     CHECK_FALSE(has_value(sut));
@@ -194,21 +194,16 @@ TEST_CASE_FIXTURE(
     "and if the given value is present in the choices set"
 ) {
     auto sut = init_arg(primary_name);
-    set_choices(sut, default_choices);
+    sut.choices(choices);
 
-    sut_value_type value;
+    for (const sut_value_type& value : choices) {
+        reset_value(sut);
+        REQUIRE_FALSE(has_value(sut));
 
-    for (const auto& v : default_choices) {
-        SUBCASE("correct value") {
-            value = v;
-        }
+        REQUIRE_NOTHROW(set_value(sut, value));
+        REQUIRE(has_value(sut));
+        CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value);
     }
-
-    CAPTURE(value);
-
-    REQUIRE_NOTHROW(set_value(sut, value));
-    REQUIRE(has_value(sut));
-    CHECK_EQ(std::any_cast<sut_value_type>(get_value(sut)), value);
 }
 
 TEST_CASE_FIXTURE(


### PR DESCRIPTION
Modified the `choices` functions of the positional and optional arguments to take as input an instance of `std::initializer_list` or a `std::ranges::range` type the value type of which is convertible to the argument's `value_type`