### PR TITLE
YT-CPPAP-44: Type-flexible argument paremeter setters

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.3.0
+    VERSION 2.3.1
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.3.0
+PROJECT_NUMBER         = 2.3.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -313,6 +313,10 @@ Command                                 Result
 ./program -i input.txt -o myfile.txt    Parsing success; Printing data to the `myfile.txt` file
 ```
 
+> [!TIP]
+>
+> The setter of the `default_value` parameter accepts any type that is convertible to the argument's value type.
+
 #### 5. `choices` - A list of valid argument values.
 
 The `choices` parameter takes as an argument an instance of `std::initializer_list` or any `std::ranges::range` type such that its value type is convertible to the argument's `value_type`.
@@ -367,7 +371,7 @@ Actions are represented as functions, which take the argument's value as an argu
 
 > [!TIP]
 >
-> A single argument can have multiple value actions. Instead of writing complex logic in one action, consider composing several simple, focused actions for better readability and reuse.
+> A single argument can have multiple value actions. Instead of writing complex logic in one action, consider composing several simple, focused actions for better readability and reusability.
 
 <br/>
 
@@ -434,7 +438,8 @@ Command                       Result
 
 > [!TIP]
 >
-> The `implicit_value` parameter is extremely useful when combined with default value (e.g. in case of boolean flags - see [Adding Arguments](#adding-arguments)).
+> - The `implicit_value` parameter is extremely useful when combined with default value (e.g. in case of boolean flags - see [Adding Arguments](#adding-arguments)).
+> - The setter of the `implicit_value` parameter accepts any type that is convertible to the argument's value type.
 
 #### 4. On-flag actions - For optional arguments, apart from value actions, you can specify on-flag actions which are executed immediately after parsing an argument's flag.
 

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -174,8 +174,8 @@ public:
      * @return Reference to the optional argument.
      * @attention Setting the default value disables the `required` flag.
      */
-    optional& default_value(const value_type& default_value) noexcept {
-        this->_default_value = default_value;
+    optional& default_value(const std::convertible_to<value_type> auto& default_value) noexcept {
+        this->_default_value = std::make_any<value_type>(default_value);
         this->_required = false;
         return *this;
     }
@@ -185,8 +185,8 @@ public:
      * @param implicit_value The implicit value to set.
      * @return Reference to the optional argument.
      */
-    optional& implicit_value(const value_type& implicit_value) noexcept {
-        this->_implicit_value = implicit_value;
+    optional& implicit_value(const std::convertible_to<value_type> auto& implicit_value) noexcept {
+        this->_implicit_value = std::make_any<value_type>(implicit_value);
         return *this;
     }
 

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -120,8 +120,8 @@ public:
      * @return Reference to the positional argument.
      * @attention Setting the default value disables the `required` flag.
      */
-    positional& default_value(const value_type& default_value) noexcept {
-        this->_default_value = default_value;
+    positional& default_value(const std::convertible_to<value_type> auto& default_value) noexcept {
+        this->_default_value = std::make_any<value_type>(default_value);
         this->_required = false;
         return *this;
     }


### PR DESCRIPTION
Aligned the setter functions of the `default_value` and `implicit_value` argument parameters to accept as arguments instances of any type convertible to the argument's value type.