### PR TITLE
YT-CPPAP-36: Improve value assignment logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.2.0
+    VERSION 2.2.1
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "CPP-AP"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.2.0
+PROJECT_NUMBER         = 2.2.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -258,9 +258,9 @@ Apart from the common parameters listed above, for optional arguments you can al
     parser.add_optional_argument("input", "i").nargs(ap::nargs::any());
     ```
 
-> [!NOTE]
+> [!IMPORTANT]
 >
-> The default nargs value is `1`.
+> The default `nargs` parameter value is `ap::nargs::any()`.
 
 #### `default_value` - The default value for an argument which will be used if no values for this argument are parsed
 

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -380,7 +380,7 @@ private:
     std::vector<flag_action_type> _flag_actions;
     std::vector<value_action_type> _value_actions;
 
-    std::size_t _nused = 0u;
+    std::size_t _nused = 0ull;
     std::vector<std::any> _values;
 };
 

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -252,10 +252,11 @@ private:
     }
 
     /// @brief Mark the optional argument as used.
-    void mark_used() override {
+    bool mark_used() override {
         ++this->_nused;
         for (const auto& action : this->_flag_actions)
             action();
+        return true;
     }
 
     /// @return True if the optional argument is used, false otherwise.
@@ -276,7 +277,7 @@ private:
      * @throws ap::error::invalid_value
      * @throws ap::error::invalid_choice
      */
-    optional& set_value(const std::string& str_value) override {
+    bool set_value(const std::string& str_value) override {
         if (not (this->_nargs_range or this->_values.empty()))
             throw error::value_already_set(this->_name);
 
@@ -295,7 +296,7 @@ private:
             std::visit(apply_visitor, action);
 
         this->_values.emplace_back(std::move(value));
-        return *this;
+        return true;
     }
 
     /// @return True if the optional argument has a value, false otherwise.

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -253,20 +253,20 @@ private:
 
     /// @brief Mark the optional argument as used.
     bool mark_used() override {
-        ++this->_nused;
+        ++this->_count;
         for (const auto& action : this->_flag_actions)
             action();
-        return true;
+        return this->_accepts_further_values();
     }
 
     /// @return True if the optional argument is used, false otherwise.
     [[nodiscard]] bool is_used() const noexcept override {
-        return this->_nused > 0;
+        return this->_count > 0;
     }
 
     /// @return The number of times the optional argument is used.
-    [[nodiscard]] std::size_t nused() const noexcept override {
-        return this->_nused;
+    [[nodiscard]] std::size_t count() const noexcept override {
+        return this->_count;
     }
 
     /**
@@ -380,7 +380,7 @@ private:
     std::vector<flag_action_type> _flag_actions;
     std::vector<value_action_type> _value_actions;
 
-    std::size_t _nused = 0ull;
+    std::size_t _count = 0ull;
     std::vector<std::any> _values;
 };
 

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -173,7 +173,7 @@ private:
     }
 
     /// @return The number of times the positional argument is used.
-    [[nodiscard]] std::size_t nused() const noexcept override {
+    [[nodiscard]] std::size_t count() const noexcept override {
         return static_cast<std::size_t>(this->_value.has_value());
     }
 
@@ -201,7 +201,7 @@ private:
             std::visit(apply_visitor, action);
 
         this->_value = value;
-        return true;
+        return false;
     }
 
     /// @return True if the positional argument has a value, false otherwise.

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -189,11 +189,8 @@ private:
         if (this->_value.has_value())
             throw error::value_already_set(this->_name);
 
-        this->_ss.clear();
-        this->_ss.str(str_value);
-
         value_type value;
-        if (not (this->_ss >> value))
+        if (not (std::istringstream(str_value) >> value))
             throw error::invalid_value(this->_name, str_value);
 
         if (not this->_is_valid_choice(value))
@@ -218,7 +215,7 @@ private:
     }
 
     /// @return Ordering relationship of positional argument range.
-    [[nodiscard]] std::weak_ordering nvalues_in_range() const noexcept override {
+    [[nodiscard]] std::weak_ordering nvalues_ordering() const noexcept override {
         return this->_value.has_value() ? std::weak_ordering::equivalent : std::weak_ordering::less;
     }
 
@@ -266,8 +263,6 @@ private:
     std::vector<value_action_type> _value_actions;
 
     std::any _value; ///< Stored value of the positional argument.
-
-    std::stringstream _ss; ///< Stringstream used for parsing values.
 };
 
 } // namespace ap::argument

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -163,7 +163,9 @@ private:
      * @brief Mark the positional argument as used.
      * @note No logic is performed for positional arguments
      */
-    void mark_used() override {}
+    bool mark_used() override {
+        return false;
+    }
 
     /// @return True if the positional argument is used, false otherwise.
     [[nodiscard]] bool is_used() const noexcept override {
@@ -183,7 +185,7 @@ private:
      * @throws ap::error::invalid_value
      * @throws ap::error::invalid_choice
      */
-    positional& set_value(const std::string& str_value) override {
+    bool set_value(const std::string& str_value) override {
         if (this->_value.has_value())
             throw error::value_already_set(this->_name);
 
@@ -202,7 +204,7 @@ private:
             std::visit(apply_visitor, action);
 
         this->_value = value;
-        return *this;
+        return true;
     }
 
     /// @return True if the positional argument has a value, false otherwise.

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -349,7 +349,7 @@ public:
      */
     [[nodiscard]] std::size_t count(std::string_view arg_name) const noexcept {
         const auto arg_opt = this->_get_argument(arg_name);
-        return arg_opt ? arg_opt->get().nused() : 0ull;
+        return arg_opt ? arg_opt->get().count() : 0ull;
     }
 
     /**

--- a/include/ap/detail/argument_descriptor.hpp
+++ b/include/ap/detail/argument_descriptor.hpp
@@ -74,7 +74,7 @@ public:
         const R& range,
         const std::string_view delimiter = default_delimiter
     ) {
-        this->params.emplace_back(name, join_with(range, delimiter));
+        this->params.emplace_back(name, join(range, delimiter));
     }
 
     /**
@@ -151,7 +151,7 @@ private:
         oss << this->get_basic(indent_width);
         if (not this->params.empty()) {
             oss << " ("
-                << join_with(this->params | std::views::transform(
+                << join(this->params | std::views::transform(
                     [](const auto& param) { return std::format("{}: {}", param.name, param.value); }
                 ))
                 << ")";

--- a/include/ap/detail/argument_interface.hpp
+++ b/include/ap/detail/argument_interface.hpp
@@ -60,7 +60,8 @@ protected:
     virtual bool bypass_required_enabled() const noexcept = 0;
 
     /// @brief Mark the argument as used.
-    virtual void mark_used() = 0;
+    // ? return true if argument can still accept values
+    virtual bool mark_used() = 0;
 
     /// @return True if the argument has been used, false otherwise.
     virtual bool is_used() const noexcept = 0;
@@ -73,7 +74,8 @@ protected:
      * @param value The string representation of the value.
      * @return Reference to the argument_interface.
      */
-    virtual argument_interface& set_value(const std::string& value) = 0;
+    // ? return true if argument can still accept values
+    virtual bool set_value(const std::string& value) = 0;
 
     /// @return True if the argument has a value, false otherwise.
     virtual bool has_value() const noexcept = 0;

--- a/include/ap/detail/argument_interface.hpp
+++ b/include/ap/detail/argument_interface.hpp
@@ -59,23 +59,23 @@ protected:
     /// @return True if bypassing the required status is enabled for the argument, false otherwise.
     virtual bool bypass_required_enabled() const noexcept = 0;
 
-    /// @brief Mark the argument as used.
-    // ? return true if argument can still accept values
+    /**
+     * @brief Mark the argument as used.
+     * @return `true` if the argument accepts further values, `false` otherwise.
+     */
     virtual bool mark_used() = 0;
 
     /// @return True if the argument has been used, false otherwise.
     virtual bool is_used() const noexcept = 0;
 
     /// @return The number of times the positional argument is used.
-    // TODO: rename to count
-    virtual std::size_t nused() const noexcept = 0;
+    virtual std::size_t count() const noexcept = 0;
 
     /**
      * @brief Set the value for the argument.
      * @param value The string representation of the value.
-     * @return Reference to the argument_interface.
+     * @return `true` if the argument accepts further values, `false` otherwise.
      */
-    // ? return true if argument can still accept values
     virtual bool set_value(const std::string& value) = 0;
 
     /// @return True if the argument has a value, false otherwise.

--- a/include/ap/detail/argument_interface.hpp
+++ b/include/ap/detail/argument_interface.hpp
@@ -67,6 +67,7 @@ protected:
     virtual bool is_used() const noexcept = 0;
 
     /// @return The number of times the positional argument is used.
+    // TODO: rename to count
     virtual std::size_t nused() const noexcept = 0;
 
     /**
@@ -84,7 +85,7 @@ protected:
     virtual bool has_parsed_values() const noexcept = 0;
 
     /// @return The ordering relationship of argument range.
-    virtual std::weak_ordering nvalues_in_range() const noexcept = 0;
+    virtual std::weak_ordering nvalues_ordering() const noexcept = 0;
 
     /// @return Reference to the stored value of the argument.
     virtual const std::any& value() const = 0;

--- a/include/ap/detail/str_utility.hpp
+++ b/include/ap/detail/str_utility.hpp
@@ -34,11 +34,11 @@ template <c_writable T>
  * @param range The input range to join.
  * @param delimiter The separator string to insert between elements.
  * @return A single string with all elements joined by the delimiter.
- * \todo Replace with std::views::join_with after transition to C++23.
+ * \todo Replace with std::views::join after transition to C++23.
  */
 template <std::ranges::range R>
 requires(c_writable<std::ranges::range_value_t<R>>)
-[[nodiscard]] std::string join_with(const R& range, const std::string_view delimiter = ", ") {
+[[nodiscard]] std::string join(const R& range, const std::string_view delimiter = ", ") {
     std::ostringstream oss;
 
     auto it = std::ranges::begin(range);

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -13,8 +13,6 @@
 
 namespace ap {
 
-// TODO: add [] or `` around arg names in error msgs
-
 /**
  * @brief Base class for exceptions thrown by the argument parser.
  *

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -39,7 +39,7 @@ public:
      */
     explicit value_already_set(const detail::argument_name& arg_name)
     : argument_parser_exception(
-          std::format("Value for argument {} has already been set.", arg_name.str())
+          std::format("Value for argument [{}] has already been set.", arg_name.str())
       ) {}
 };
 
@@ -52,7 +52,7 @@ public:
      */
     explicit invalid_value(const detail::argument_name& arg_name, const std::string& value)
     : argument_parser_exception(
-          std::format("Cannot parse value `{}` for argument {}.", value, arg_name.str())
+          std::format("Cannot parse value `{}` for argument [{}].", value, arg_name.str())
       ) {}
 };
 
@@ -65,7 +65,7 @@ public:
      */
     explicit invalid_choice(const detail::argument_name& arg_name, const std::string& value)
     : argument_parser_exception(
-          std::format("Value `{}` is not a valid choice for argument {}.", value, arg_name.str())
+          std::format("Value `{}` is not a valid choice for argument [{}].", value, arg_name.str())
       ) {}
 };
 
@@ -80,7 +80,7 @@ public:
         const std::string_view arg_name, const std::string_view reason
     )
     : argument_parser_exception(
-          std::format("Given name `{}` is invalid.\nReason: {}", arg_name, reason)
+          std::format("Given name [{}] is invalid.\nReason: {}", arg_name, reason)
       ) {}
 };
 
@@ -91,7 +91,7 @@ public:
      * @param arg_name The name of the argument causing the collision.
      */
     explicit argument_name_used(const detail::argument_name& arg_name)
-    : argument_parser_exception(std::format("Given name `{}` already used.", arg_name.str())) {}
+    : argument_parser_exception(std::format("Given name [{}] already used.", arg_name.str())) {}
 };
 
 /// @brief Exception thrown when an argument with a specific name is not found.
@@ -101,7 +101,7 @@ public:
      * @param arg_name The name of the argument that was not found.
      */
     explicit argument_not_found(const std::string_view& arg_name)
-    : argument_parser_exception(std::format("Argument with given name `{}` not found.", arg_name)) {
+    : argument_parser_exception(std::format("Argument with given name [{}] not found.", arg_name)) {
     }
 };
 
@@ -117,7 +117,7 @@ public:
         const detail::argument_name& arg_name, const std::type_info& value_type
     )
     : argument_parser_exception(std::format(
-          "Invalid value type specified for argument {} = {}.", arg_name.str(), value_type.name()
+          "Invalid value type specified for argument [{}] = {}.", arg_name.str(), value_type.name()
       )) {}
 };
 
@@ -129,7 +129,9 @@ public:
      * @param arg_name The name of the required argument that was not parsed.
      */
     explicit required_argument_not_parsed(const detail::argument_name& arg_name)
-    : argument_parser_exception("No values parsed for a required argument " + arg_name.str()) {}
+    : argument_parser_exception(
+          std::format("No values parsed for a required argument [{}]", arg_name.str())
+      ) {}
 };
 
 /// @brief Exception thrown when there is an error deducing the argument for given values.
@@ -169,9 +171,13 @@ private:
         const std::weak_ordering ordering, const detail::argument_name& arg_name
     ) {
         if (std::is_lt(ordering))
-            return "Not enought values provided for optional argument " + arg_name.str();
+            return std::format(
+                "Not enought values provided for optional argument [{}]", arg_name.str()
+            );
         else
-            return "Too many values provided for optional argument " + arg_name.str();
+            return std::format(
+                "Too many values provided for optional argument [{}]", arg_name.str()
+            );
     }
 };
 

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -141,7 +141,7 @@ public:
      */
     explicit argument_deduction_failure(const std::vector<std::string_view>& values)
     : argument_parser_exception(std::format(
-          "Failed to deduce the argument for the given values [{}]", detail::join_with(values)
+          "Failed to deduce the argument for the given values [{}]", detail::join(values)
       )) {}
 };
 

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -12,6 +12,8 @@
 
 namespace ap {
 
+// TODO: add [] or `` around arg names in error msgs
+
 /**
  * @brief Base class for exceptions thrown by the argument parser.
  *
@@ -130,6 +132,7 @@ public:
 };
 
 /// @brief Exception thrown when there is an error deducing the argument for a given value.
+// TODO: rename to dangling_value ?
 class free_value : public argument_parser_exception {
 public:
     /**

--- a/include/ap/error/exceptions.hpp
+++ b/include/ap/error/exceptions.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "ap/detail/argument_name.hpp"
+#include "ap/detail/str_utility.hpp"
 
 #include <format>
 
@@ -131,18 +132,17 @@ public:
     : argument_parser_exception("No values parsed for a required argument " + arg_name.str()) {}
 };
 
-/// @brief Exception thrown when there is an error deducing the argument for a given value.
-// TODO: rename to dangling_value ?
-class free_value : public argument_parser_exception {
+/// @brief Exception thrown when there is an error deducing the argument for given values.
+class argument_deduction_failure : public argument_parser_exception {
 public:
     /**
-     * @brief Constructor for the free_value class.
-     * @param value The value for which the argument deduction failed.
+     * @brief Constructor for the dangling_values class.
+     * @param values The value for which the argument deduction failed.
      */
-    explicit free_value(const std::string& value)
-    : argument_parser_exception(
-          std::format("Failed to deduce the argument for the given value `{}`", value)
-      ) {}
+    explicit argument_deduction_failure(const std::vector<std::string_view>& values)
+    : argument_parser_exception(std::format(
+          "Failed to deduce the argument for the given values [{}]", detail::join_with(values)
+      )) {}
 };
 
 /// @brief Exception thrown when an invalid number of values is provided for an argument.

--- a/include/ap/nargs/range.hpp
+++ b/include/ap/nargs/range.hpp
@@ -121,7 +121,6 @@ private:
     range(const std::optional<count_type> lower_bound, const std::optional<count_type> upper_bound)
     : _lower_bound(lower_bound), _upper_bound(upper_bound) {}
 
-    // TODO: make the bound vars public
     std::optional<count_type> _lower_bound;
     std::optional<count_type> _upper_bound;
 

--- a/include/ap/nargs/range.hpp
+++ b/include/ap/nargs/range.hpp
@@ -116,6 +116,7 @@ private:
     range(const std::optional<count_type> lower_bound, const std::optional<count_type> upper_bound)
     : _lower_bound(lower_bound), _upper_bound(upper_bound) {}
 
+    // TODO: make the bound vars public
     std::optional<count_type> _lower_bound;
     std::optional<count_type> _upper_bound;
 

--- a/include/ap/nargs/range.hpp
+++ b/include/ap/nargs/range.hpp
@@ -44,12 +44,9 @@ public:
 
     ~range() = default;
 
+    /// @brief Returns `true` if at least one bound (lower, upper) is set. Otherwise returns `false`
     [[nodiscard]] bool is_bound() const noexcept {
         return this->_lower_bound.has_value() or this->_upper_bound.has_value();
-    }
-
-    [[nodiscard]] bool is_unbound() const noexcept {
-        return not this->is_bound();
     }
 
     /**

--- a/include/ap/nargs/range.hpp
+++ b/include/ap/nargs/range.hpp
@@ -44,6 +44,14 @@ public:
 
     ~range() = default;
 
+    [[nodiscard]] bool is_bound() const noexcept {
+        return this->_lower_bound.has_value() or this->_upper_bound.has_value();
+    }
+
+    [[nodiscard]] bool is_unbound() const noexcept {
+        return not this->is_bound();
+    }
+
     /**
      * @brief Determines the ordering of the count against a range instance.
      *

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -19,7 +19,7 @@ struct optional_argument_test_fixture {
     using value_type = typename optional<T>::value_type;
 
     template <c_argument_value_type T>
-    void mark_used(optional<T>& arg) const {
+    bool mark_used(optional<T>& arg) const {
         return arg.mark_used();
     }
 
@@ -34,12 +34,12 @@ struct optional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    optional<T>& set_value(optional<T>& arg, const T& value) const {
+    bool set_value(optional<T>& arg, const T& value) const {
         return arg.set_value(std::to_string(value));
     }
 
     template <c_argument_value_type T>
-    optional<T>& set_value(optional<T>& arg, const std::string& str_value) const {
+    bool set_value(optional<T>& arg, const std::string& str_value) const {
         return arg.set_value(str_value);
     }
 

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -31,8 +31,8 @@ struct optional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    std::size_t get_nused(const optional<T>& arg) const {
-        return arg.nused();
+    std::size_t get_count(const optional<T>& arg) const {
+        return arg.count();
     }
 
     template <c_argument_value_type T>

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -3,10 +3,12 @@
 #define AP_TESTING
 
 #include <ap/argument/optional.hpp>
+#include <ap/detail/str_utility.hpp>
 
 using ap::argument::optional;
 using ap::detail::argument_descriptor;
 using ap::detail::argument_name;
+using ap::detail::as_string;
 using ap::detail::c_argument_value_type;
 
 namespace ap_testing {
@@ -35,12 +37,22 @@ struct optional_argument_test_fixture {
 
     template <c_argument_value_type T>
     bool set_value(optional<T>& arg, const T& value) const {
-        return arg.set_value(std::to_string(value));
+        return set_value(arg, as_string(value));
     }
 
     template <c_argument_value_type T>
     bool set_value(optional<T>& arg, const std::string& str_value) const {
         return arg.set_value(str_value);
+    }
+
+    template <c_argument_value_type T>
+    void set_value_force(optional<T>& arg, const T& value) const {
+        set_value_force(arg, as_string(value));
+    }
+
+    template <c_argument_value_type T>
+    void set_value_force(optional<T>& arg, const std::string& str_value) const {
+        arg._values.emplace_back(str_value);
     }
 
     template <c_argument_value_type T>
@@ -59,8 +71,8 @@ struct optional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::weak_ordering nvalues_in_range(const optional<T>& arg) const {
-        return arg.nvalues_in_range();
+    [[nodiscard]] std::weak_ordering nvalues_ordering(const optional<T>& arg) const {
+        return arg.nvalues_ordering();
     }
 
     template <c_argument_value_type T>

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -44,8 +44,8 @@ struct positional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::size_t get_nused(const positional<T>& arg) const {
-        return arg.nused();
+    [[nodiscard]] std::size_t get_count(const positional<T>& arg) const {
+        return arg.count();
     }
 
     template <c_argument_value_type T>

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -59,12 +59,12 @@ struct positional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    positional<T>& set_value(positional<T>& arg, const T& value) const {
+    bool set_value(positional<T>& arg, const T& value) const {
         return arg.set_value(std::to_string(value));
     }
 
     template <c_argument_value_type T>
-    positional<T>& set_value(positional<T>& arg, const std::string& str_value) const {
+    bool set_value(positional<T>& arg, const std::string& str_value) const {
         return arg.set_value(str_value);
     }
 

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -74,8 +74,8 @@ struct positional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
-    [[nodiscard]] std::weak_ordering nvalues_in_range(const positional<T>& arg) const {
-        return arg.nvalues_in_range();
+    [[nodiscard]] std::weak_ordering nvalues_ordering(const positional<T>& arg) const {
+        return arg.nvalues_ordering();
     }
 
     template <c_argument_value_type T>

--- a/tests/include/utility.hpp
+++ b/tests/include/utility.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace ap_testing {
+
+template <typename T>
+void discard_result(T&&) {
+    // do nothing
+}
+
+} // namespace ap_testing

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -2,6 +2,7 @@
 
 #include "argument_parser_test_fixture.hpp"
 #include "doctest.h"
+#include "utility.hpp"
 
 using namespace ap_testing;
 using namespace ap::argument;
@@ -329,7 +330,7 @@ TEST_CASE_FIXTURE(
     "value() should throw if there is no argument with given name present"
 ) {
     add_arguments(n_positional_args, n_optional_args);
-    CHECK_THROWS_AS(sut.value(invalid_arg_name), ap::error::argument_not_found);
+    CHECK_THROWS_AS(discard_result(sut.value(invalid_arg_name)), ap::error::argument_not_found);
 }
 
 TEST_CASE_FIXTURE(
@@ -340,8 +341,8 @@ TEST_CASE_FIXTURE(
 
     for (std::size_t i = 0ull; i < n_args_total; ++i) {
         const auto arg_name = init_arg_name(i);
-        CHECK_THROWS_AS(sut.value(arg_name.primary), std::logic_error);
-        CHECK_THROWS_AS(sut.value(arg_name.secondary.value()), std::logic_error);
+        CHECK_THROWS_AS(discard_result(sut.value(arg_name.primary)), std::logic_error);
+        CHECK_THROWS_AS(discard_result(sut.value(arg_name.secondary.value())), std::logic_error);
     }
 }
 
@@ -363,7 +364,8 @@ TEST_CASE_FIXTURE(
 
         REQUIRE(sut.has_value(arg_name.primary));
         CHECK_THROWS_AS(
-            sut.value<invalid_value_type>(arg_name.primary), ap::error::invalid_value_type
+            discard_result(sut.value<invalid_value_type>(arg_name.primary)),
+            ap::error::invalid_value_type
         );
     }
 
@@ -422,7 +424,9 @@ TEST_CASE_FIXTURE(
     "value_or() should throw if there is no argument with given name present"
 ) {
     add_arguments(n_positional_args, n_optional_args);
-    CHECK_THROWS_AS(sut.value_or(invalid_arg_name, empty_str), ap::error::argument_not_found);
+    CHECK_THROWS_AS(
+        discard_result(sut.value_or(invalid_arg_name, empty_str)), ap::error::argument_not_found
+    );
 }
 
 TEST_CASE_FIXTURE(
@@ -443,7 +447,8 @@ TEST_CASE_FIXTURE(
 
         REQUIRE(sut.has_value(arg_name.primary));
         CHECK_THROWS_AS(
-            sut.value_or<invalid_value_type>(arg_name.primary, invalid_value_type{}),
+            discard_result(sut.value_or<invalid_value_type>(arg_name.primary, invalid_value_type{})
+            ),
             ap::error::invalid_value_type
         );
     }
@@ -599,8 +604,8 @@ TEST_CASE_FIXTURE(
 ) {
     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
 
-    CHECK_THROWS_AS(sut.values(positional_primary_name), std::logic_error);
-    CHECK_THROWS_AS(sut.values(positional_secondary_name), std::logic_error);
+    CHECK_THROWS_AS(discard_result(sut.values(positional_primary_name)), std::logic_error);
+    CHECK_THROWS_AS(discard_result(sut.values(positional_secondary_name)), std::logic_error);
 }
 
 TEST_CASE_FIXTURE(
@@ -640,11 +645,11 @@ TEST_CASE_FIXTURE(
     sut.parse_args(argc, argv);
 
     REQUIRE_THROWS_AS(
-        sut.values<invalid_argument_value_type>(optional_primary_name),
+        discard_result(sut.values<invalid_argument_value_type>(optional_primary_name)),
         ap::error::invalid_value_type
     );
     REQUIRE_THROWS_AS(
-        sut.values<invalid_argument_value_type>(optional_secondary_name),
+        discard_result(sut.values<invalid_argument_value_type>(optional_secondary_name)),
         ap::error::invalid_value_type
     );
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -86,7 +86,7 @@ TEST_CASE_FIXTURE(
     auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
     arg_tokens.erase(std::next(arg_tokens.begin(), static_cast<std::ptrdiff_t>(n_positional_args)));
 
-    CHECK_THROWS_AS(parse_args_impl(arg_tokens), ap::error::free_value);
+    CHECK_THROWS_AS(parse_args_impl(arg_tokens), ap::error::argument_deduction_failure);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_nargs_range.cpp
+++ b/tests/source/test_nargs_range.cpp
@@ -10,103 +10,112 @@ using namespace ap::nargs;
 
 namespace {
 
-constexpr range::count_type ndefault = 1ull;
-constexpr range::count_type nlow = 3ull;
-constexpr range::count_type nhigh = 9ull;
-constexpr range::count_type nmid = (nlow + nhigh) / 2ull;
+constexpr range::count_type exact_bound = 1ull;
+constexpr range::count_type lower_bound = 3ull;
+constexpr range::count_type upper_bound = 9ull;
+constexpr range::count_type mid = (lower_bound + upper_bound) / 2ull;
 
-constexpr range::count_type nmin = std::numeric_limits<range::count_type>::min();
-constexpr range::count_type nmax = std::numeric_limits<range::count_type>::max();
+constexpr range::count_type min_bound = std::numeric_limits<range::count_type>::min();
+constexpr range::count_type max_bound = std::numeric_limits<range::count_type>::max();
 
 } // namespace
 
 TEST_SUITE_BEGIN("test_nargs_range");
 
+TEST_CASE("is_bound should return true only if at least one bound is set") {
+    CHECK_FALSE(any().is_bound());
+
+    CHECK(at_least(lower_bound).is_bound());
+    CHECK(up_to(upper_bound).is_bound());
+    CHECK(range(exact_bound).is_bound());
+    CHECK(range(lower_bound, upper_bound).is_bound());
+}
+
 TEST_CASE("ordering should return true for default range only when n is 1") {
     const auto sut = range();
 
-    REQUIRE(std::is_eq(sut.ordering(ndefault)));
+    REQUIRE(std::is_eq(sut.ordering(exact_bound)));
 
-    REQUIRE(std::is_lt(sut.ordering(ndefault - 1)));
-    REQUIRE(std::is_gt(sut.ordering(ndefault + 1)));
+    REQUIRE(std::is_lt(sut.ordering(exact_bound - 1)));
+    REQUIRE(std::is_gt(sut.ordering(exact_bound + 1)));
 }
 
 TEST_CASE("ordering should return true if n is in range") {
     SUBCASE("range is [n]") {
-        const auto sut = range(nmid);
+        const auto sut = range(mid);
 
-        REQUIRE(std::is_eq(sut.ordering(nmid)));
+        REQUIRE(std::is_eq(sut.ordering(mid)));
 
-        REQUIRE(std::is_lt(sut.ordering(nmid - 1)));
-        REQUIRE(std::is_gt(sut.ordering(nmid + 1)));
+        REQUIRE(std::is_lt(sut.ordering(mid - 1)));
+        REQUIRE(std::is_gt(sut.ordering(mid + 1)));
     }
 
-    SUBCASE("range is [low, high]") {
-        const auto sut = range(nlow, nhigh);
+    SUBCASE("range is [lower, upper]") {
+        const auto sut = range(lower_bound, upper_bound);
 
-        REQUIRE(std::is_eq(sut.ordering(nlow)));
-        REQUIRE(std::is_eq(sut.ordering(nhigh)));
-        REQUIRE(std::is_eq(sut.ordering(nmid)));
+        REQUIRE(std::is_eq(sut.ordering(lower_bound)));
+        REQUIRE(std::is_eq(sut.ordering(upper_bound)));
+        REQUIRE(std::is_eq(sut.ordering(mid)));
 
-        REQUIRE(std::is_lt(sut.ordering(nlow - 1)));
-        REQUIRE(std::is_gt(sut.ordering(nhigh + 1)));
+        REQUIRE(std::is_lt(sut.ordering(lower_bound - 1)));
+        REQUIRE(std::is_gt(sut.ordering(upper_bound + 1)));
     }
 }
 
 TEST_CASE("range builders should return correct range objects") {
     SUBCASE("at_least") {
-        const auto sut = at_least(nlow);
+        const auto sut = at_least(lower_bound);
 
-        REQUIRE(std::is_eq(sut.ordering(nlow)));
-        REQUIRE(std::is_eq(sut.ordering(nhigh)));
-        REQUIRE(std::is_eq(sut.ordering(nmax)));
+        REQUIRE(std::is_eq(sut.ordering(lower_bound)));
+        REQUIRE(std::is_eq(sut.ordering(upper_bound)));
+        REQUIRE(std::is_eq(sut.ordering(max_bound)));
 
-        REQUIRE(std::is_lt(sut.ordering(nlow - 1)));
-        REQUIRE(std::is_lt(sut.ordering(nmin)));
+        REQUIRE(std::is_lt(sut.ordering(lower_bound - 1)));
+        REQUIRE(std::is_lt(sut.ordering(min_bound)));
     }
 
     SUBCASE("more_than") {
-        const auto sut = more_than(nlow);
+        const auto sut = more_than(lower_bound);
 
-        REQUIRE(std::is_eq(sut.ordering(nlow + 1)));
-        REQUIRE(std::is_eq(sut.ordering(nhigh)));
-        REQUIRE(std::is_eq(sut.ordering(nmax)));
+        REQUIRE(std::is_eq(sut.ordering(lower_bound + 1)));
+        REQUIRE(std::is_eq(sut.ordering(upper_bound)));
+        REQUIRE(std::is_eq(sut.ordering(max_bound)));
 
-        REQUIRE(std::is_lt(sut.ordering(nlow)));
-        REQUIRE(std::is_lt(sut.ordering(nmin)));
+        REQUIRE(std::is_lt(sut.ordering(lower_bound)));
+        REQUIRE(std::is_lt(sut.ordering(min_bound)));
     }
 
     SUBCASE("less_than") {
-        const auto sut = less_than(nhigh);
+        const auto sut = less_than(upper_bound);
 
-        REQUIRE(std::is_eq(sut.ordering(nhigh - 1)));
-        REQUIRE(std::is_eq(sut.ordering(nlow)));
-        REQUIRE(std::is_eq(sut.ordering(nmin)));
+        REQUIRE(std::is_eq(sut.ordering(upper_bound - 1)));
+        REQUIRE(std::is_eq(sut.ordering(lower_bound)));
+        REQUIRE(std::is_eq(sut.ordering(min_bound)));
 
-        REQUIRE(std::is_gt(sut.ordering(nhigh)));
-        REQUIRE(std::is_gt(sut.ordering(nmax)));
+        REQUIRE(std::is_gt(sut.ordering(upper_bound)));
+        REQUIRE(std::is_gt(sut.ordering(max_bound)));
     }
 
     SUBCASE("up_to") {
-        const auto sut = up_to(nhigh);
+        const auto sut = up_to(upper_bound);
 
-        REQUIRE(std::is_eq(sut.ordering(nhigh)));
-        REQUIRE(std::is_eq(sut.ordering(nlow)));
-        REQUIRE(std::is_eq(sut.ordering(nmin)));
+        REQUIRE(std::is_eq(sut.ordering(upper_bound)));
+        REQUIRE(std::is_eq(sut.ordering(lower_bound)));
+        REQUIRE(std::is_eq(sut.ordering(min_bound)));
 
-        REQUIRE(std::is_gt(sut.ordering(nhigh + 1)));
-        REQUIRE(std::is_gt(sut.ordering(nmax)));
+        REQUIRE(std::is_gt(sut.ordering(upper_bound + 1)));
+        REQUIRE(std::is_gt(sut.ordering(max_bound)));
     }
 
     SUBCASE("any") {
         const auto sut = any();
 
-        REQUIRE(std::is_eq(sut.ordering(nmin)));
-        REQUIRE(std::is_eq(sut.ordering(ndefault)));
-        REQUIRE(std::is_eq(sut.ordering(nlow)));
-        REQUIRE(std::is_eq(sut.ordering(nmid)));
-        REQUIRE(std::is_eq(sut.ordering(nhigh)));
-        REQUIRE(std::is_eq(sut.ordering(nmax)));
+        REQUIRE(std::is_eq(sut.ordering(min_bound)));
+        REQUIRE(std::is_eq(sut.ordering(exact_bound)));
+        REQUIRE(std::is_eq(sut.ordering(lower_bound)));
+        REQUIRE(std::is_eq(sut.ordering(mid)));
+        REQUIRE(std::is_eq(sut.ordering(upper_bound)));
+        REQUIRE(std::is_eq(sut.ordering(max_bound)));
     }
 }
 

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -202,9 +202,9 @@ TEST_CASE_FIXTURE(
     CHECK(is_used(sut));
 }
 
-TEST_CASE_FIXTURE(optional_argument_test_fixture, "nused() should return 0 by default") {
+TEST_CASE_FIXTURE(optional_argument_test_fixture, "count() should return 0 by default") {
     const auto sut = init_arg(primary_name);
-    CHECK_EQ(get_nused(sut), 0ull);
+    CHECK_EQ(get_count(sut), 0ull);
 }
 
 TEST_CASE_FIXTURE(
@@ -214,11 +214,11 @@ TEST_CASE_FIXTURE(
 ) {
     auto sut = init_arg(primary_name);
 
-    constexpr std::size_t nused = 5ull;
-    for (std::size_t n = 0ull; n < nused; ++n)
+    constexpr std::size_t count = 5ull;
+    for (std::size_t n = 0ull; n < count; ++n)
         mark_used(sut);
 
-    CHECK_EQ(get_nused(sut), nused);
+    CHECK_EQ(get_count(sut), count);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -159,7 +159,7 @@ TEST_CASE_FIXTURE(
 
     const auto choices_it = std::ranges::find(desc.params, "choices", &parameter_descriptor::name);
     REQUIRE_NE(choices_it, desc.params.end());
-    CHECK_EQ(choices_it->value, ap::detail::join_with(choices, ", "));
+    CHECK_EQ(choices_it->value, ap::detail::join(choices, ", "));
 
     const auto default_value_it =
         std::ranges::find(desc.params, "default value", &parameter_descriptor::name);

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -131,7 +131,7 @@ TEST_CASE_FIXTURE(
     REQUIRE_FALSE(desc.params.empty());
     const auto& choices_param = desc.params.back();
     CHECK_EQ(choices_param.name, "choices");
-    CHECK_EQ(choices_param.value, ap::detail::join_with(choices, ", "));
+    CHECK_EQ(choices_param.value, ap::detail::join(choices, ", "));
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_required() should return true") {

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -328,20 +328,20 @@ TEST_CASE_FIXTURE(positional_argument_test_fixture, "values() should throw logic
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "nvalues_in_range() should return less by default"
+    positional_argument_test_fixture, "nvalues_ordering() should return less by default"
 ) {
     const auto sut = init_arg(primary_name);
-    CHECK(std::is_lt(nvalues_in_range(sut)));
+    CHECK(std::is_lt(nvalues_ordering(sut)));
 }
 
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture,
-    "nvalues_in_range() should return equivalent if a value has been set"
+    "nvalues_ordering() should return equivalent if a value has been set"
 ) {
     auto sut = init_arg(primary_name);
     set_value(sut, value_1);
 
-    CHECK(std::is_eq(nvalues_in_range(sut)));
+    CHECK(std::is_eq(nvalues_ordering(sut)));
 }
 
 TEST_SUITE_END();

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -154,18 +154,18 @@ TEST_CASE_FIXTURE(
     CHECK(is_used(sut));
 }
 
-TEST_CASE_FIXTURE(positional_argument_test_fixture, "nused() should return 0 by default") {
+TEST_CASE_FIXTURE(positional_argument_test_fixture, "count() should return 0 by default") {
     const auto sut = init_arg(primary_name);
-    CHECK_EQ(get_nused(sut), 0ull);
+    CHECK_EQ(get_count(sut), 0ull);
 }
 
 TEST_CASE_FIXTURE(
-    positional_argument_test_fixture, "nused() should return 1 when argument contains a value"
+    positional_argument_test_fixture, "count() should return 1 when argument contains a value"
 ) {
     auto sut = init_arg(primary_name);
     set_value(sut, value_1);
 
-    CHECK_EQ(get_nused(sut), 1ull);
+    CHECK_EQ(get_count(sut), 1ull);
 }
 
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "has_value() should return false by default") {

--- a/tests/source/test_str_utility.cpp
+++ b/tests/source/test_str_utility.cpp
@@ -16,19 +16,19 @@ constexpr std::string_view delimiter = ",";
 
 TEST_SUITE_BEGIN("test_str_utility");
 
-TEST_CASE("join_with should return an empty string for an empty range") {
+TEST_CASE("join should return an empty string for an empty range") {
     std::vector<int> range{};
-    CHECK_EQ(join_with(range, delimiter), "");
+    CHECK_EQ(join(range, delimiter), "");
 }
 
-TEST_CASE("join_with should return a string with no delimiters for a single element range") {
+TEST_CASE("join should return a string with no delimiters for a single element range") {
     std::vector<int> range = {1};
-    CHECK_EQ(join_with(range, delimiter), "1");
+    CHECK_EQ(join(range, delimiter), "1");
 }
 
-TEST_CASE("join_with should return a proper range representation for a multi element range") {
+TEST_CASE("join should return a proper range representation for a multi element range") {
     std::vector<int> range = {1, 2, 3};
-    CHECK_EQ(join_with(range, delimiter), "1,2,3");
+    CHECK_EQ(join(range, delimiter), "1,2,3");
 }
 
 TEST_SUITE_END(); // test_str_utility


### PR DESCRIPTION
- Any values passed for an optional argument which exceed the upper bound specified with the `nargs` parameter will now be treated as dangling and an error will be thrown immediately instead of at the end during the verification step
- Improved argument name formatting in error messages
- Changed the default `nargs` parameter value to `nargs::any()` - unbound range