### PR TITLE
CPP-AP: version 2.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.12)
 
-# Check if CPP-AP is a top level project
 if (NOT DEFINED PROJECT_NAME)
     set(CPP_AP_IS_TOP_LEVEL_PROJECT ON)
 else()
@@ -18,12 +17,12 @@ project(cpp-ap
 option(BUILD_TESTS "Build project tests" OFF)
 
 # The library target
-add_library(cpp-ap INTERFACE)
-target_include_directories(cpp-ap INTERFACE
+add_library(cpp-ap-2 INTERFACE)
+target_include_directories(cpp-ap-2 INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-set_target_properties(cpp-ap PROPERTIES
+set_target_properties(cpp-ap-2 PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
@@ -32,49 +31,49 @@ set_target_properties(cpp-ap PROPERTIES
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/cpp-ap)
+set(INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/cpp-ap-2)
 
 # Install the headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Install the library target
-install(TARGETS cpp-ap EXPORT cpp-ap-targets)
+install(TARGETS cpp-ap-2 EXPORT cpp-ap-2-targets)
 
-# Create a Config file for find_package
+# Create a config file for find_package
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpp-ap-config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpp-ap-2-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config.cmake
     INSTALL_DESTINATION ${INSTALL_DIR}
 )
 
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config-version.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY ExactVersion
 )
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config-version.cmake
     DESTINATION ${INSTALL_DIR}
 )
 
-install(EXPORT cpp-ap-targets
-    FILE cpp-ap-targets.cmake
-    NAMESPACE cpp-ap::
+install(EXPORT cpp-ap-2-targets
+    FILE cpp-ap-2-targets.cmake
+    NAMESPACE cpp-ap-2::
     DESTINATION ${INSTALL_DIR}
 )
 
-# Include the tests directory if CPP-AP is a top level project
+# Include the tests directory if CPP-AP is a top-level project
 if (CPP_AP_IS_TOP_LEVEL_PROJECT AND BUILD_TESTS)
     add_subdirectory(tests)
 endif()
 
 # Exporting from the build tree
-export(EXPORT cpp-ap-targets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-targets.cmake
-    NAMESPACE cpp-ap::
+export(EXPORT cpp-ap-2-targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-targets.cmake
+    NAMESPACE cpp-ap-2::
 )
 
-export(PACKAGE cpp-ap)
+export(PACKAGE cpp-ap-2)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Command-line argument parser for C++20
 <br />
 <br />
 
-## Table of contents
+## Table of Contents
 
 - [Tutorial](#tutorial)
   - [Including CPP-AP into a project](#including-cpp-ap-into-a-project)
@@ -81,8 +81,8 @@ set_target_properties(my_project PROPERTIES
     CXX_STANDARD_REQUIRED YES
 )
 
-# Link against the cpp-ap library
-target_link_libraries(my_project PRIVATE cpp-ap)
+# Link against the cpp-ap (v2) library
+target_link_libraries(my_project PRIVATE cpp-ap-2)
 ```
 
 #### Downloading the library

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# CPP-AP
+# CPP-AP-2
 
 Command-line argument parser for C++20
 
@@ -27,6 +27,7 @@ Command-line argument parser for C++20
 
 ## Table of Contents
 
+- [Key Changes in v2](#key-changes-in-v2)
 - [Tutorial](#tutorial)
   - [Including CPP-AP into a project](#including-cpp-ap-into-a-project)
     - [CMake integration](#cmake-integration)
@@ -44,6 +45,39 @@ Command-line argument parser for C++20
 - [Documentation](#documentation)
 - [Compiler support](#compiler-compatibilty)
 - [License](#license)
+
+<br />
+<br />
+
+## Key Changes in v2
+
+### The Structure
+
+The *v2* version of the library no longer uses a single-header approach, however it is still a header-only library. With this change it is now required to download the entire library - either with [CMake](#cmake-integration) or from the [releases page](https://github.com/SpectraL519/cpp-ap/releases).
+
+### Range-based Approach
+
+Aligned functions to use a generic range-based approach, which allows for more flexibility in using the library.
+
+| **Function** | **Description** |
+| :- | :- |
+| <pre>argument_parser::parse_args(<br/>    const AR& argv<br/>)</pre> | <div align="center">**New**</div>Parses the command-line arguments passed through a range of string-convertible objects.<br/>**NOTE:** The `parse_args(argc, argv)` function is still available. |
+| <pre>argument::positional::choices(<br/>    std::initializer_list&lt;value_type&gt; choices<br/>)</pre> | <div align="center">**Aligned**</div>Sets the *choices* parameter of a positional argument.<br/>**NOTE:** Previously the function used `std::vector<value_type>`. |
+| <pre>argument::positional::choices(<br/>    const CR& choices<br/>)</pre> | <div align="center">**New**</div>Sets the *choices* parameter of a positional argument using a range of `value_type`-convertible objects. |
+| <pre>argument::optional::choices(<br/>    std::initializer_list&lt;value_type&gt; choices<br/>)</pre> | <div align="center">**Aligned**</div>Sets the *choices* parameter of an optional argument.<br/>**NOTE:** Previously the function used `std::vector<value_type>`. |
+| <pre>argument::optional::choices(<br/>    const CR& choices<br/>)</pre> | <div align="center">**New**</div>Sets the *choices* parameter of an optional argument using a range of `value_type`-convertible objects. |
+
+### New Utility Functions
+
+Added utility functions to the `argument_parser` class that encapsulate common behavior, reducing the need to write boilerplate code and simplifying the argument-parsing logic.
+
+| **Function** | **Description** |
+| :- | :- |
+| <pre>void try_parse_args(int argc, char* argv[])<br/>void try_parse_args(const AR& argv)</pre> | Parses the command-line arguments and, in case of an error, prints the error message and exits with a failure status. |
+| <pre>void handle_help_action()</pre> | Checks the value of the `help` boolean flag argument and exits with success status if the value is `true`. |
+| <pre>T value_or<T, U>(<br/>    std::string_view arg_name, U&& default_value<br/>)</pre> | Returns the argument's value if possible and `default_value` otherwise. |
+
+A more detailed explanation of these functions is available in the [Tutorial](#tutorial) section.
 
 <br />
 <br />

--- a/README.md
+++ b/README.md
@@ -322,7 +322,7 @@ The available default arguments are:
 
 > [!NOTE]
 > As of now the *on flag/use action* functionality is not implemented in the library - this will be added in a future release.
-> To properly use the help argument in the current release add the, use the `parser.handle_help_action()` method right beneath the `parser.parse_args(argc, argv)` try-catch block. This would be equivalent to:
+> To properly use the help argument in the current release add the, use the `parser.handle_help_action()` method after parsing the arguments. This would be equivalent to:
 >
 > ```c++
 > if (parser.value<bool>("help")) {
@@ -379,6 +379,19 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 > [!IMPORTANT]
 > The `parse_args(argc, argv)` method ignores the first argument (the program name) and is equivalent to calling `parse_args(std::span(argv + 1, argc - 1))`.
 
+> [!TIP]
+> The `argument_parser` class defines `try_parse_args` methods, which are equivalent to:
+>
+> ```c++
+> try {
+>     parser.parse_args(...);
+> }
+> catch (const ap::argument_parser_exception& err) {
+>     std::cerr << "[ERROR] : " << err.what() << std::endl << parser << std::endl;
+>     std::exit(EXIT_FAILURE);
+> }
+> ```
+
 ```c++
 // power.cpp
 #include <ap/argument_parser.hpp>
@@ -401,13 +414,7 @@ int main(int argc, char* argv[]) {
     parser.default_optional_arguments({ap::argument::default_optional::help});
 
     // parse command-line arguments
-    try {
-        parser.parse_args(argc, argv);
-    }
-    catch (const ap::argument_parser_exception& err) {
-        std::cerr << "[ERROR] : " << err.what() << std::endl << parser << std::endl;
-        std::exit(EXIT_FAILURE);
-    }
+    parser.try_parse_args(argc, argv);
 
     // handle the `help` argument
     parser.handle_help_action();

--- a/README.md
+++ b/README.md
@@ -414,7 +414,9 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 > The `parse_args(argc, argv)` method ignores the first argument (the program name) and is equivalent to calling `parse_args(std::span(argv + 1, argc - 1))`.
 
 > [!TIP]
-> The `argument_parser` class defines `try_parse_args` methods, which are equivalent to:
+> The `parse_args` functions may throw an `ap::argument_parser_exception` if the provided command-line arguments do not match the expected configuration. To simplify error handling, the `argument_parser` class provides `try_parse_args` methods, which automatically catch these exceptions, print the error message, and exit with a failure status.
+>
+> Internally, This is equivalent to:
 >
 > ```c++
 > try {

--- a/README.md
+++ b/README.md
@@ -321,8 +321,8 @@ The available default arguments are:
   ```
 
 > [!NOTE]
-> As of now the *on flag action* functionality is not implemented in the library - this will be added in a future release.
-> To properly use the help argument in the current release add the following right beneath the `parser.parse_args(argc, argv)` try-catch block:
+> As of now the *on flag/use action* functionality is not implemented in the library - this will be added in a future release.
+> To properly use the help argument in the current release add the, use the `parser.handle_help_action()` method right beneath the `parser.parse_args(argc, argv)` try-catch block. This would be equivalent to:
 >
 > ```c++
 > if (parser.value<bool>("help")) {
@@ -409,11 +409,8 @@ int main(int argc, char* argv[]) {
         std::exit(EXIT_FAILURE);
     }
 
-    // check for the help argument presence
-    if (parser.value<bool>("help")) {
-        std::cout << parser << std::endl;
-        std::exit(EXIT_SUCCESS);
-    }
+    // handle the `help` argument
+    parser.handle_help_action();
 
     // check if any values for the `exponent` argument have been parsed
     if (not parser.has_value("exponent")) {

--- a/cmake/cpp-ap-2-config.cmake.in
+++ b/cmake/cpp-ap-2-config.cmake.in
@@ -4,4 +4,4 @@ include(CMakeFindDependencyMacro)
 
 set_and_check(CPP_AP_INCLUDE_DIR "@PACKAGE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")
 
-include("${CMAKE_CURRENT_LIST_DIR}/cpp-ap-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cpp-ap-2-targets.cmake")

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -251,6 +251,43 @@ public:
         this->_check_nvalues_in_range();
     }
 
+    /**
+     * @brief Parses the command-line arguments and exits on error.
+     * @param argc Number of command-line arguments.
+     * @param argv Array of command-line argument values.
+     * @note The first argument (the program name) is ignored.
+     */
+    void try_parse_args(int argc, char* argv[]) {
+        this->try_parse_args(std::span(argv + 1, argc - 1));
+    }
+
+    /**
+     * @brief Parses the command-line arguments and exits on error.
+     *
+     * Calls `parse_args(argv)` in a try-catch block. If an error is thrown, then its
+     * message and the parser are printed to `std::cerr` and the function exists with
+     * `EXIT_FAILURE` status.
+     *
+     * @tparam AR The argument range type.
+     * @param argv A range of command-line argument values.
+     */
+    template <detail::c_range_of<std::string, detail::type_validator::convertible> AR>
+    void try_parse_args(const AR& argv) {
+        try {
+            this->parse_args(argv);
+        }
+        catch (const ap::argument_parser_exception& err) {
+            std::cerr << "[ERROR] : " << err.what() << std::endl << *this << std::endl;
+            std::exit(EXIT_FAILURE);
+        }
+    }
+
+    /**
+     * @brief Handles the `help` argument logic.
+     *
+     * Extracts the value of the `help` boolean flag argument and if the value `is` true,
+     * prints the parser to `std::cout` anb exists with `EXIT_SUCCESS` status.
+     */
     void handle_help_action() const noexcept {
         if (this->value<bool>("help")) {
             std::cout << *this << std::endl;
@@ -635,7 +672,7 @@ inline void add_default_argument(
 ) noexcept {
     switch (arg_discriminator) {
     case argument::default_optional::help:
-        arg_parser.add_flag("help", "h").bypass_required().help("Display help message");
+        arg_parser.add_flag("help", "h").bypass_required().help("Display the help message");
         break;
 
     case argument::default_optional::input:

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -285,7 +285,7 @@ public:
     /**
      * @brief Handles the `help` argument logic.
      *
-     * Extracts the value of the `help` boolean flag argument and if the value `is` true,
+     * Checks the value of the `help` boolean flag argument and if the value `is` true,
      * prints the parser to `std::cout` anb exists with `EXIT_SUCCESS` status.
      */
     void handle_help_action() const noexcept {

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -251,6 +251,13 @@ public:
         this->_check_nvalues_in_range();
     }
 
+    void handle_help_action() const noexcept {
+        if (this->value<bool>("help")) {
+            std::cout << *this << std::endl;
+            std::exit(EXIT_SUCCESS);
+        }
+    }
+
     /**
      * @param arg_name The name of the argument.
      * @return True if the argument has a value, false otherwise.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,4 +33,4 @@ set_target_properties(run PROPERTIES
     CXX_EXTENSIONS NO
 )
 target_include_directories(run PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(run PRIVATE cpp-ap)
+target_link_libraries(run PRIVATE cpp-ap-2)


### PR DESCRIPTION
- Introduced the minor value in the version tags
- Changed the CMake target names to `cpp-ap-2`
- Added the `try_parse_args` and `handle_help_action` functions to the `argument_parser` class