### PR TITLE
YT-CPPAP-31: Add range-based parsing argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,12 @@ The available default arguments are:
 
 ### Parsing arguments
 
-To parse the command-line arguments use the `argument_parser::parse_args` method:
+To parse the command-line arguments use the `void argument_parser::parse_args(const AR& argv)` method, where `AR` must be a type that satisfies `std::ranges::range` and its value type is convertible to `std::string`.
+
+The `argument_parser` class also defines the `void parse_args(int argc, char* argv[])` overload, which works directly with the `argc` and `argv` arguments of the `main` function.
+
+> [!IMPORTANT]
+> The `parse_args(argc, argv)` method ignores the first argument (the program name) and is equivalent to calling `parse_args(std::span(argv + 1, argc - 1))`.
 
 ```c++
 // power.cpp

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -228,7 +228,7 @@ public:
     /**
      * @brief Parses the command-line arguments.
      * @param argc Number of command-line arguments.
-     * @param argv Array of command-line argument strings.
+     * @param argv Array of command-line argument values.
      * @note The first argument (the program name) is ignored.
      */
     void parse_args(int argc, char* argv[]) {
@@ -238,7 +238,7 @@ public:
     /**
      * @brief Parses the command-line arguments.
      * @tparam AR The argument range type.
-     * @param argv A range of command-line arguments.
+     * @param argv A range of command-line argument values.
      */
     template <detail::c_range_of<std::string, detail::type_validator::convertible> AR>
     void parse_args(const AR& argv) {

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -229,9 +229,20 @@ public:
      * @brief Parses the command-line arguments.
      * @param argc Number of command-line arguments.
      * @param argv Array of command-line argument strings.
+     * @note The first argument (the program name) is ignored.
      */
     void parse_args(int argc, char* argv[]) {
-        this->_parse_args_impl(this->_tokenize(std::span(argv + 1, argc - 1)));
+        this->parse_args(std::span(argv + 1, argc - 1));
+    }
+
+    /**
+     * @brief Parses the command-line arguments.
+     * @tparam AR The argument range type.
+     * @param argv A range of command-line arguments.
+     */
+    template <detail::c_range_of<std::string, detail::type_validator::convertible> AR>
+    void parse_args(const AR& argv) {
+        this->_parse_args_impl(this->_tokenize(argv));
 
         if (this->_are_required_args_bypassed())
             return;


### PR DESCRIPTION
- Added the range-based overload of the `parse_args` method, which defines the parsing logic
- Aligned the `parse_args(argc, argv)` method to call the range-based function with a span constructed from `argc` and `argv`