### PR TITLE
YT-CPPAP-38: Argument base class alignment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.2.1
+    VERSION 2.2.2
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "CPP-AP"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.2.1
+PROJECT_NUMBER         = 2.2.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -182,11 +182,6 @@ public:
         return *this;
     }
 
-    /// @return True if argument is optional, false otherwise.
-    [[nodiscard]] bool is_optional() const noexcept override {
-        return this->_optional;
-    }
-
     /// @brief Friend class declaration for access by argument_parser.
     friend class ::ap::argument_parser;
 
@@ -345,8 +340,6 @@ private:
     [[nodiscard]] bool _accepts_further_values() const noexcept {
         return not std::is_gt(this->_nargs_range.ordering(this->_values.size() + 1ull));
     }
-
-    static constexpr bool _optional = true;
 
     bool _required = false;
     bool _bypass_required = false;

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -27,11 +27,11 @@ namespace ap::argument {
  * @brief The optioanl argument class.
  * @tparam T The argument's value type.
  */
-template <ap::detail::c_argument_value_type T = std::string>
-class optional : public ap::detail::argument_base {
+template <detail::c_argument_value_type T = std::string>
+class optional : public detail::argument_base {
 public:
     using value_type = T; ///< The argument's value type.
-    using count_type = ap::nargs::range::count_type; ///< The argument's value count type.
+    using count_type = nargs::range::count_type; ///< The argument's value count type.
 
     optional() = delete;
 
@@ -39,7 +39,7 @@ public:
      * @brief Constructor for optional argument with the `name` identifier.
      * @param name The `name` identifier of the optional argument.
      */
-    optional(const ap::detail::argument_name& name) : _name(name) {}
+    optional(const detail::argument_name& name) : argument_base(name) {}
 
     ~optional() = default;
 
@@ -87,29 +87,29 @@ public:
      * @param range The nargs range to set.
      * @return Reference to the optional argument.
      */
-    optional& nargs(const ap::nargs::range& range) noexcept {
+    optional& nargs(const nargs::range& range) noexcept {
         this->_nargs_range = range;
         return *this;
     }
 
     /**
      * @brief Set the nargs range for the optional argument.
-     * @param count The count for nargs range.
+     * @param n The exact bound for nargs range.
      * @return Reference to the optional argument.
      */
-    optional& nargs(const count_type count) noexcept {
-        this->_nargs_range = ap::nargs::range(count);
+    optional& nargs(const count_type n) noexcept {
+        this->_nargs_range = nargs::range(n);
         return *this;
     }
 
     /**
      * @brief Set the nargs range for the optional argument.
-     * @param nlow The lower bound for nargs range.
-     * @param nhigh The upper bound for nargs range.
+     * @param lower_bound The lower bound for nargs range.
+     * @param upper_bound The upper bound for nargs range.
      * @return Reference to the optional argument.
      */
-    optional& nargs(const count_type nlow, const count_type nhigh) noexcept {
-        this->_nargs_range = ap::nargs::range(nlow, nhigh);
+    optional& nargs(const count_type lower_bound, const count_type upper_bound) noexcept {
+        this->_nargs_range = nargs::range(lower_bound, upper_bound);
         return *this;
     }
 
@@ -120,10 +120,10 @@ public:
      * @param action The action function to set.
      * @return Reference to the optional argument.
      */
-    template <ap::action::detail::c_action_specifier AS, typename F>
+    template <action::detail::c_action_specifier AS, typename F>
     optional& action(F&& action) noexcept {
-        if constexpr (ap::action::detail::c_value_action_specifier<AS>) {
-            using callable_type = ap::action::detail::callable_type<AS, value_type>;
+        if constexpr (action::detail::c_value_action_specifier<AS>) {
+            using callable_type = action::detail::callable_type<AS, value_type>;
             this->_value_actions.emplace_back(std::forward<callable_type>(action));
         }
         else {
@@ -199,18 +199,8 @@ public:
 
 private:
     using value_action_type =
-        ap::action::detail::value_action_variant_type<T>; ///< The argument's value action type.
-    using flag_action_type = typename ap::action_type::on_flag::type;
-
-    /// @return Reference to the name of the optional argument.
-    [[nodiscard]] const ap::detail::argument_name& name() const noexcept override {
-        return this->_name;
-    }
-
-    /// @return Reference to the optional help message for the optional argument.
-    [[nodiscard]] const std::optional<std::string>& help() const noexcept override {
-        return this->_help_msg;
-    }
+        action::detail::value_action_variant_type<T>; ///< The argument's value action type.
+    using flag_action_type = typename action_type::on_flag::type;
 
     /**
      * @param verbose The verbosity mode value.
@@ -285,7 +275,7 @@ private:
         if (not (std::istringstream(str_value) >> value))
             throw error::invalid_value(this->_name, str_value);
 
-        if (not this->_is_valid_choice(value))
+        if (not detail::is_valid_choice(value, this->_choices))
             throw error::invalid_choice(this->_name, str_value);
 
         const auto apply_visitor = action::detail::apply_visitor<value_type>{value};
@@ -352,28 +342,15 @@ private:
         return this->_default_value;
     }
 
-    /**
-     * @brief Check if the provided choice is valid for the optional argument.
-     * @param choice The value to check against choices.
-     * @return True if choice is valid, false otherwise.
-     */
-    [[nodiscard]] bool _is_valid_choice(const value_type& choice) const noexcept {
-        // TODO: replace with `std::ranges::contains` after transition to C++23
-        return this->_choices.empty()
-            or std::ranges::find(this->_choices, choice) != this->_choices.end();
-    }
-
     [[nodiscard]] bool _accepts_further_values() const noexcept {
         return not std::is_gt(this->_nargs_range.ordering(this->_values.size() + 1ull));
     }
 
     static constexpr bool _optional = true;
-    const ap::detail::argument_name _name;
-    std::optional<std::string> _help_msg;
 
     bool _required = false;
     bool _bypass_required = false;
-    ap::nargs::range _nargs_range = nargs::any();
+    nargs::range _nargs_range = nargs::any();
     std::any _default_value;
     std::any _implicit_value;
     std::vector<value_type> _choices;

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -8,8 +8,8 @@
 
 #include "ap/action/detail/utility.hpp"
 #include "ap/action/predefined_actions.hpp"
+#include "ap/detail/argument_base.hpp"
 #include "ap/detail/argument_descriptor.hpp"
-#include "ap/detail/argument_interface.hpp"
 #include "ap/detail/concepts.hpp"
 #include "ap/nargs/range.hpp"
 
@@ -28,7 +28,7 @@ namespace ap::argument {
  * @tparam T The argument's value type.
  */
 template <ap::detail::c_argument_value_type T = std::string>
-class optional : public ap::detail::argument_interface {
+class optional : public ap::detail::argument_base {
 public:
     using value_type = T; ///< The argument's value type.
     using count_type = ap::nargs::range::count_type; ///< The argument's value count type.

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -8,7 +8,7 @@
 
 #include "ap/action/detail/utility.hpp"
 #include "ap/action/predefined_actions.hpp"
-#include "ap/detail/argument_interface.hpp"
+#include "ap/detail/argument_base.hpp"
 #include "ap/detail/concepts.hpp"
 
 #ifdef AP_TESTING
@@ -26,7 +26,7 @@ namespace ap::argument {
  * @tparam T The argument's value type.
  */
 template <ap::detail::c_argument_value_type T = std::string>
-class positional : public ap::detail::argument_interface {
+class positional : public ap::detail::argument_base {
 public:
     using value_type = T; ///< The argument's value type.
 

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -102,11 +102,6 @@ public:
         return *this;
     }
 
-    /// @return True if argument is optional, false otherwise.
-    [[nodiscard]] bool is_optional() const noexcept override {
-        return this->_optional;
-    }
-
     /// @brief Friend class declaration for access by argument_parser.
     friend class ::ap::argument_parser;
 
@@ -230,8 +225,6 @@ private:
             std::format("Positional argument `{}` has only 1 value.", this->_name.primary)
         );
     }
-
-    static constexpr bool _optional = false;
 
     static constexpr bool _required = true;
     static constexpr bool _bypass_required = false;

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -483,9 +483,9 @@ public:
 #endif
 
 private:
-    using arg_ptr_t = std::unique_ptr<detail::argument_interface>;
+    using arg_ptr_t = std::unique_ptr<detail::argument_base>;
     using arg_ptr_list_t = std::vector<arg_ptr_t>;
-    using arg_opt_t = std::optional<std::reference_wrapper<detail::argument_interface>>;
+    using arg_opt_t = std::optional<std::reference_wrapper<detail::argument_base>>;
 
     using arg_token_list_t = std::vector<detail::argument_token>;
     using arg_token_list_iterator_t = typename arg_token_list_t::const_iterator;

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -27,9 +27,6 @@ class argument_base {
 public:
     virtual ~argument_base() = default;
 
-    /// @return `true` if the argument is optional, `false` otherwise.
-    virtual bool is_optional() const noexcept = 0;
-
     friend class ::ap::argument_parser;
 
 protected:

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -2,7 +2,10 @@
 // This file is part of the CPP-AP project (https://github.com/SpectraL519/cpp-ap).
 // Licensed under the MIT License. See the LICENSE file in the project root for full license information.
 
-/// @file argument_base.hpp
+/**
+ * @file argument_base.hpp
+ * @brief Defines the base argument class and common utility.
+ */
 
 #pragma once
 
@@ -30,11 +33,17 @@ public:
     friend class ::ap::argument_parser;
 
 protected:
-    /// @return Reference to the name of the argument.
-    virtual const argument_name& name() const noexcept = 0;
+    argument_base(const argument_name& name) : _name(name) {}
 
-    /// @return Optional help message for the argument.
-    virtual const std::optional<std::string>& help() const noexcept = 0;
+    /// @return Reference the name of the positional argument.
+    [[nodiscard]] const ap::detail::argument_name& name() const noexcept {
+        return this->_name;
+    }
+
+    /// @return Optional help message for the positional argument.
+    [[nodiscard]] const std::optional<std::string>& help() const noexcept {
+        return this->_help_msg;
+    }
 
     /**
      * @param verbose The verbosity mode value.
@@ -81,7 +90,22 @@ protected:
 
     /// @return Reference to the vector of parsed values of the argument.
     virtual const std::vector<std::any>& values() const = 0;
+
+    const ap::detail::argument_name _name;
+    std::optional<std::string> _help_msg;
 };
+
+/**
+ * @brief Checks if the provided choice is valid for the given set of choices.
+ * @param value A value, the validity of which is to be checked.
+ * @param choices The set against which the choice validity will be checked.
+ * @return `true` if the choice is valid, `false` otherwise.
+ */
+template <c_argument_value_type T>
+[[nodiscard]] bool is_valid_choice(const T& value, const std::vector<T>& choices) noexcept {
+    // TODO: replace with `std::ranges::contains` after transition to C++23
+    return choices.empty() or std::ranges::find(choices, value) != choices.end();
+}
 
 } // namespace detail
 } // namespace ap

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -2,7 +2,7 @@
 // This file is part of the CPP-AP project (https://github.com/SpectraL519/cpp-ap).
 // Licensed under the MIT License. See the LICENSE file in the project root for full license information.
 
-/// @file argument_interface.hpp
+/// @file argument_base.hpp
 
 #pragma once
 
@@ -20,23 +20,12 @@ class argument_parser;
 namespace detail {
 
 /// @brief Argument class interface
-class argument_interface {
+class argument_base {
 public:
-    virtual ~argument_interface() = default;
+    virtual ~argument_base() = default;
 
-    /// @return True if the argument is optional, false otherwise.
+    /// @return `true` if the argument is optional, `false` otherwise.
     virtual bool is_optional() const noexcept = 0;
-
-    /**
-     * @brief Overloaded stream insertion operator.
-     * @param os The output stream.
-     * @param argument The argument_interface to output.
-     * @return The output stream.
-     */
-    friend std::ostream& operator<<(std::ostream& os, const argument_interface& argument) noexcept {
-        os << argument.name() << " : " << argument.help().value_or("No help message provided");
-        return os;
-    }
 
     friend class ::ap::argument_parser;
 
@@ -53,10 +42,10 @@ protected:
      */
     virtual detail::argument_descriptor desc(const bool verbose) const noexcept = 0;
 
-    /// @return True if the argument is required, false otherwise
+    /// @return `true` if the argument is required, `false` otherwise
     virtual bool is_required() const noexcept = 0;
 
-    /// @return True if bypassing the required status is enabled for the argument, false otherwise.
+    /// @return `true` if bypassing the required status is enabled for the argument, `false` otherwise.
     virtual bool bypass_required_enabled() const noexcept = 0;
 
     /**
@@ -65,7 +54,7 @@ protected:
      */
     virtual bool mark_used() = 0;
 
-    /// @return True if the argument has been used, false otherwise.
+    /// @return `true` if the argument has been used, `false` otherwise.
     virtual bool is_used() const noexcept = 0;
 
     /// @return The number of times the positional argument is used.
@@ -78,10 +67,10 @@ protected:
      */
     virtual bool set_value(const std::string& value) = 0;
 
-    /// @return True if the argument has a value, false otherwise.
+    /// @return `true` if the argument has a value, `false` otherwise.
     virtual bool has_value() const noexcept = 0;
 
-    /// @return True if the argument has parsed values., false otherwise.
+    /// @return `true` if the argument has parsed values., `false` otherwise.
     virtual bool has_parsed_values() const noexcept = 0;
 
     /// @return The ordering relationship of argument range.

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -92,7 +92,7 @@ struct optional_argument_test_fixture {
 
     template <c_argument_value_type T>
     [[nodiscard]] const std::optional<std::string>& get_help(const optional<T>& arg) const {
-        return arg.help();
+        return arg._help_msg;
     }
 
     template <c_argument_value_type T>

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -25,7 +25,7 @@ struct positional_argument_test_fixture {
 
     template <c_argument_value_type T>
     [[nodiscard]] const std::optional<std::string>& get_help(const positional<T>& arg) const {
-        return arg.help();
+        return arg._help_msg;
     }
 
     template <c_argument_value_type T>

--- a/tests/include/utility.hpp
+++ b/tests/include/utility.hpp
@@ -1,10 +1,23 @@
 #pragma once
 
+#include <ap/argument/optional.hpp>
+#include <ap/argument/positional.hpp>
+
 namespace ap_testing {
 
 template <typename T>
 void discard_result(T&&) {
     // do nothing
+}
+
+template <ap::detail::c_argument_value_type T = std::string>
+bool is_positional(const ap::detail::argument_base& arg) {
+    return dynamic_cast<const ap::argument::positional<T>*>(&arg);
+}
+
+template <ap::detail::c_argument_value_type T = std::string>
+bool is_optional(const ap::detail::argument_base& arg) {
+    return dynamic_cast<const ap::argument::optional<T>*>(&arg);
 }
 
 } // namespace ap_testing

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -3,6 +3,7 @@
 #include "argument_parser_test_fixture.hpp"
 #include "doctest.h"
 #include "optional_argument_test_fixture.hpp"
+#include "utility.hpp"
 
 using namespace ap_testing;
 using namespace ap::argument;
@@ -143,14 +144,6 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_add_argument,
-    "add_positional_argument should return a positional argument reference"
-) {
-    const auto& argument = sut.add_positional_argument(primary_name_1, secondary_name_1);
-    CHECK_FALSE(argument.is_optional());
-}
-
-TEST_CASE_FIXTURE(
-    test_argument_parser_add_argument,
     "add_positional_argument should throw only when adding an"
     "argument with a previously used name"
 ) {
@@ -173,14 +166,6 @@ TEST_CASE_FIXTURE(
             ap::error::argument_name_used
         );
     }
-}
-
-TEST_CASE_FIXTURE(
-    test_argument_parser_add_argument,
-    "add_optional_argument should return an optional argument reference"
-) {
-    const auto& argument = sut.add_optional_argument(primary_name_1, secondary_name_1);
-    CHECK(argument.is_optional());
 }
 
 TEST_CASE_FIXTURE(
@@ -218,7 +203,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("StoreImplicitly = true") {
         auto& argument = sut.add_flag(primary_name_1, secondary_name_1);
 
-        REQUIRE(argument.is_optional());
+        REQUIRE(is_optional<bool>(argument));
         CHECK_FALSE(sut.value<bool>(primary_name_1));
 
         opt_arg_fixture.mark_used(argument);
@@ -228,7 +213,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("StoreImplicitly = false") {
         auto& argument = sut.add_flag<false>(primary_name_1, secondary_name_1);
 
-        REQUIRE(argument.is_optional());
+        REQUIRE(is_optional<bool>(argument));
         CHECK(sut.value<bool>(primary_name_1));
 
         opt_arg_fixture.mark_used(argument);
@@ -267,11 +252,11 @@ TEST_CASE_FIXTURE(
 
     const auto input_arg = get_argument("input");
     REQUIRE(input_arg);
-    REQUIRE_FALSE(input_arg->get().is_optional());
+    CHECK(is_positional<std::string>(input_arg.value()));
 
     const auto output_arg = get_argument("output");
     REQUIRE(output_arg);
-    REQUIRE_FALSE(output_arg->get().is_optional());
+    CHECK(is_positional<std::string>(output_arg.value()));
 }
 
 TEST_CASE_FIXTURE(
@@ -304,15 +289,16 @@ TEST_CASE_FIXTURE(
 
     const auto help_arg = get_argument(help_flag);
     REQUIRE(help_arg);
-    CHECK(help_arg->get().is_optional());
+    CHECK(is_optional<bool>(help_arg.value()));
 
     const auto input_arg = get_argument(input_flag);
     REQUIRE(input_arg);
-    CHECK(input_arg->get().is_optional());
+    CHECK(is_optional<std::string>(input_arg.value()));
+
 
     const auto output_arg = get_argument(output_flag);
     REQUIRE(output_arg);
-    CHECK(output_arg->get().is_optional());
+    CHECK(is_optional<std::string>(output_arg.value()));
 }
 
 TEST_SUITE_END();

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -47,11 +47,6 @@ const range non_default_range = range{1ull, choices.size()};
 
 TEST_SUITE_BEGIN("test_optional_argument");
 
-TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_optional() should return true") {
-    const auto sut = init_arg(primary_name);
-    CHECK(sut.is_optional());
-}
-
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "name() should return the proper argument_name instance"
 ) {

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -40,11 +40,6 @@ constexpr sut_value_type invalid_choice = 4;
 
 TEST_SUITE_BEGIN("test_positional_argument");
 
-TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_optional() should return false") {
-    const auto sut = init_arg(primary_name);
-    CHECK_FALSE(sut.is_optional());
-}
-
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "name() should return the proper argument_name instance"
 ) {


### PR DESCRIPTION
- Renamed the `argument_interface` class to `argument_base`
- Move common/default functionality of the `positional` and `optional` classes to the base class