### PR TITLE
YT-CPPAP-34: Add argument name pattern verification

### DIFF
--- a/include/ap/action/predefined_actions.hpp
+++ b/include/ap/action/predefined_actions.hpp
@@ -17,7 +17,10 @@ detail::callable_type<ap::action_type::modify, T> none() noexcept {
     return [](T&) {};
 }
 
-/// @brief Returns a predefined action for file name handling arguments. Checks whether a file with the given name exists.
+/**
+ * @brief Returns a predefined action for file name handling arguments. Checks whether a file with the given name exists.
+ * @throws ap::argument_parser_exception
+ */
 inline detail::callable_type<ap::action_type::modify, std::string> check_file_exists() noexcept {
     return [](std::string& file_path) {
         if (not std::filesystem::exists(file_path))

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -229,8 +229,14 @@ private:
      * @brief Set the value for the optional argument.
      * @param str_value The string value to set.
      * @return Reference to the optional argument.
+     * @throws ap::error::value_already_set
+     * @throws ap::error::invalid_value
+     * @throws ap::error::invalid_choice
      */
     optional& set_value(const std::string& str_value) override {
+        if (not (this->_nargs_range or this->_values.empty()))
+            throw error::value_already_set(this->_name);
+
         this->_ss.clear();
         this->_ss.str(str_value);
 
@@ -242,9 +248,6 @@ private:
             throw error::invalid_choice(this->_name, str_value);
 
         this->_apply_action(value);
-
-        if (not (this->_nargs_range or this->_values.empty()))
-            throw error::value_already_set(this->_name);
 
         this->_values.emplace_back(std::move(value));
         return *this;
@@ -287,7 +290,10 @@ private:
             or (this->is_used() and this->_implicit_value.has_value());
     }
 
-    /// @return Reference to the predefined value of the optional argument.
+    /**
+     * @return Reference to the predefined value of the optional argument.
+     * @throws std::logic_error
+     */
     [[nodiscard]] const std::any& _predefined_value() const {
         if (this->is_used()) {
             if (not this->_implicit_value.has_value())

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -158,6 +158,9 @@ private:
      * @brief Set the value for the positional argument.
      * @param str_value The string representation of the value.
      * @return Reference to the positional argument.
+     * @throws ap::error::value_already_set
+     * @throws ap::error::invalid_value
+     * @throws ap::error::invalid_choice
      */
     positional& set_value(const std::string& str_value) override {
         if (this->_value.has_value())
@@ -194,7 +197,10 @@ private:
         return this->_value.has_value() ? std::weak_ordering::equivalent : std::weak_ordering::less;
     }
 
-    /// @brief Get the stored value of the positional argument.
+    /**
+     * @brief Get the stored value of the positional argument.
+     * @throws std::logic_error
+     */
     [[nodiscard]] const std::any& value() const override {
         if (not this->_value.has_value())
             throw std::logic_error(
@@ -203,7 +209,10 @@ private:
         return this->_value;
     }
 
-    /// @return Reference to the vector of parsed values for the positional argument.
+    /**
+     * @return Reference to the vector of parsed values for the positional argument.
+     * @throws std::logic_error
+     */
     [[nodiscard]] const std::vector<std::any>& values() const override {
         throw std::logic_error(
             std::format("Positional argument `{}` has only 1 value.", this->_name.primary)

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -437,6 +437,10 @@ private:
     using arg_token_list_t = std::vector<detail::argument_token>;
     using arg_token_list_iterator_t = typename arg_token_list_t::const_iterator;
 
+    /**
+     * @brief Verifies the pattern of an argument name and if it's invalid, an error is thrown
+     * @throws ap::error::invalid_argument_name_pattern
+     */
     void _verify_arg_name_pattern(const std::string_view arg_name) const {
         if (arg_name.empty())
             throw error::invalid_argument_name_pattern(

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -121,6 +121,7 @@ public:
      * @tparam T Type of the argument value.
      * @param primary_name The primary name of the argument.
      * @return Reference to the added positional argument.
+     * @throws ap::error::invalid_argument_name_pattern
      * @throws ap::error::argument_name_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
@@ -143,7 +144,8 @@ public:
      * @param primary_name The primary name of the argument.
      * @param secondary_name The secondary name of the argument.
      * @return Reference to the added positional argument.
-     * @throws ap::error::argument_name_is_used
+     * @throws ap::error::invalid_argument_name_pattern
+     * @throws ap::error::argument_name_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -167,7 +169,8 @@ public:
      * @tparam T Type of the argument value.
      * @param primary_name The primary name of the argument.
      * @return Reference to the added optional argument.
-     * @throws ap::error::argument_name_is_used
+     * @throws ap::error::invalid_argument_name_pattern
+     * @throws ap::error::argument_name_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -189,7 +192,8 @@ public:
      * @param primary_name The primary name of the argument.
      * @param secondary_name The secondary name of the argument.
      * @return Reference to the added optional argument.
-     * @throws ap::error::argument_name_is_used
+     * @throws ap::error::invalid_argument_name_pattern
+     * @throws ap::error::argument_name_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -209,8 +213,8 @@ public:
     }
 
     /**
-     * @brief Adds a boolean flag argument to the parser's configuration.
-     * @tparam StoreImplicitly Flag indicating whether to store implicitly.
+     * @brief Adds a boolean flag argument (an optional argument with `value_type = bool`) to the parser's configuration.
+     * @tparam StoreImplicitly A boolean value used as the `implicit_value` parameter of the argument.
      * @param primary_name The primary name of the flag.
      * @return Reference to the added boolean flag argument.
      */
@@ -223,8 +227,8 @@ public:
     }
 
     /**
-     * @brief Adds a boolean flag argument to the parser's configuration.
-     * @tparam StoreImplicitly Flag indicating whether to store implicitly.
+     * @brief Adds a boolean flag argument (an optional argument with `value_type = bool`) to the parser's configuration.
+     * @tparam StoreImplicitly A boolean value used as the `implicit_value` parameter of the argument.
      * @param primary_name The primary name of the flag.
      * @param secondary_name The secondary name of the flag.
      * @return Reference to the added boolean flag argument.

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -126,6 +126,8 @@ public:
      */
     template <detail::c_argument_value_type T = std::string>
     argument::positional<T>& add_positional_argument(std::string_view primary_name) {
+        this->_verify_arg_name_pattern(primary_name);
+
         const detail::argument_name arg_name = {primary_name};
         if (this->_is_arg_name_used(arg_name))
             throw error::argument_name_used(arg_name);
@@ -147,6 +149,9 @@ public:
     argument::positional<T>& add_positional_argument(
         std::string_view primary_name, std::string_view secondary_name
     ) {
+        this->_verify_arg_name_pattern(primary_name);
+        this->_verify_arg_name_pattern(secondary_name);
+
         const detail::argument_name arg_name = {primary_name, secondary_name};
         if (this->_is_arg_name_used(arg_name))
             throw error::argument_name_used(arg_name);
@@ -165,6 +170,8 @@ public:
      */
     template <detail::c_argument_value_type T = std::string>
     argument::optional<T>& add_optional_argument(std::string_view primary_name) {
+        this->_verify_arg_name_pattern(primary_name);
+
         const detail::argument_name arg_name = {primary_name};
         if (this->_is_arg_name_used(arg_name))
             throw error::argument_name_used(arg_name);
@@ -186,6 +193,9 @@ public:
     argument::optional<T>& add_optional_argument(
         std::string_view primary_name, std::string_view secondary_name
     ) {
+        this->_verify_arg_name_pattern(primary_name);
+        this->_verify_arg_name_pattern(secondary_name);
+
         const detail::argument_name arg_name = {primary_name, secondary_name};
         if (this->_is_arg_name_used(arg_name))
             throw error::argument_name_used(arg_name);
@@ -427,12 +437,33 @@ private:
     using arg_token_list_t = std::vector<detail::argument_token>;
     using arg_token_list_iterator_t = typename arg_token_list_t::const_iterator;
 
+    void _verify_arg_name_pattern(const std::string_view arg_name) const {
+        if (arg_name.empty())
+            throw error::invalid_argument_name_pattern(
+                arg_name, "An argument name cannot be empty."
+            );
+
+        if (arg_name.front() == this->_flag_prefix_char)
+            throw error::invalid_argument_name_pattern(
+                arg_name,
+                std::format(
+                    "An argument name cannot begin with a flag prefix character ({}).",
+                    this->_flag_prefix_char
+                )
+            );
+
+        if (std::isdigit(arg_name.front()))
+            throw error::invalid_argument_name_pattern(
+                arg_name, "An argument name cannot begin with a digit."
+            );
+    }
+
     /**
      * @brief Returns a unary predicate function which checks if the given name matches the argument's name
      * @param arg_name The name of the argument.
      * @return Argument predicate based on the provided name.
      */
-    [[nodiscard]] auto _name_match_predicate(std::string_view arg_name) const noexcept {
+    [[nodiscard]] auto _name_match_predicate(const std::string_view arg_name) const noexcept {
         return [arg_name](const arg_ptr_t& arg) { return arg->name().match(arg_name); };
     }
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -121,6 +121,7 @@ public:
      * @tparam T Type of the argument value.
      * @param primary_name The primary name of the argument.
      * @return Reference to the added positional argument.
+     * @throws ap::error::argument_name_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -142,6 +143,7 @@ public:
      * @param primary_name The primary name of the argument.
      * @param secondary_name The secondary name of the argument.
      * @return Reference to the added positional argument.
+     * @throws ap::error::argument_name_is_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -165,6 +167,7 @@ public:
      * @tparam T Type of the argument value.
      * @param primary_name The primary name of the argument.
      * @return Reference to the added optional argument.
+     * @throws ap::error::argument_name_is_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -186,6 +189,7 @@ public:
      * @param primary_name The primary name of the argument.
      * @param secondary_name The secondary name of the argument.
      * @return Reference to the added optional argument.
+     * @throws ap::error::argument_name_is_used
      *
      * \todo Check forbidden characters (after adding the assignment character).
      */
@@ -327,6 +331,8 @@ public:
      * @tparam T Type of the argument value.
      * @param arg_name The name of the argument.
      * @return The value of the argument.
+     * @throws ap::error::argument_not_found
+     * @throws ap::error::invalid_value_type
      */
     template <detail::c_argument_value_type T = std::string>
     T value(std::string_view arg_name) const {
@@ -349,6 +355,8 @@ public:
      * @param arg_name The name of the argument.
      * @param default_value The default value.
      * @return The value of the argument.
+     * @throws ap::error::argument_not_found
+     * @throws ap::error::invalid_value_type
      */
     template <detail::c_argument_value_type T = std::string, std::convertible_to<T> U>
     T value_or(std::string_view arg_name, U&& default_value) const {
@@ -374,6 +382,8 @@ public:
      * @tparam T Type of the argument values.
      * @param arg_name The name of the argument.
      * @return The values of the argument as a vector.
+     * @throws ap::error::argument_not_found
+     * @throws ap::error::invalid_value_type
      */
     template <detail::c_argument_value_type T = std::string>
     std::vector<T> values(std::string_view arg_name) const {
@@ -586,6 +596,8 @@ private:
      * @brief Parse optional arguments based on command-line input.
      * @param arg_tokens The list of command-line argument tokens.
      * @param token_it Iterator for iterating through command-line argument tokens.
+     * @throws ap::error::argument_not_found
+     * @throws ap::error::free_value
      */
     void _parse_optional_args(
         const arg_token_list_t& arg_tokens, arg_token_list_iterator_t& token_it
@@ -625,7 +637,10 @@ private:
         });
     }
 
-    /// @brief Check if all required positional and optional arguments are used.
+    /**
+     * @brief Check if all required positional and optional arguments are used.
+     * @throws ap::error::required_argument_not_parsed
+     */
     void _check_required_args() const {
         for (const auto& arg : this->_positional_args)
             if (not arg->is_used())
@@ -636,7 +651,10 @@ private:
                 throw error::required_argument_not_parsed(arg->name());
     }
 
-    /// @brief Check if the number of argument values is within the specified range.
+    /**
+     * @brief Check if the number of argument values is within the specified range.
+     * @throws ap::error::invalid_nvalues
+     */
     void _check_nvalues_in_range() const {
         for (const auto& arg : this->_positional_args) {
             const auto nvalues_ordering = arg->nvalues_in_range();

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -68,6 +68,16 @@ public:
       ) {}
 };
 
+class invalid_argument_name_pattern : public argument_parser_exception {
+public:
+    explicit invalid_argument_name_pattern(
+        const std::string_view arg_name, const std::string_view reason
+    )
+    : argument_parser_exception(
+          std::format("Given name `{}` is invalid.\nReason: {}", arg_name, reason)
+      ) {}
+};
+
 /// @brief Exception thrown when there is a collision in argument names.
 class argument_name_used : public argument_parser_exception {
 public:

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -19,7 +19,6 @@ namespace ap {
 class argument_parser_exception : public std::runtime_error {
 public:
     /**
-     * @brief Constructor for the argument_parser_exception class.
      * @param message A descriptive error message providing information about the exception.
      */
     explicit argument_parser_exception(const std::string& message) : std::runtime_error(message) {}
@@ -31,7 +30,6 @@ namespace error {
 class value_already_set : public argument_parser_exception {
 public:
     /**
-     * @brief Constructor for the value_already_set class.
      * @param arg_name The name of the argument that already has a value set.
      */
     explicit value_already_set(const detail::argument_name& arg_name)
@@ -44,7 +42,6 @@ public:
 class invalid_value : public argument_parser_exception {
 public:
     /**
-     * @brief Constructor for the invalid_value class.
      * @param arg_name The name of the argument for which the value parsing failed.
      * @param value The value that failed to parse.
      */
@@ -58,7 +55,6 @@ public:
 class invalid_choice : public argument_parser_exception {
 public:
     /**
-     * @brief Constructor for the invalid_choice class.
      * @param arg_name The name of the argument for which the value is not in choices.
      * @param value The value that is not in the allowed choices.
      */
@@ -68,8 +64,13 @@ public:
       ) {}
 };
 
+/// @brief Exception thrown when an argument name string pattern is invalid.
 class invalid_argument_name_pattern : public argument_parser_exception {
 public:
+    /**
+     * @param arg_name The name of the argument, the pattern of which is invalid.
+     * @param reaseon The reason why the pattern of the given argument name is invalid.
+     */
     explicit invalid_argument_name_pattern(
         const std::string_view arg_name, const std::string_view reason
     )
@@ -82,7 +83,6 @@ public:
 class argument_name_used : public argument_parser_exception {
 public:
     /**
-     * @brief Constructor for the argument_name_used class.
      * @param arg_name The name of the argument causing the collision.
      */
     explicit argument_name_used(const detail::argument_name& arg_name)
@@ -93,7 +93,6 @@ public:
 class argument_not_found : public argument_parser_exception {
 public:
     /**
-     * @brief Constructor for the argument_name_not_found_error class.
      * @param arg_name The name of the argument that was not found.
      */
     explicit argument_not_found(const std::string_view& arg_name)


### PR DESCRIPTION
Adder the argument name verification functionality to the `argument_parser` class - an error is thrown if `argument_parser::add_*` is called with a name that:
- is empty
- begins with the flag prefix character
- begins with a digit