### PR TITLE
YT-CPPAP-41: Documentation deployment refinement

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -60,14 +60,24 @@ jobs:
       - name: Install dependencies
         run: sudo apt install doxygen -y
 
-      - name: Extract the project version
+      - name: Extract and validate the project version
+        continue-on-error: false
         run: |
           VERSION=$(python3 scripts/check_version.py)
           echo "project version = $VERSION"
+          VERSION_TAG="${GITHUB_REF##*/}"
+          echo "git version tag = $VERSION_TAG"
+          if [[ "$VERSION_TAG" != "v$VERSION" ]]; then
+            echo "Error: Tag missmatch: git version tag = $VERSION_TAG, project version: v$VERSION"
+            exit 1
+          fi
           echo "VERSION=$VERSION" >> $GITHUB_ENV
 
       - name: Run doxygen
-        run: doxygen Doxyfile
+        continue-on-error: false
+        run: |
+          doxygen Doxyfile
+          python3 scripts/postprocess_doxyhtml.py ./documentation
 
       - name: Deploy to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
@@ -76,3 +86,28 @@ jobs:
           publish_dir: ./documentation
           publish_branch: gh-pages
           destination_dir: ${{ env.VERSION }}
+
+      - name: Deploy documantation as latest (setup)
+        if: ${{ success() }}
+        run: |
+          CURRENT_VERSION="v${VERSION}"
+          echo "Current version: $CURRENT_VERSION"
+          git fetch --tags --force
+          ALL_TAGS=$(git tag | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V)
+          LATEST_TAG=$(echo "$ALL_TAGS" | tail -n 1)
+          echo "Latest tag: $LATEST_TAG"
+          if [ "$CURRENT_VERSION" = "$LATEST_TAG" ]; then
+            echo "Current tag is the latest. Deploying to 'latest/'..."
+            echo "DEPLOY_LATEST=true" >> $GITHUB_ENV
+          else
+            echo "Current tag is NOT the latest. Skipping deployment to 'latest/'."
+          fi
+
+      - name: Deploy to GitHub Pages as 'latest'
+        if: env.DEPLOY_LATEST == 'true'
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./documentation
+          publish_branch: gh-pages
+          destination_dir: latest

--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -27,7 +27,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: sudo apt install doxygen -y
+        run: |
+          sudo apt install doxygen -y
+          pip install beautifulsoup4
 
       - name: Validate the project version
         run: |
@@ -35,7 +37,10 @@ jobs:
           echo "project version = $VERSION"
 
       - name: Run doxygen
-        run: doxygen Doxyfile
+        continue-on-error: false
+        run: |
+          doxygen Doxyfile
+          python3 scripts/postprocess_doxyhtml.py ./documentation
 
       - name: Validate output
         run: test -d documentation && test -f documentation/index.html
@@ -58,7 +63,9 @@ jobs:
           python-version: "3.12"
 
       - name: Install dependencies
-        run: sudo apt install doxygen -y
+        run: |
+          sudo apt install doxygen -y
+          pip install beautifulsoup4
 
       - name: Extract and validate the project version
         continue-on-error: false

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.2.5
+    VERSION 2.2.6
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = "CPP-AP"
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.2.5
+PROJECT_NUMBER         = 2.2.6
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a
@@ -1315,7 +1315,7 @@ HTML_STYLESHEET        =
 # documentation.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css
+HTML_EXTRA_STYLESHEET  = doxygen-awesome-css/doxygen-awesome.css doxygen-ext-stylesheet.css
 
 # The HTML_EXTRA_FILES tag can be used to specify one or more extra images or
 # other source files which should be copied to the HTML output directory. Note

--- a/Doxyfile
+++ b/Doxyfile
@@ -42,7 +42,7 @@ DOXYFILE_ENCODING      = UTF-8
 # title of most generated pages and in a few other places.
 # The default value is: My Project.
 
-PROJECT_NAME           = "CPP-AP"
+PROJECT_NAME           = CPP-AP
 
 # The PROJECT_NUMBER tag can be used to enter a project or revision number. This
 # could be handy for archiving the generated documentation or if some version

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-MIT License
+#### MIT License
 
 Copyright (c) 2023-2025 Jakub Musiał and other contributors
 https://github.com/SpectraL519/cpp-ap

--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# CPP-AP-2
+<h1>
+  CPP-AP-2
+  <a href="https://github.com/SpectraL519/cpp-ap" target="_blank">
+    <i class="fa fa-github" style="font-size: 0.8em; margin-left: 0.5em;"></i>
+  </a>
+</h1>
 
 Command-line argument parser for C++20
 
@@ -28,7 +33,7 @@ Command-line argument parser for C++20
 
 ## Related Pages
 
-- [Tutorial](/docs/tutorial.md)
+- [Tutorial](/docs/tutorial.md#tutorial)
   - [Setting Up CPP-AP](/docs/tutorial.md#setting-up-cpp-ap)
     - [CMake Integration](/docs/tutorial.md#cmake-integration)
     - [Downloading the Library](/docs/tutorial.md#downloading-the-library)
@@ -39,10 +44,10 @@ Command-line argument parser for C++20
   - [Parsing Arguments](/docs/tutorial.md#parsing-arguments)
   - [Retrieving Argument Values](/docs/tutorial.md#retrieving-argument-values)
   - [Examples](/docs/tutorial.md#examples)
-- [Dev notes](/docs/dev_notes.md)
+- [Dev notes](/docs/dev_notes.md#dev-notes)
   - [Building and testing](/docs/dev_notes.md#building-and-testing)
   - [Formatting](/docs/dev_notes.md#formatting)
-  - [Documentation](https://spectral519.github.io/cpp-ap/2.2.5/)
+  - [Documentation](/docs/dev_notes.md#documentation)
 
 <br />
 
@@ -61,4 +66,4 @@ Command-line argument parser for C++20
 
 ## License
 
-The `CPP-AP` project uses the [MIT License](https://mit-license.org/) which can be found in the [LICENSE.md](/LICENSE.md) file
+The `CPP-AP` project uses the [MIT License](https://mit-license.org/) which can be found in the [LICENSE](/LICENSE.md#mit-license) file

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1>
   CPP-AP-2
   <a href="https://github.com/SpectraL519/cpp-ap" target="_blank">
-    <i class="fa fa-github" style="font-size: 0.8em; margin-left: 0.5em;"></i>
+    <i class="fa fa-github" style="font-size: 1.3em; margin-left: 6px; position: relative; top: -0.08em;"></i>
   </a>
 </h1>
 

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -61,10 +61,15 @@ python scripts/format.py --help
 
 ## Documentation
 
-> [!INFO]
-> You can view the online documentation [here](https://spectral519.github.io/cpp-ap/).
+> [!NOTE]
 >
-> **NOTE:** The online documentation is available only for versions `>= 2.2.5`.
+> You can view the online documentation for the latest version [here](https://spectral519.github.io/cpp-ap/latest/).
+>
+> To view the documentation for the previous versions use the following URL pattern:
+> ```
+> https://spectral519.github.io/cpp-ap/<version>
+> ```
+> Please keep in mind that the online documentation is available only for versions `>= 2.2.5` - for older versions the documentation has to be built locally.
 
 The documentation for this project can be generated using Doxygen, styled with a custom [fork](https://github.com/SpectraL519/doxygen-awesome-css/tree/theme-alignment) of the [doxygen-awesome-css](https://github.com/jothepro/doxygen-awesome-css) theme.
 
@@ -87,4 +92,8 @@ This should create a `documentation` directory containing the project's document
 
 > [!NOTE]
 >
-> Markdown links to other files might not be rendered properly in the Doxygen output, however the referenced pages will still be generated in the *Related Pages* section.
+> Markdown links to other files or sections and the GFM-style callouts might not be rendered properly in the Doxygen output. To fix these issues you can run the postprocessing script:
+> ```
+> python3 scripts/postprocess_doxyhtml.py ./documentation
+> ```
+> or you can view those documents by using the *Related Pages* section on the navigation bar.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -155,10 +155,10 @@ Parameters which can be specified for both positional and optional arguments inc
 
 #### `help` - The argument's description which will be printed when printing the parser class instance.
 
-    ```cpp
-    parser.add_positional_argument<std::size_t>("number", "n")
-          .help("a positive integer value");
-    ```
+```cpp
+parser.add_positional_argument<std::size_t>("number", "n")
+      .help("a positive integer value");
+```
 
 #### `choices` - A list of valid argument values.
 
@@ -173,9 +173,9 @@ parser.add_optional_argument<char>("method", "m").choices({'a', 'b', 'c'});
 > The `choices` function can be used only if the argument's `value_type` is equality comparable (defines the `==` operator).
 
 #### Value actions - Function performed after parsing an argument's value.
-  Actions are represented as functions, which take the argument's value as an argument. The available action types are:
+Actions are represented as functions, which take the argument's value as an argument. The available action types are:
 
-  - `observe` actions | `void(const value_type&)` - applied to the parsed value. No value is returned - this action type is used to perform some logic on the parsed value without modifying it.
+- `observe` actions | `void(const value_type&)` - applied to the parsed value. No value is returned - this action type is used to perform some logic on the parsed value without modifying it.
 
   ```cpp
   void is_valid_user_tag(const std::string& tag) {
@@ -187,29 +187,29 @@ parser.add_optional_argument<char>("method", "m").choices({'a', 'b', 'c'});
         .action<ap::action_type::observe>(is_valid_user_tag);
   ```
 
-  - `transform` actions | `value_type(const value_type&)` - applied to the parsed value. The returned value will be used to initialize the argument's value.
+- `transform` actions | `value_type(const value_type&)` - applied to the parsed value. The returned value will be used to initialize the argument's value.
 
-    ```cpp
-    std::string to_lower(std::string s) {
-        for (auto& c : s)
-            c = static_cast<char>(std::tolower(c));
-        return s;
-    }
+  ```cpp
+  std::string to_lower(std::string s) {
+      for (auto& c : s)
+          c = static_cast<char>(std::tolower(c));
+      return s;
+  }
 
-    parser.add_optional_argument<std::string>("key", "k")
-          .action<ap::action_type::transform>(to_lower);
-    ```
+  parser.add_optional_argument<std::string>("key", "k")
+        .action<ap::action_type::transform>(to_lower);
+  ```
 
-  - `modify` actions | `void(value_type&)` - applied to the initialized value of an argument.
+- `modify` actions | `void(value_type&)` - applied to the initialized value of an argument.
 
-    ```cpp
-    void capitalize(std::string& s) {
-        s.at(0) = std::toupper(s.at(0));
-    }
+  ```cpp
+  void capitalize(std::string& s) {
+      s.at(0) = std::toupper(s.at(0));
+  }
 
-    parser.add_optional_argument<std::string>("name", "n")
-          .action<ap::action_type::modify>(capitalize);
-    ```
+  parser.add_optional_argument<std::string>("name", "n")
+        .action<ap::action_type::modify>(capitalize);
+  ```
 
 > [!TIP]
 >
@@ -223,40 +223,40 @@ Apart from the common parameters listed above, for optional arguments you can al
 
 #### `required` - If this option is set for an argument and it's value is not passed in the command-line, an exception will be thrown.
 
-  ```cpp
-  parser.add_optional_argument("output", "o").required();
-  ```
+```cpp
+parser.add_optional_argument("output", "o").required();
+```
 
 #### `bypass_required` - If this option is set for an argument, parsing it's value will overrite the `required` option for other optional arguments and all positional arguments.
 
 #### `nargs` - Sets the allowed number of values to be parsed for an argument. This can be set as a:
 
-  - Concrete number:
+- Specific number:
 
-    ```cpp
-    parser.add_optional_argument("input", "i").nargs(1);
-    ```
+  ```cpp
+  parser.add_optional_argument("input", "i").nargs(1);
+  ```
 
-  - Bound range:
+- Fully bound range:
 
-    ```cpp
-    parser.add_optional_argument("input", "i").nargs(1, 3);
-    ```
+  ```cpp
+  parser.add_optional_argument("input", "i").nargs(1, 3);
+  ```
 
-  - Partially bound range:
+- Partially bound range:
 
-    ```cpp
-    parser.add_optional_argument("input", "i").nargs(ap::nargs::at_least(1));  // n >= 1
-    parser.add_optional_argument("input", "i").nargs(ap::nargs::more_than(1)); // n > 1
-    parser.add_optional_argument("input", "i").nargs(ap::nargs::less_than(5)); // n < 5
-    parser.add_optional_argument("input", "i").nargs(ap::nargs::up_to(5));     // n <= 5
-    ```
+  ```cpp
+  parser.add_optional_argument("input", "i").nargs(ap::nargs::at_least(1));  // n >= 1
+  parser.add_optional_argument("input", "i").nargs(ap::nargs::more_than(1)); // n > 1
+  parser.add_optional_argument("input", "i").nargs(ap::nargs::less_than(5)); // n < 5
+  parser.add_optional_argument("input", "i").nargs(ap::nargs::up_to(5));     // n <= 5
+  ```
 
-  - Unbound range:
+- Unbound range:
 
-    ```cpp
-    parser.add_optional_argument("input", "i").nargs(ap::nargs::any());
-    ```
+  ```cpp
+  parser.add_optional_argument("input", "i").nargs(ap::nargs::any());
+  ```
 
 > [!IMPORTANT]
 >
@@ -264,38 +264,38 @@ Apart from the common parameters listed above, for optional arguments you can al
 
 #### `default_value` - The default value for an argument which will be used if no values for this argument are parsed
 
-  ```cpp
-  parser.add_opitonal_argument("output", "o").default_value("out.txt");
-  ```
+```cpp
+parser.add_opitonal_argument("output", "o").default_value("out.txt");
+```
 
 #### `implicit_value` - A value which will be set for an argument if only it's flag is parsed from the command-line but no values follow.
 
-  ```cpp
-  // program.cpp
-  parser.add_optional_argument("save", "s")
-        .implicit_value("out.txt")
-        .help("save the program's output to a file");
-  ```
+```cpp
+// program.cpp
+parser.add_optional_argument("save", "s")
+      .implicit_value("out.txt")
+      .help("save the program's output to a file");
+```
 
-  In this example if you run the program with only a `-s` or `--save` flag and no value, the value will be set to `out.txt`.
+In this example if you run the program with only a `-s` or `--save` flag and no value, the value will be set to `out.txt`.
 
 #### On-flag actions - For optional arguments, apart from value actions, you can specify on-flag actions which are executed immediately after parsing an argument's flag.
 
-  ```cpp
-  void print_debug_info() noexcept {
-  #ifdef NDEBUG
-      std::cout << "Running in release mode.\n";
-  #else
-      std::cout << "Running in debug mode.\n";
-  #endif
-      std::exit(EXIT_SUCCESS);
-  };
+```cpp
+void print_debug_info() noexcept {
+#ifdef NDEBUG
+    std::cout << "Running in release mode.\n";
+#else
+    std::cout << "Running in debug mode.\n";
+#endif
+    std::exit(EXIT_SUCCESS);
+};
 
-  parser.add_optional_argument("--debug-info")
-        .action<ap::action_type::on_flag>(print_debug_info);
-  ```
+parser.add_optional_argument("--debug-info")
+      .action<ap::action_type::on_flag>(print_debug_info);
+```
 
-  Here the `print_debug_info` function will be called right after parsing the `--debug-info` flag and the program will exit, even if there are more arguments after this flag.
+Here the `print_debug_info` function will be called right after parsing the `--debug-info` flag and the program will exit, even if there are more arguments after this flag.
 
 <br/>
 <br/>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -177,15 +177,15 @@ parser.add_optional_argument<char>("method", "m").choices({'a', 'b', 'c'});
 
   - `observe` actions | `void(const value_type&)` - applied to the parsed value. No value is returned - this action type is used to perform some logic on the parsed value without modifying it.
 
-    ```cpp
-    void is_valid_user_tag(const std::string& tag) {
-        if (tag.empty() or tag.front() != '@')
-            throw std::runtime_error(std::format("Invalid user tag: `{}` — must start with '@'", tag));
-    }
+  ```cpp
+  void is_valid_user_tag(const std::string& tag) {
+      if (tag.empty() or tag.front() != '@')
+          throw std::runtime_error(std::format("Invalid user tag: `{}` — must start with '@'", tag));
+  }
 
-    parser.add_optional_argument<std::string>("user", "u")
-          .action<ap::action_type::observe>(is_valid_user_tag);
-    ```
+  parser.add_optional_argument<std::string>("user", "u")
+        .action<ap::action_type::observe>(is_valid_user_tag);
+  ```
 
   - `transform` actions | `value_type(const value_type&)` - applied to the parsed value. The returned value will be used to initialize the argument's value.
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -305,86 +305,72 @@ Here the `print_debug_info` function will be called right after parsing the `--d
 
 ### Actions
 
----
+- `print_config` | on-flag
 
-#### `print_config` | on-flag
+  Prints the configuration of the parser to the output stream and optionally exits with the given code.
 
-Prints the configuration of the parser to the output stream and optionally exits with the given code.
+  ```cpp
+  typename ap::action_type::on_flag::type print_config(
+      const ap::argument_parser& parser,
+      const std::optional<int> exit_code = std::nullopt,
+      std::ostream& os = std::cout
+  ) noexcept;
+  ```
 
-```cpp
-typename ap::action_type::on_flag::type print_config(
-    const ap::argument_parser& parser,
-    const std::optional<int> exit_code = std::nullopt,
-    std::ostream& os = std::cout
-) noexcept;
-```
+- `check_file_exists` | observe (value type: `std::string`)
 
----
+  Throws if the provided file path does not exist.
 
-#### `check_file_exists` | observe (value type: `std::string`)
+  ```cpp
+  detail::callable_type<ap::action_type::observe, std::string> check_file_exists() noexcept;
+  ```
 
-Throws if the provided file path does not exist.
+- `gt` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
 
-```cpp
-detail::callable_type<ap::action_type::observe, std::string> check_file_exists() noexcept;
-```
+  Validates that the value is strictly greater than `lower_bound`.
 
----
+  ```cpp
+  template <ap::detail::c_arithmetic T>
+  detail::callable_type<ap::action_type::observe, T> gt(const T lower_bound) noexcept;
+  ```
 
-#### `gt` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
+- `geq` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
 
-Validates that the value is strictly greater than `lower_bound`.
+  Validates that the value is greater than or equal to `lower_bound`.
 
-```cpp
-template <ap::detail::c_arithmetic T>
-detail::callable_type<ap::action_type::observe, T> gt(const T lower_bound) noexcept;
-```
+  ```cpp
+  template <ap::detail::c_arithmetic T>
+  detail::callable_type<ap::action_type::observe, T> geq(const T lower_bound) noexcept;
+  ```
 
----
+- `lt` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
 
-#### `geq` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
+  Validates that the value is strictly less than `upper_bound`.
 
-Validates that the value is greater than or equal to `lower_bound`.
+  ```cpp
+  template <ap::detail::c_arithmetic T>
+  detail::callable_type<ap::action_type::observe, T> lt(const T upper_bound) noexcept
+  ```
 
-```cpp
-template <ap::detail::c_arithmetic T>
-detail::callable_type<ap::action_type::observe, T> geq(const T lower_bound) noexcept;
-```
+- `leq` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
 
----
+  Validates that the value is less than or equal to `upper_bound`.
 
-#### `lt` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
+  ```cpp
+  template <ap::detail::c_arithmetic T>
+  detail::callable_type<ap::action_type::observe, T> leq(const T upper_bound) noexcept
+  ```
 
-Validates that the value is strictly less than `upper_bound`.
+- `within` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
 
-```cpp
-template <ap::detail::c_arithmetic T>
-detail::callable_type<ap::action_type::observe, T> lt(const T upper_bound) noexcept
-```
+  Checks if the value is within the given interval. Bound inclusivity is customizable using template parameters.
 
----
-
-#### `leq` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
-
-Validates that the value is less than or equal to `upper_bound`.
-
-```cpp
-template <ap::detail::c_arithmetic T>
-detail::callable_type<ap::action_type::observe, T> leq(const T upper_bound) noexcept
-```
-
----
-
-#### `within` | observe (value type: [arithmetic](https://en.cppreference.com/w/cpp/types/is_arithmetic))
-
-Checks if the value is within the given interval. Bound inclusivity is customizable using template parameters.
-
-```cpp
-template <ap::detail::c_arithmetic T, bool LeftInclusive = true, bool RightInclusive = true>
-detail::callable_type<ap::action_type::observe, T> within(
-    const T lower_bound, const T upper_bound
-) noexcept
-```
+  ```cpp
+  template <ap::detail::c_arithmetic T, bool LeftInclusive = true, bool RightInclusive = true>
+  detail::callable_type<ap::action_type::observe, T> within(
+      const T lower_bound, const T upper_bound
+  ) noexcept
+  ```
 
 <br/>
 <br/>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -153,14 +153,14 @@ parser.add_optional_argument<bool>("disable_another_option", "dao")
 
 Parameters which can be specified for both positional and optional arguments include:
 
-#### `help` - The argument's description which will be printed when printing the parser class instance.
+#### 1. `help` - The argument's description which will be printed when printing the parser class instance.
 
 ```cpp
 parser.add_positional_argument<std::size_t>("number", "n")
       .help("a positive integer value");
 ```
 
-#### `choices` - A list of valid argument values.
+#### 2. `choices` - A list of valid argument values.
 
 The `choices` parameter takes as an argument an instance of `std::initializer_list` or any `std::ranges::range` type such that its value type is convertible to the argument's `value_type`.
 
@@ -172,7 +172,7 @@ parser.add_optional_argument<char>("method", "m").choices({'a', 'b', 'c'});
 >
 > The `choices` function can be used only if the argument's `value_type` is equality comparable (defines the `==` operator).
 
-#### Value actions - Function performed after parsing an argument's value.
+#### 3. Value actions - Function performed after parsing an argument's value.
 Actions are represented as functions, which take the argument's value as an argument. The available action types are:
 
 - `observe` actions | `void(const value_type&)` - applied to the parsed value. No value is returned - this action type is used to perform some logic on the parsed value without modifying it.
@@ -221,15 +221,15 @@ Actions are represented as functions, which take the argument's value as an argu
 
 Apart from the common parameters listed above, for optional arguments you can also specify the following parameters:
 
-#### `required` - If this option is set for an argument and it's value is not passed in the command-line, an exception will be thrown.
+#### 1. `required` - If this option is set for an argument and it's value is not passed in the command-line, an exception will be thrown.
 
 ```cpp
 parser.add_optional_argument("output", "o").required();
 ```
 
-#### `bypass_required` - If this option is set for an argument, parsing it's value will overrite the `required` option for other optional arguments and all positional arguments.
+#### 2. `bypass_required` - If this option is set for an argument, parsing it's value will overrite the `required` option for other optional arguments and all positional arguments.
 
-#### `nargs` - Sets the allowed number of values to be parsed for an argument. This can be set as a:
+#### 3. `nargs` - Sets the allowed number of values to be parsed for an argument. This can be set as a:
 
 - Specific number:
 
@@ -262,13 +262,13 @@ parser.add_optional_argument("output", "o").required();
 >
 > The default `nargs` parameter value is `ap::nargs::any()`.
 
-#### `default_value` - The default value for an argument which will be used if no values for this argument are parsed
+#### 4. `default_value` - The default value for an argument which will be used if no values for this argument are parsed
 
 ```cpp
 parser.add_opitonal_argument("output", "o").default_value("out.txt");
 ```
 
-#### `implicit_value` - A value which will be set for an argument if only it's flag is parsed from the command-line but no values follow.
+#### 5. `implicit_value` - A value which will be set for an argument if only it's flag is parsed from the command-line but no values follow.
 
 ```cpp
 // program.cpp
@@ -279,7 +279,7 @@ parser.add_optional_argument("save", "s")
 
 In this example if you run the program with only a `-s` or `--save` flag and no value, the value will be set to `out.txt`.
 
-#### On-flag actions - For optional arguments, apart from value actions, you can specify on-flag actions which are executed immediately after parsing an argument's flag.
+#### 6. On-flag actions - For optional arguments, apart from value actions, you can specify on-flag actions which are executed immediately after parsing an argument's flag.
 
 ```cpp
 void print_debug_info() noexcept {
@@ -465,7 +465,11 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 
 > [!IMPORTANT]
 >
-> The `parse_args(argc, argv)` method ignores the first argument (the program name) and is equivalent to calling `parse_args(std::span(argv + 1, argc - 1))`.
+> The `parse_args(argc, argv)` method ignores the first argument (the program name) and is equivalent to calling:
+>
+> ```cpp
+> parse_args(std::span(argv + 1, argc - 1));
+> ```
 
 > [!TIP]
 >

--- a/doxygen-ext-stylesheet.css
+++ b/doxygen-ext-stylesheet.css
@@ -1,0 +1,9 @@
+@import url('https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css');
+
+.fa {
+  vertical-align: middle;
+  transition: transform 0.2s;
+}
+.fa:hover {
+  transform: scale(1.2);
+}

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -29,7 +29,7 @@ def main(cmake: Path, doxygen: Path):
         sys.exit(1)
 
     if cmake_version != doxy_version:
-        print(f"Version mismatch: CMakeLists.txt = {cmake_version}, Doxyfile = {doxy_version}", file=sys.stderr)
+        print(f"Error: Version mismatch: CMakeLists.txt = {cmake_version}, Doxyfile = {doxy_version}", file=sys.stderr)
         sys.exit(1)
 
     print(cmake_version) # print the version to stdout for shell capture

--- a/scripts/postprocess_doxyhtml.py
+++ b/scripts/postprocess_doxyhtml.py
@@ -70,6 +70,12 @@ def process_gfm(content: str) -> str:
     return content
 
 
+def process_heading_code_blocks(content: str) -> str:
+    content = content.replace("&lt;tt&gt;", "<code>")
+    content = content.replace("&lt;/tt&gt;", "</code>")
+    return content
+
+
 def remove_mainpage_title(content: str, filename: str) -> str:
     if filename != "index.html":
         return content
@@ -85,6 +91,7 @@ def process_file(f: Path):
     content = f.read_text(encoding='utf-8')
     content = process_md_refs(content)
     content = process_gfm(content)
+    content = process_heading_code_blocks(content)
     content = remove_mainpage_title(content, f.name)
     f.write_text(content, encoding='utf-8')
 

--- a/scripts/postprocess_doxyhtml.py
+++ b/scripts/postprocess_doxyhtml.py
@@ -1,0 +1,90 @@
+import argparse
+import re
+from pathlib import Path
+
+
+def encode_md_link(path_str: str) -> str:
+    """
+    Encode a Markdown filepath according to Doxygen's rules:
+    - prefix with 'md_'
+    - replace '/' with '_2'
+    - double underscores '__' for underscores '_'
+    """
+    # Separate anchor if present
+    if '#' in path_str:
+        filepath, anchor = path_str.split('#', 1)
+        anchor = '#' + anchor
+    else:
+        filepath, anchor = path_str, ''
+
+    # Remove leading slash and .md suffix
+    filepath = filepath.removeprefix('/')
+    if not filepath.endswith('.md'):
+        return path_str  # Not a .md file
+    filepath = filepath.removesuffix('.md')
+
+    # Encode path separators and underscores
+    parts = filepath.split('/')
+    encoded_parts = []
+    for part in parts:
+        # Double underscores
+        part = part.replace('_', '__')
+        encoded_parts.append(part)
+    encoded_path = '_2'.join(encoded_parts)
+
+    # Add md_ prefix and .html suffix
+    return f"md_{encoded_path}.html{anchor}"
+
+
+def process_md_refs(content: str) -> str:
+    pattern = re.compile(r'href="([^"]+\.md(?:#[^"]*)?)"')
+
+    def replacer(match):
+        link = match.group(1)
+        new_link = encode_md_link(link)
+        return f'href="{new_link}"'
+
+    return pattern.sub(replacer, content)
+
+
+def process_gfm(content: str) -> str:
+    """
+    Replace GFM-style callouts with styled inline HTML spans.
+    """
+    callouts = {
+        '[!NOTE]':      ('Note', '#1e90ff', 'fa fa-info-circle'),
+        '[!TIP]':       ('Tip', '#28a745', 'fa fa-lightbulb-o'),
+        '[!IMPORTANT]': ('Important', '#d63384', 'fa fa-exclamation-circle'),
+        '[!WARNING]':   ('Warning', '#fd7e14', 'fa fa-exclamation-triangle'),
+        '[!CAUTION]':   ('Caution', '#dc3545', 'fa fa-ban'),
+    }
+
+    for tag, (label, color, icon_class) in callouts.items():
+        replacement = (
+            f'<span style="color: {color}; font-weight: bold; font-size: 1.1em;">'
+            f'<i class="{icon_class}" style="margin-right: 6px; vertical-align: middle; font-size: 1.3em; position: relative; top: -0.08em;"></i> {label}:</span>'
+        )
+        content = content.replace(tag, replacement)
+
+    return content
+
+
+def process_file(f: Path):
+    content = f.read_text(encoding='utf-8')
+    content = process_md_refs(content)
+    content = process_gfm(content)
+    f.write_text(content, encoding='utf-8')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Postprocess Doxygen HTML files to fix links.')
+    parser.add_argument('directory', type=Path, help='Root directory of generated HTML files')
+
+    args = parser.parse_args()
+
+    for f in args.directory.rglob('*.html'):
+        process_file(f)
+
+
+if __name__ == '__main__':
+    main()

--- a/scripts/postprocess_doxyhtml.py
+++ b/scripts/postprocess_doxyhtml.py
@@ -1,6 +1,7 @@
 import argparse
 import re
 from pathlib import Path
+from bs4 import BeautifulSoup
 
 
 def encode_md_link(path_str: str) -> str:
@@ -69,10 +70,22 @@ def process_gfm(content: str) -> str:
     return content
 
 
+def remove_mainpage_title(content: str, filename: str) -> str:
+    if filename != "index.html":
+        return content
+
+    soup = BeautifulSoup(content, 'html.parser')
+    header_div = soup.find("div", class_="header")
+    if header_div:
+        header_div.decompose()
+    return str(soup)
+
+
 def process_file(f: Path):
     content = f.read_text(encoding='utf-8')
     content = process_md_refs(content)
     content = process_gfm(content)
+    content = remove_mainpage_title(content, f.name)
     f.write_text(content, encoding='utf-8')
 
 


### PR DESCRIPTION
- Added the documentation postprocessing script, which:
  - fixes the markdown file links, GFM-style callouts, heading code blocks
  - removes the mainpage title generated by doxygen
- Aligned the documentation workflow to:
  - validate that the current cmake and doxygen version matches the created tag
  - apply the postprocessing step to the generated documentation
  - upload the current version to the `latest` directory as well as to the <version> directory if the current tag is actually the latest
- Aligned the docs to include the proper explanation of how to generate and browse the documentation
- Aligned the indentation in docs so that they are properly handeled by doxygen
- Added the repository link to the docomuentation main page (readme)