### PR TITLE
[none] Aligned argument name printing in parser's description

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.2.3
+    VERSION 2.2.4
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "CPP-AP"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.2.3
+PROJECT_NUMBER         = 2.2.4
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -538,7 +538,7 @@ int main(int argc, char* argv[]) {
 }
 
 // compiled with:
-// g++ -o power power.cpp -I <cpp-ap-include-dir>
+// g++ -o power power.cpp -I <cpp-ap-include-dir> -std=c++20
 ```
 
 ### Argument Parsing Rules:
@@ -556,19 +556,19 @@ int main(int argc, char* argv[]) {
   ```shell
   ./power
   # out:
-  # [ERROR] : No values parsed for a required argument base
+  # [ERROR] : No values parsed for a required argument [base]
   # Program: power calculator
   #
-  #   calculates the value of an expression: base ^ exponent
+  #   Calculates the value of an expression: base ^ exponent
   #
   # Positional arguments:
   #
   #   base : the exponentation base value
   #
-  # Optional arguments: [--,-]
+  # Optional arguments:
   #
-  #   exponent, e : the exponent value
-  #   help, h     : Display the help message
+  #   --exponent, -e : the exponent value
+  #   --help, -h     : Display the help message
   ```
 
 > [!IMPORTANT]
@@ -597,19 +597,19 @@ int main(int argc, char* argv[]) {
   ```shell
   ./power 2 1 2 3
   # out:
-  # [ERROR] : Failed to deduce the argument for the given value `1`
+  # [ERROR] : Failed to deduce the argument for values [1, 2, 3]
   # Program: power calculator
   #
-  #   calculates the value of an expression: base ^ exponent
+  #   Calculates the value of an expression: base ^ exponent
   #
   # Positional arguments:
   #
   #   base : the exponentation base value
   #
-  # Optional arguments: [--,-]
+  # Optional arguments:
   #
-  #   exponent, e : the exponent value
-  #   help, h     : Display the help message
+  #   --exponent, -e : the exponent value
+  #   --help, -h     : Display the help message
   ```
 
 > [!IMPORTANT]

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -201,8 +201,8 @@ private:
      * @param verbose The verbosity mode value.
      * @return An argument_descriptor instance for the argument.
      */
-    [[nodiscard]] detail::argument_descriptor desc(const bool verbose) const noexcept override {
-        detail::argument_descriptor desc(this->_name.str(), this->_help_msg);
+    [[nodiscard]] detail::argument_descriptor desc(const bool verbose, const char flag_char) const noexcept override {
+        detail::argument_descriptor desc(this->_name.str(flag_char), this->_help_msg);
 
         if (not verbose)
             return desc;

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -201,7 +201,8 @@ private:
      * @param verbose The verbosity mode value.
      * @return An argument_descriptor instance for the argument.
      */
-    [[nodiscard]] detail::argument_descriptor desc(const bool verbose, const char flag_char) const noexcept override {
+    [[nodiscard]] detail::argument_descriptor desc(const bool verbose, const char flag_char)
+        const noexcept override {
         detail::argument_descriptor desc(this->_name.str(flag_char), this->_help_msg);
 
         if (not verbose)

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -118,9 +118,9 @@ private:
 
     /**
      * @param verbose The verbosity mode value.
-     * @return An argument_descriptor instance for the argument.
+     * @return An argument descriptor object for the argument.
      */
-    [[nodiscard]] detail::argument_descriptor desc(const bool verbose) const noexcept override {
+    [[nodiscard]] detail::argument_descriptor desc(const bool verbose, [[maybe_unused]] const char flag_char) const noexcept override {
         detail::argument_descriptor desc(this->_name.str(), this->_help_msg);
 
         if (not verbose)

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -120,7 +120,9 @@ private:
      * @param verbose The verbosity mode value.
      * @return An argument descriptor object for the argument.
      */
-    [[nodiscard]] detail::argument_descriptor desc(const bool verbose, [[maybe_unused]] const char flag_char) const noexcept override {
+    [[nodiscard]] detail::argument_descriptor desc(
+        const bool verbose, [[maybe_unused]] const char flag_char
+    ) const noexcept override {
         detail::argument_descriptor desc(this->_name.str(), this->_help_msg);
 
         if (not verbose)

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -450,7 +450,7 @@ public:
         }
 
         if (not this->_optional_args.empty()) {
-            os << "\nOptional arguments: [--,-]\n";
+            os << "\nOptional arguments:\n";
             this->_print(os, this->_optional_args, verbose);
         }
     }
@@ -579,7 +579,7 @@ private:
      */
     [[nodiscard]] bool _is_flag(const std::string& arg) const noexcept {
         if (arg.starts_with(this->_flag_prefix))
-            return this->_is_arg_name_used({arg.substr(this->_primary_flag_prefxi_length)});
+            return this->_is_arg_name_used({arg.substr(this->_primary_flag_prefix_length)});
 
         if (arg.starts_with(this->_flag_prefix_char))
             return this->_is_arg_name_used({arg.substr(this->_secondary_flag_prefix_length)});
@@ -593,7 +593,7 @@ private:
      */
     void _strip_flag_prefix(std::string& arg_flag) const noexcept {
         if (arg_flag.starts_with(this->_flag_prefix))
-            arg_flag.erase(0, this->_primary_flag_prefxi_length);
+            arg_flag.erase(0, this->_primary_flag_prefix_length);
         else
             arg_flag.erase(0, this->_secondary_flag_prefix_length);
     }
@@ -753,14 +753,14 @@ private:
     void _print(std::ostream& os, const arg_ptr_list_t& args, const bool verbose) const noexcept {
         if (verbose) {
             for (const auto& arg : args)
-                os << '\n' << arg->desc(verbose).get(this->_indent_width) << '\n';
+                os << '\n' << arg->desc(verbose, this->_flag_prefix_char).get(this->_indent_width) << '\n';
         }
         else {
             std::vector<detail::argument_descriptor> descriptors;
             descriptors.reserve(args.size());
 
             for (const auto& arg : args)
-                descriptors.emplace_back(arg->desc(verbose));
+                descriptors.emplace_back(arg->desc(verbose, this->_flag_prefix_char));
 
             std::size_t max_arg_name_length = 0ull;
             for (const auto& desc : descriptors)
@@ -780,8 +780,8 @@ private:
     arg_ptr_list_t _positional_args;
     arg_ptr_list_t _optional_args;
 
+    static constexpr uint8_t _primary_flag_prefix_length = 2u;
     static constexpr uint8_t _secondary_flag_prefix_length = 1u;
-    static constexpr uint8_t _primary_flag_prefxi_length = 2u;
     static constexpr char _flag_prefix_char = '-';
     static constexpr std::string _flag_prefix = "--";
     static constexpr uint8_t _indent_width = 2;

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -753,7 +753,8 @@ private:
     void _print(std::ostream& os, const arg_ptr_list_t& args, const bool verbose) const noexcept {
         if (verbose) {
             for (const auto& arg : args)
-                os << '\n' << arg->desc(verbose, this->_flag_prefix_char).get(this->_indent_width) << '\n';
+                os << '\n'
+                   << arg->desc(verbose, this->_flag_prefix_char).get(this->_indent_width) << '\n';
         }
         else {
             std::vector<detail::argument_descriptor> descriptors;

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -46,7 +46,8 @@ protected:
      * @param verbose The verbosity mode value.
      * @return An argument_descriptor instance for the argument.
      */
-    virtual detail::argument_descriptor desc(const bool verbose, const char flag_char) const noexcept = 0;
+    virtual detail::argument_descriptor desc(const bool verbose, const char flag_char)
+        const noexcept = 0;
 
     /// @return `true` if the argument is required, `false` otherwise
     virtual bool is_required() const noexcept = 0;

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -46,7 +46,7 @@ protected:
      * @param verbose The verbosity mode value.
      * @return An argument_descriptor instance for the argument.
      */
-    virtual detail::argument_descriptor desc(const bool verbose) const noexcept = 0;
+    virtual detail::argument_descriptor desc(const bool verbose, const char flag_char) const noexcept = 0;
 
     /// @return `true` if the argument is required, `false` otherwise
     virtual bool is_required() const noexcept = 0;

--- a/include/ap/detail/argument_name.hpp
+++ b/include/ap/detail/argument_name.hpp
@@ -81,7 +81,8 @@ struct argument_name {
     }
 
     /// @brief Get a string representation of the argument_name.
-    [[nodiscard]] std::string str(const std::optional<char> flag_char = std::nullopt) const noexcept {
+    [[nodiscard]] std::string str(const std::optional<char> flag_char = std::nullopt)
+        const noexcept {
         // if flag_char = nullopt, then the fallback character doesn't matter - the string will be empty
         const std::string fc(flag_char.has_value(), flag_char.value_or(char()));
         return this->secondary

--- a/include/ap/detail/argument_name.hpp
+++ b/include/ap/detail/argument_name.hpp
@@ -81,10 +81,12 @@ struct argument_name {
     }
 
     /// @brief Get a string representation of the argument_name.
-    [[nodiscard]] std::string str() const noexcept {
+    [[nodiscard]] std::string str(const std::optional<char> flag_char = std::nullopt) const noexcept {
+        // if flag_char = nullopt, then the fallback character doesn't matter - the string will be empty
+        const std::string fc(flag_char.has_value(), flag_char.value_or(char()));
         return this->secondary
-                 ? std::format("{}, {}", this->primary, this->secondary.value())
-                 : std::format("{}", this->primary);
+                 ? std::format("{}{}{}, {}{}", fc, fc, this->primary, fc, this->secondary.value())
+                 : std::format("{}{}{}", fc, fc, this->primary);
     }
 
     /**

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -97,13 +97,15 @@ struct optional_argument_test_fixture {
 
     template <c_argument_value_type T>
     [[nodiscard]] argument_descriptor get_desc(const optional<T>& arg, const bool verbose) const {
-        return arg.desc(verbose);
+        return arg.desc(verbose, flag_char);
     }
 
     template <c_argument_value_type T>
     [[nodiscard]] bool is_required(const optional<T>& arg) const {
         return arg.is_required();
     }
+
+    static constexpr char flag_char = '-';
 };
 
 } // namespace ap_testing

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -30,7 +30,7 @@ struct positional_argument_test_fixture {
 
     template <c_argument_value_type T>
     [[nodiscard]] argument_descriptor get_desc(const positional<T>& arg, const bool verbose) const {
-        return arg.desc(verbose);
+        return arg.desc(verbose, flag_char);
     }
 
     template <c_argument_value_type T>
@@ -87,6 +87,8 @@ struct positional_argument_test_fixture {
     const std::vector<std::any>& get_values(const positional<T>& arg) const {
         return arg.values();
     }
+
+    static constexpr char flag_char = '-';
 };
 
 } // namespace ap_testing

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -89,14 +89,14 @@ TEST_CASE_FIXTURE(
     auto sut = sut_type(arg_name);
 
     auto desc = get_desc(sut, verbose);
-    REQUIRE_EQ(desc.name, get_name(sut).str());
+    REQUIRE_EQ(desc.name, get_name(sut).str(flag_char));
     CHECK_FALSE(desc.help);
     CHECK(desc.params.empty());
 
     // with a help msg
     sut.help(help_msg);
     desc = get_desc(sut, verbose);
-    REQUIRE_EQ(desc.name, get_name(sut).str());
+    REQUIRE_EQ(desc.name, get_name(sut).str(flag_char));
     CHECK(desc.help);
     CHECK_EQ(desc.help.value(), help_msg);
     CHECK(desc.params.empty());
@@ -111,7 +111,7 @@ TEST_CASE_FIXTURE(
     auto sut = sut_type(arg_name);
 
     auto desc = get_desc(sut, verbose);
-    REQUIRE_EQ(desc.name, get_name(sut).str());
+    REQUIRE_EQ(desc.name, get_name(sut).str(flag_char));
     CHECK_FALSE(desc.help);
     CHECK(desc.params.empty());
 


### PR DESCRIPTION
Printing the parser's description aligned to print
```
Optional arguments:

  --argument, -a : help message
```
instead of
```
Optional arguments [--,-]:

  argument, a : help message
```

