### PR TITLE
Split argument name matching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.2.6
+    VERSION 2.2.7
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.2.6
+PROJECT_NUMBER         = 2.2.7
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -623,6 +623,18 @@ private:
         return false;
     }
 
+    [[nodiscard]] std::string _unstripped_token_value(const detail::argument_token& tok
+    ) const noexcept {
+        switch (tok.type) {
+        case detail::argument_token::t_flag_primary:
+            return std::format("{}{}", this->_flag_prefix, tok.value);
+        case detail::argument_token::t_flag_secondary:
+            return std::format("{}{}", this->_flag_prefix_char, tok.value);
+        default:
+            return tok.value;
+        }
+    }
+
     /**
      * @brief Remove the flag prefix from the argument.
      * @param arg_flag The argument flag to strip the prefix from.
@@ -701,7 +713,8 @@ private:
 
                 const auto opt_arg_it = this->_find_opt_arg(token_it->value, token_it->type);
                 if (opt_arg_it == this->_optional_args.end())
-                    throw parsing_failure::unknown_argument(token_it->value);
+                    throw parsing_failure::unknown_argument(this->_unstripped_token_value(*token_it)
+                    );
 
                 curr_opt_arg = std::ref(*opt_arg_it);
                 if (not curr_opt_arg->get()->mark_used())

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -20,7 +20,6 @@
 #include <iostream>
 #include <ranges>
 #include <span>
-#include <utility>
 
 #ifdef AP_TESTING
 
@@ -281,7 +280,7 @@ public:
             return;
 
         this->_verify_required_args();
-        this->_verify_nvalues(); // should this be before the bypass check ?
+        this->_verify_nvalues();
     }
 
     /**
@@ -514,6 +513,7 @@ private:
     /**
      * @brief Returns a unary predicate function which checks if the given name matches the argument's name
      * @param arg_name The name of the argument.
+     * @param m_type The match type used within the predicate.
      * @return Argument predicate based on the provided name.
      */
     [[nodiscard]] auto _name_match_predicate(
@@ -526,6 +526,7 @@ private:
     /**
      * @brief Returns a unary predicate function which checks if the given name matches the argument's name
      * @param arg_name The name of the argument.
+     * @param m_type The match type used within the predicate.
      * @return Argument predicate based on the provided name.
      */
     [[nodiscard]] auto _name_match_predicate(
@@ -607,6 +608,18 @@ private:
         return false;
     }
 
+    /**
+     * @brief Get the unstripped token value (including the flag prefix).
+     *
+     * Given an argument token, this function reconstructs and returns the original argument string,
+     * including any flag prefix that may have been stripped during tokenization.
+     *
+     * @param tok An argument token, the value of which will be processed.
+     * @return The reconstructed argument value:
+     *   - If the token type is `t_flag_primary`, returns the value prefixed with "--".
+     *   - If the token type is `t_flag_secondary`, returns the value prefixed with "-".
+     *   - For all other token types, returns the token's value as is (without any prefix).
+     */
     [[nodiscard]] std::string _unstripped_token_value(const detail::argument_token& tok
     ) const noexcept {
         switch (tok.type) {
@@ -787,7 +800,7 @@ private:
      * @brief Find an optional argument based on a flag token.
      * @param flag_tok An argument_token instance, the value of which will be used to find the argument.
      * @return An iterator to the argument's position.
-     * @note If the `flag_tok.type` is not a valid flag token type, then the end iterator will be returned.
+     * @note If the `flag_tok.type` is not a valid flag token, then the end iterator will be returned.
      */
     [[nodiscard]] arg_ptr_list_iter_t _find_opt_arg(const detail::argument_token& flag_tok
     ) noexcept {

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -17,10 +17,9 @@
 
 #include <algorithm>
 #include <format>
+#include <iostream>
 #include <ranges>
 #include <span>
-
-#include <iostream>
 #include <utility>
 
 #ifdef AP_TESTING
@@ -513,22 +512,17 @@ private:
     }
 
     [[nodiscard]] arg_ptr_list_iter_t _find_opt_arg(
-        const std::string& name,
-        const detail::argument_token::token_type flag_token
+        const std::string& name, const detail::argument_token::token_type flag_token
     ) noexcept {
         switch (flag_token) {
         case detail::argument_token::t_flag_primary:
-            return std::ranges::find(
-                this->_optional_args,
-                name,
-                [](const auto& arg_ptr) { return arg_ptr->name().primary; }
-            );
+            return std::ranges::find(this->_optional_args, name, [](const auto& arg_ptr) {
+                return arg_ptr->name().primary;
+            });
         case detail::argument_token::t_flag_secondary:
-            return std::ranges::find(
-                this->_optional_args,
-                name,
-                [](const auto& arg_ptr) { return arg_ptr->name().secondary; }
-            );
+            return std::ranges::find(this->_optional_args, name, [](const auto& arg_ptr) {
+                return arg_ptr->name().secondary;
+            });
         default:
             return this->_optional_args.end();
         }
@@ -555,7 +549,9 @@ private:
         const detail::argument_name& arg_name,
         const detail::argument_name::match_type m_type = detail::argument_name::m_any
     ) const noexcept {
-        return [&arg_name, m_type](const arg_ptr_t& arg) { return arg->name().match(arg_name, m_type); };
+        return [&arg_name, m_type](const arg_ptr_t& arg) {
+            return arg->name().match(arg_name, m_type);
+        };
     }
 
     /**
@@ -614,10 +610,15 @@ private:
      */
     [[nodiscard]] bool _is_flag(const std::string& arg) const noexcept {
         if (arg.starts_with(this->_flag_prefix))
-            return this->_is_arg_name_used({arg.substr(this->_primary_flag_prefix_length)}, detail::argument_name::m_primary);
+            return this->_is_arg_name_used(
+                {arg.substr(this->_primary_flag_prefix_length)}, detail::argument_name::m_primary
+            );
 
         if (arg.starts_with(this->_flag_prefix_char))
-            return this->_is_arg_name_used({arg.substr(this->_secondary_flag_prefix_length)}, detail::argument_name::m_secondary);
+            return this->_is_arg_name_used(
+                {arg.substr(this->_secondary_flag_prefix_length)},
+                detail::argument_name::m_secondary
+            );
 
         return false;
     }

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -511,23 +511,6 @@ private:
             );
     }
 
-    [[nodiscard]] arg_ptr_list_iter_t _find_opt_arg(
-        const std::string& name, const detail::argument_token::token_type flag_token
-    ) noexcept {
-        switch (flag_token) {
-        case detail::argument_token::t_flag_primary:
-            return std::ranges::find(this->_optional_args, name, [](const auto& arg_ptr) {
-                return arg_ptr->name().primary;
-            });
-        case detail::argument_token::t_flag_secondary:
-            return std::ranges::find(this->_optional_args, name, [](const auto& arg_ptr) {
-                return arg_ptr->name().secondary;
-            });
-        default:
-            return this->_optional_args.end();
-        }
-    }
-
     /**
      * @brief Returns a unary predicate function which checks if the given name matches the argument's name
      * @param arg_name The name of the argument.
@@ -655,6 +638,7 @@ private:
      * @brief Implementation of parsing command-line arguments.
      * @param arg_tokens The list of command-line argument tokens.
      * @throws ap::parsing_failure
+     * \todo Use `c_range_of<argument_token>` instead of `arg_token_list_t` directly.
      */
     void _parse_args_impl(const arg_token_list_t& arg_tokens) {
         arg_token_list_iterator_t token_it = arg_tokens.begin();
@@ -796,6 +780,23 @@ private:
         }
 
         return std::nullopt;
+    }
+
+    [[nodiscard]] arg_ptr_list_iter_t _find_opt_arg(
+        const std::string& name, const detail::argument_token::token_type flag_token
+    ) noexcept {
+        switch (flag_token) {
+        case detail::argument_token::t_flag_primary:
+            return std::ranges::find(this->_optional_args, name, [](const auto& arg_ptr) {
+                return arg_ptr->name().primary;
+            });
+        case detail::argument_token::t_flag_secondary:
+            return std::ranges::find(this->_optional_args, name, [](const auto& arg_ptr) {
+                return arg_ptr->name().secondary;
+            });
+        default:
+            return this->_optional_args.end();
+        }
     }
 
     /**

--- a/include/ap/detail/argument_name.hpp
+++ b/include/ap/detail/argument_name.hpp
@@ -6,11 +6,11 @@
 
 #pragma once
 
+#include <cstdint>
 #include <format>
 #include <optional>
 #include <string>
 #include <string_view>
-#include <cstdint>
 
 namespace ap::detail {
 
@@ -64,7 +64,8 @@ struct argument_name {
      * @param arg_name The name string to match.
      * @return True if name is equal to either the primary or the secondary name of the argument_name instance.
      */
-    [[nodiscard]] bool match(std::string_view arg_name, const match_type m_type = m_any) const noexcept {
+    [[nodiscard]] bool match(std::string_view arg_name, const match_type m_type = m_any)
+        const noexcept {
         switch (m_type) {
         case m_any:
             return this->match_primary(arg_name) or this->match_secondary(arg_name);
@@ -82,7 +83,9 @@ struct argument_name {
      * @param arg_name The argument_name instance to match.
      * @return True if arg_name's primary or secondary value matches the argument_name instance.
      */
-    [[nodiscard]] bool match(const argument_name& arg_name, [[maybe_unused]] const match_type m_type = m_any) const noexcept {
+    [[nodiscard]] bool match(
+        const argument_name& arg_name, [[maybe_unused]] const match_type m_type = m_any
+    ) const noexcept {
         if (this->match(arg_name.primary))
             return true;
 

--- a/include/ap/detail/argument_name.hpp
+++ b/include/ap/detail/argument_name.hpp
@@ -16,7 +16,12 @@ namespace ap::detail {
 
 /// @brief Structure holding the argument's name.
 struct argument_name {
-    enum class match_type : std::uint8_t { m_any, m_primary, m_secondary };
+    /// @brief Specifies the type of argument name match.
+    enum class match_type : std::uint8_t {
+        m_any, ///< Matches either the primary or the secondary name.
+        m_primary, ///< Matches only the primary name.
+        m_secondary ///< Matches only the secondary name.
+    };
     using enum match_type;
 
     argument_name() = delete;
@@ -51,7 +56,7 @@ struct argument_name {
      */
     bool operator==(const argument_name& other) const noexcept {
         if (not (this->secondary and other.secondary) and (this->secondary or other.secondary))
-            return false;
+            return false; // only one of the compared argument names has a secondary name
 
         if (this->primary != other.primary)
             return false;
@@ -62,7 +67,8 @@ struct argument_name {
     /**
      * @brief Matches the given string to the argument_name instance.
      * @param arg_name The name string to match.
-     * @return True if name is equal to either the primary or the secondary name of the argument_name instance.
+     * @param m_type The match type used to find the argument.
+     * @return `true` if the given name matches the primary/secondary name (depending on the match type).
      */
     [[nodiscard]] bool match(std::string_view arg_name, const match_type m_type = m_any)
         const noexcept {
@@ -81,6 +87,7 @@ struct argument_name {
     /**
      * @brief Matches the given argument name to the argument_name instance.
      * @param arg_name The argument_name instance to match.
+     * @param m_type UNUSED - necessary to match the signature of the `string_view` overload of the `match` function.
      * @return True if arg_name's primary or secondary value matches the argument_name instance.
      */
     [[nodiscard]] bool match(
@@ -105,9 +112,9 @@ struct argument_name {
     }
 
     /**
-     * @brief Matches the given string to the primary name of an argument_name instance.
+     * @brief Matches the given string to the secondary name of an argument_name instance.
      * @param arg_name The name string to match.
-     * @return True if name is equal to either the primary name of the argument_name instance.
+     * @return True if name is equal to either the secondary name of the argument_name instance.
      */
     [[nodiscard]] bool match_secondary(std::string_view arg_name) const noexcept {
         return this->secondary and arg_name == this->secondary.value();

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 namespace ap::detail {
@@ -13,7 +14,7 @@ namespace ap::detail {
 /// @brief Structure representing a single command-line argument token.
 struct argument_token {
     /// @brief The token type discriminator.
-    enum class token_type : bool { t_flag, t_value };
+    enum class token_type : std::uint8_t { t_flag_primary, t_flag_secondary, t_value };
     using enum token_type;
 
     argument_token() = delete;

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -14,7 +14,11 @@ namespace ap::detail {
 /// @brief Structure representing a single command-line argument token.
 struct argument_token {
     /// @brief The token type discriminator.
-    enum class token_type : std::uint8_t { t_flag_primary, t_flag_secondary, t_value };
+    enum class token_type : std::uint8_t {
+        t_flag_primary, ///< Represents the primary (--) flag argument.
+        t_flag_secondary, ///< Represents the secondary (-) flag argument.
+        t_value ///< Represents a value argument.
+    };
     using enum token_type;
 
     argument_token() = delete;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -17,7 +17,7 @@ foreach(SOURCE_DIR ${SOURCE_DIRS})
 endforeach()
 
 # Set compile options
-set(DEFAULT_CXX_FLAGS "-Werror -Wall -Wextra -Wcast-align -Wconversion -Wunreachable-code -Wuninitialized -pedantic -g -O2")
+set(DEFAULT_CXX_FLAGS "-Werror -Wall -Wextra -Wcast-align -Wconversion -Wunreachable-code -Wuninitialized -pedantic -g -O0")
 if (NOT CMAKE_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "${DEFAULT_CXX_FLAGS}" CACHE STRING "Default C++ compiler flags" FORCE)
 endif()

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -118,7 +118,7 @@ struct argument_parser_test_fixture {
         for (std::size_t i = 0ull; i < n_optional_args; ++i) {
             const auto arg_idx = n_positional_args + i;
             arg_tokens.push_back(
-                argument_token{argument_token::t_flag, init_arg_name(arg_idx).primary}
+                argument_token{argument_token::t_flag_primary, init_arg_name(arg_idx).primary}
             );
             arg_tokens.push_back(argument_token{argument_token::t_value, init_arg_value(arg_idx)});
         }

--- a/tests/source/test_argument_name.cpp
+++ b/tests/source/test_argument_name.cpp
@@ -64,42 +64,59 @@ TEST_CASE("operator==(argument_name) should return true if both primary and seco
     CHECK_EQ(arg_name_full_1, arg_name_full_1);
 }
 
-TEST_CASE("match(string_view) should return true if the given string matches at least one name") {
-    SUBCASE("argument_name with primary name only") {
-        CHECK(arg_name_primary_1.match(primary_1));
-    }
+TEST_CASE("match(string_view, any) should return true if the given string matches at least one name"
+) {
+    // argument_name with primary name only
+    CHECK(arg_name_primary_1.match(primary_1));
 
-    SUBCASE("argument_name with both names") {
-        CHECK(arg_name_full_1.match(primary_1));
-        CHECK(arg_name_full_1.match(secondary_1));
-    }
+    // argument_name with both names
+    CHECK(arg_name_full_1.match(primary_1));
+    CHECK(arg_name_full_1.match(secondary_1));
 }
 
-TEST_CASE("match(string_view) should return false if the given string dosn't match any name") {
-    SUBCASE("argument_name with primary name only") {
-        CHECK_FALSE(arg_name_primary_1.match(primary_2));
-        CHECK_FALSE(arg_name_primary_1.match(secondary_2));
-    }
+TEST_CASE("match(string_view, any) should return false if the given string dosn't match any name") {
+    // argument_name with primary name only
+    CHECK_FALSE(arg_name_primary_1.match(primary_2));
+    CHECK_FALSE(arg_name_primary_1.match(secondary_2));
 
-    SUBCASE("argument_name with both names") {
-        CHECK_FALSE(arg_name_full_1.match(primary_2));
-        CHECK_FALSE(arg_name_full_1.match(secondary_2));
-    }
+    // argument_name with both names
+    CHECK_FALSE(arg_name_full_1.match(primary_2));
+    CHECK_FALSE(arg_name_full_1.match(secondary_2));
+}
+
+TEST_CASE("match(string_view, primary) should return true only if the given string matches the "
+          "primary name") {
+    // argument_name with primary name only
+    CHECK(arg_name_primary_1.match(primary_1, argument_name::m_primary));
+    CHECK_FALSE(arg_name_primary_1.match(secondary_1, argument_name::m_primary));
+
+    // argument_name with both names
+    CHECK(arg_name_full_1.match(primary_1, argument_name::m_primary));
+    CHECK_FALSE(arg_name_full_1.match(secondary_1, argument_name::m_primary));
+}
+
+TEST_CASE("match(string_view, secondary) should return true only if the given string matches the "
+          "secondary name") {
+    // argument_name with primary name only
+    CHECK_FALSE(arg_name_primary_1.match(primary_1, argument_name::m_secondary));
+    CHECK_FALSE(arg_name_primary_1.match(secondary_1, argument_name::m_secondary));
+
+    // argument_name with both names
+    CHECK_FALSE(arg_name_full_1.match(primary_1, argument_name::m_secondary));
+    CHECK(arg_name_full_1.match(secondary_1, argument_name::m_secondary));
 }
 
 TEST_CASE("match(argument_name) should return true if either the primary or the secondary name of "
           "the passed argument_name matches at least one name") {
-    SUBCASE("argument_name with primary name only") {
-        CHECK(arg_name_primary_1.match(arg_name_primary_1));
-        CHECK(arg_name_primary_1.match(argument_name{primary_2, primary_1}));
-    }
+    // argument_name with primary name only
+    CHECK(arg_name_primary_1.match(arg_name_primary_1));
+    CHECK(arg_name_primary_1.match(argument_name{primary_2, primary_1}));
 
-    SUBCASE("argument_name with both names") {
-        CHECK(arg_name_full_1.match(argument_name{primary_1, secondary_2}));
-        CHECK(arg_name_full_1.match(argument_name{secondary_1, primary_1}));
-        CHECK(arg_name_full_1.match(argument_name{primary_2, primary_1}));
-        CHECK(arg_name_full_1.match(argument_name{primary_2, secondary_1}));
-    }
+    // argument_name with both names
+    CHECK(arg_name_full_1.match(argument_name{primary_1, secondary_2}));
+    CHECK(arg_name_full_1.match(argument_name{secondary_1, primary_1}));
+    CHECK(arg_name_full_1.match(argument_name{primary_2, primary_1}));
+    CHECK(arg_name_full_1.match(argument_name{primary_2, secondary_1}));
 }
 
 TEST_CASE("match(argument_name) should return false if neither the primary nor the secondary name "

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -66,7 +66,7 @@ TEST_CASE_FIXTURE(
 
     std::size_t opt_arg_idx = n_positional_args;
     for (std::size_t i = n_positional_args; i < arg_tokens.size(); i += 2ull) {
-        REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag);
+        REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag_primary);
         CHECK(init_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
 
         REQUIRE_EQ(arg_tokens.at(i + 1ull).type, argument_token::t_value);
@@ -244,7 +244,7 @@ TEST_CASE_FIXTURE(
 
     const auto bypass_required_arg_name = init_arg_name(n_args_total);
     sut.add_optional_argument<bool>(
-           bypass_required_arg_name.primary, bypass_required_arg_name.secondary.value()
+        bypass_required_arg_name.primary, bypass_required_arg_name.secondary.value()
     )
         .default_value(false)
         .implicit_value(true)

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -244,7 +244,7 @@ TEST_CASE_FIXTURE(
 
     const auto bypass_required_arg_name = init_arg_name(n_args_total);
     sut.add_optional_argument<bool>(
-        bypass_required_arg_name.primary, bypass_required_arg_name.secondary.value()
+           bypass_required_arg_name.primary, bypass_required_arg_name.secondary.value()
     )
         .default_value(false)
         .implicit_value(true)

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -201,6 +201,47 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
+    "parse_args should throw when an optional argument's flag uses the correct name but an "
+    "incorrect flag prefix"
+) {
+    constexpr std::size_t n_opt_args = 1ull;
+    constexpr std::size_t opt_arg_idx = 0ull;
+    add_arguments(no_args, n_opt_args);
+
+    auto argc = get_argc(no_args, n_opt_args);
+    auto argv_vec = init_argv_vec(no_args, n_opt_args);
+
+    const auto opt_arg_name = init_arg_name(opt_arg_idx);
+
+    std::string invalid_flag;
+
+    SUBCASE("primary name with a secondary flag prefix") {
+        invalid_flag = "-" + opt_arg_name.primary;
+    }
+    SUBCASE("secondary name with a primary flag prefix") {
+        invalid_flag = "--" + opt_arg_name.secondary.value();
+    }
+
+    CAPTURE(invalid_flag);
+
+    auto arg_flag_it = std::ranges::find(argv_vec, init_arg_flag_primary(opt_arg_idx));
+    if (arg_flag_it == argv_vec.end())
+        FAIL("could not find the optional argument flag");
+
+    *arg_flag_it = invalid_flag;
+    auto argv = to_char_2d_array(argv_vec);
+
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(invalid_flag).what(),
+        parsing_failure
+    );
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
     "parse_args should not throw if the number of positional values are correct and all required "
     "optional arguments have values"
 ) {


### PR DESCRIPTION
- Introduced the `match_type` enum class to specify how the argument name should be matched
- Split the `t_flag` argument token to `t_flag_primary` and `t_flag_secondary`
- Aligned the argument parsing implementation to match the specified flags properly:
  `--` flags are matched only to the primary names and `-` flags only to the secondary names