### PR TITLE
YT-CPPAP-51: Improve string value handling and argument flag detection

### DIFF
--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -29,12 +29,11 @@ jobs:
           cmake -B build -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false
 
-      - name: Build test executable
+      - name: Build tests
         run: |
-          cd build && make -j 4
+          cmake --build build/ -j 4
         continue-on-error: false
 
       - name: Run tests
         run: |
-          ./build/tests/run
-        continue-on-error: false
+          ctest --test-dir build/tests/ -V

--- a/.github/workflows/gpp.yaml
+++ b/.github/workflows/gpp.yaml
@@ -29,11 +29,11 @@ jobs:
           cmake -B build -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false
 
-      - name: Build test executable
+      - name: Build tests
         run: |
-          cd build && make -j 4
+          cmake --build build/ -j 4
         continue-on-error: false
 
       - name: Run tests
         run: |
-          ./build/tests/run
+          ctest --test-dir build/tests/ -V

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # build files
 *build*/
 *.exe
+Testing/
 
 # documentation files
 /documentation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.3.1
+    VERSION 2.4.0
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.3.1
+PROJECT_NUMBER         = 2.4.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -19,15 +19,13 @@ This will build each test file as a separate executable in the `build/tests/` di
 
 ### Run the tests
 
-You can run tests from each test file manually with:
+You can run tests from each test file separately with:
 
 ```shell
 ./build/tests/<test-name>
 ```
 
-where `<test-name>` is the name of the test file without the extension.
-
-To run all tests at once run:
+To execute all tests at once run:
 
 ```shell
 ctest --test-dir build/tests/ # -V (to capture output from each test executable)

--- a/docs/dev_notes.md
+++ b/docs/dev_notes.md
@@ -12,22 +12,26 @@
 
 ```shell
 cmake -B build -DBUILD_TESTS=ON
-cd build
-make # -j <n>
+cmake --build build/ # -j <njobs>
 ```
 
-This will build the test executable `run` in the `<project-root>/build/tests` directory.
+This will build each test file as a separate executable in the `build/tests/` directory.
 
 ### Run the tests
 
+You can run tests from each test file manually with:
+
 ```shell
-cd build
-./tests/run # -ts=<test-suite-name>
+./build/tests/<test-name>
 ```
 
-> [!NOTE]
->
-> Test suites in the project have the same names as the files they're in except for the `test_extarnal_libs_config.cpp` file which defines the `test_doctest_config` test suite.
+where `<test-name>` is the name of the test file without the extension.
+
+To run all tests at once run:
+
+```shell
+ctest --test-dir build/tests/ # -V (to capture output from each test executable)
+```
 
 <br />
 <br />

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -110,8 +110,8 @@ parser.add_<positional/optional>_argument<value_type>("argument", "a");
 >
 > The library supports any argument value types which meet the following requirements:
 >
-> - The `std::ostream& operator<<` is overloaded for the value type
-> - The value type has a copy constructor and an assignment operator
+> - The type is [constructible from](https://en.cppreference.com/w/cpp/concepts/constructible_from) `const std::string&` or the stream extraction operator - `std::istream& operator>>` is defined for the type.
+> - The type satisfies the [`std::semiregular`](https://en.cppreference.com/w/cpp/concepts/semiregular.html) concept - is default initializable and copyable.
 
 > [!IMPORTANT]
 >

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -638,9 +638,11 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 
 > [!WARNING]
 >
-> By default the `argument_parser` class treats all* command-line arguments beggining with a `--` or `-` prefix as optional argument flags and if the flag's value does not match any of the specified arguments, then such flag is considered *unknown* and an exception will be thrown.
+> By default the `argument_parser` class treats *all\** command-line arguments beggining with a `--` or `-` prefix as optional argument flags and if the flag's value does not match any of the specified arguments, then such flag is considered *unknown* and an exception will be thrown.
 >
-> This behaviour can be altered so that the unknown argument flags will be treated as values, not flags.
+> *\** If a command-line argument begins with a flag prefix, but contains whitespaces (e.g. `"--flag value"`), then it is treated as a value and not a flag.
+>
+> This behavior can be altered so that the unknown argument flags will be treated as values, not flags.
 >
 > Example:
 > ```cpp
@@ -796,7 +798,7 @@ int main(int argc, char* argv[]) {
 
 > [!IMPORTANT]
 >
-> The parser behaviour depends on the argument definitions. The argument parameters are described int the [Argument parameters](#argument-parameters) section.
+> The parser's behavior depends on the argument definitions - see [Argument Parameters](#argument-parameters) section.
 
 <br/>
 <br/>
@@ -808,14 +810,14 @@ You can retrieve the argument's value with:
 
 ```cpp
 (const) auto value = parser.value<value_type>("argument_name"); // (1)
-(const) auto value = parser.value_or<value_type>("argument_name", default_value); // (2)
+(const) auto value = parser.value_or<value_type>("argument_name", fallback_value); // (2)
 ```
 
 1. This will return the value parsed for the given argument.
 
     For optional arguments this will return the argument's predefined value if no value has been parsed. Additionaly, if more than one value has been parsed for an optional argument, this function will return the first parsed value.
 
-2. When a value has been parsed for the argument, the behaviour is the same as in case **(1)**. Otherwise, this will return `value_type{std::forward<U>(default_value)}` (where `U` is the deducted type of `default_value`), if:
+2. When a value has been parsed for the argument, the behavior is the same as in case **(1)**. Otherwise, this will return `value_type{std::forward<U>(fallback_value)}` (where `U` is the deducted type of `fallback_value`), if:
 
     - There is no value parsed for a positional argument
     - There is no parsed values and no predefined values for an optional arrument

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -633,6 +633,10 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 > parse_args(std::span(argv + 1, argc - 1));
 > ```
 
+> [!WARNING]
+>
+> TODO: describe the default argument flag detection behaviour and the use of the `AP_UNKNOWN_FLAGS_AS_VALUES` macro
+
 > [!TIP]
 >
 > The `parse_args` function may throw an `ap::argument_parser_exception` (specifically the `ap::parsing_failure` derived exception) if the provided command-line arguments do not match the expected configuration. To simplify error handling, the `argument_parser` class provides `try_parse_args` methods, which automatically catch these exceptions, print the error message, and exit with a failure status.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -635,7 +635,30 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 
 > [!WARNING]
 >
-> TODO: describe the default argument flag detection behaviour and the use of the `AP_UNKNOWN_FLAGS_AS_VALUES` macro
+> By default the `argument_parser` class treats all* command-line arguments beggining with a `--` or `-` prefix as optional argument flags and if the flag's value does not match any of the specified arguments, then such flag is considered *unknown* and an exception will be thrown.
+>
+> This behaviour can be altered so that the unknown argument flags will be treated as values, not flags.
+>
+> Example:
+> ```cpp
+> parser.add_optional_argument("option", "o");
+> parser.try_parse_args(argc, argv);
+> std::cout << "option: " << parser.value("option");
+>
+> /*
+> ./program --option --unknown-flag
+> option: --unknown-flag
+> ```
+>
+> To do this add the following in you `CMakeLists.txt` file:
+> ```cmake
+> target_compile_definitions(cpp-ap-2 PRIVATE AP_UNKNOWN_FLAGS_AS_VALUES)
+> ```
+> or simply add:
+> ```cpp
+> #define AP_UNKNOWN_FLAGS_AS_VALUES
+> ```
+> before the `#include <ap/argument_parser.hpp>` statement.
 
 > [!TIP]
 >

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -106,16 +106,19 @@ or
 parser.add_<positional/optional>_argument<value_type>("argument", "a");
 ```
 
-> [!NOTE]
+> [!IMPORTANT]
 >
 > The library supports any argument value types which meet the following requirements:
 >
 > - The type is [constructible from](https://en.cppreference.com/w/cpp/concepts/constructible_from) `const std::string&` or the stream extraction operator - `std::istream& operator>>` is defined for the type.
+>
+>    **IMPORTANT:** The argument parser will always use direct initialization from `std::string` and will use the extraction operator only if an argument's value type cannot be initialized from `std::string`.
+>
 > - The type satisfies the [`std::semiregular`](https://en.cppreference.com/w/cpp/concepts/semiregular.html) concept - is default initializable and copyable.
 
-> [!IMPORTANT]
+> [!NOTE]
 >
-> If the `value_type` is not provided, `std::string` will be used.
+> The default value type of any argument is `std::string`.
 
 You can also add boolean flags:
 

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -263,8 +263,13 @@ private:
             throw parsing_failure::invalid_nvalues(this->_name, std::weak_ordering::greater);
 
         value_type value;
-        if (not (std::istringstream(str_value) >> value))
-            throw parsing_failure::invalid_value(this->_name, str_value);
+        if constexpr (detail::c_trivially_readable<value_type>) {
+            value = value_type(str_value);
+        }
+        else {
+            if (not (std::istringstream(str_value) >> value))
+                throw parsing_failure::invalid_value(this->_name, str_value);
+        }
 
         if (not detail::is_valid_choice(value, this->_choices))
             throw parsing_failure::invalid_choice(this->_name, str_value);

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -207,12 +207,10 @@ private:
 
     /**
      * @param verbose The verbosity mode value.
-     * @param flag_char The character used for the argument flag prefix.
      * @return An argument descriptor object for the argument.
      */
-    [[nodiscard]] detail::argument_descriptor desc(const bool verbose, const char flag_char)
-        const noexcept override {
-        detail::argument_descriptor desc(this->_name.str(flag_char), this->_help_msg);
+    [[nodiscard]] detail::argument_descriptor desc(const bool verbose) const noexcept override {
+        detail::argument_descriptor desc(this->_name.str(), this->_help_msg);
 
         if (not verbose)
             return desc;

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -156,12 +156,9 @@ private:
 
     /**
      * @param verbose The verbosity mode value.
-     * @param flag_char The character used for the argument flag prefix.
      * @return An argument descriptor object for the argument.
      */
-    [[nodiscard]] detail::argument_descriptor desc(
-        const bool verbose, [[maybe_unused]] const char flag_char
-    ) const noexcept override {
+    [[nodiscard]] detail::argument_descriptor desc(const bool verbose) const noexcept override {
         detail::argument_descriptor desc(this->_name.str(), this->_help_msg);
 
         if (not verbose)

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -207,8 +207,13 @@ private:
             throw parsing_failure::value_already_set(this->_name);
 
         value_type value;
-        if (not (std::istringstream(str_value) >> value))
-            throw parsing_failure::invalid_value(this->_name, str_value);
+        if constexpr (detail::c_trivially_readable<value_type>) {
+            value = value_type(str_value);
+        }
+        else {
+            if (not (std::istringstream(str_value) >> value))
+                throw parsing_failure::invalid_value(this->_name, str_value);
+        }
 
         if (not detail::is_valid_choice(value, this->_choices))
             throw parsing_failure::invalid_choice(this->_name, str_value);

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -497,7 +497,6 @@ private:
                 arg_name, "An argument name cannot be empty."
             );
 
-        // TODO: add tests
         if (detail::contains_whitespaces(arg_name))
             throw invalid_configuration::invalid_argument_name(
                 arg_name, "An argument name cannot contain whitespaces."

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -193,7 +193,7 @@ public:
     argument::optional<T>& add_optional_argument(std::string_view primary_name) {
         this->_verify_arg_name_pattern(primary_name);
 
-        const detail::argument_name arg_name = {primary_name};
+        const detail::argument_name arg_name(primary_name, std::nullopt, this->_flag_prefix_char);
         if (this->_is_arg_name_used(arg_name))
             throw invalid_configuration::argument_name_used(arg_name);
 
@@ -218,7 +218,7 @@ public:
         this->_verify_arg_name_pattern(primary_name);
         this->_verify_arg_name_pattern(secondary_name);
 
-        const detail::argument_name arg_name = {primary_name, secondary_name};
+        const detail::argument_name arg_name(primary_name, secondary_name, this->_flag_prefix_char);
         if (this->_is_arg_name_used(arg_name))
             throw invalid_configuration::argument_name_used(arg_name);
 
@@ -510,6 +510,8 @@ private:
             throw invalid_configuration::invalid_argument_name(
                 arg_name, "An argument name cannot begin with a digit."
             );
+
+        // TODO: cannot contain whitespace characters
     }
 
     /**
@@ -859,15 +861,14 @@ private:
     void _print(std::ostream& os, const arg_ptr_list_t& args, const bool verbose) const noexcept {
         if (verbose) {
             for (const auto& arg : args)
-                os << '\n'
-                   << arg->desc(verbose, this->_flag_prefix_char).get(this->_indent_width) << '\n';
+                os << '\n' << arg->desc(verbose).get(this->_indent_width) << '\n';
         }
         else {
             std::vector<detail::argument_descriptor> descriptors;
             descriptors.reserve(args.size());
 
             for (const auto& arg : args)
-                descriptors.emplace_back(arg->desc(verbose, this->_flag_prefix_char));
+                descriptors.emplace_back(arg->desc(verbose));
 
             std::size_t max_arg_name_length = 0ull;
             for (const auto& desc : descriptors)

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -58,11 +58,9 @@ protected:
 
     /**
      * @param verbose The verbosity mode value.
-     * @param flag_char The character used for the argument flag prefix.
      * @return An argument descriptor object for the argument.
      */
-    virtual detail::argument_descriptor desc(const bool verbose, const char flag_char)
-        const noexcept = 0;
+    virtual detail::argument_descriptor desc(const bool verbose) const noexcept = 0;
 
     /**
      * @brief Mark the argument as used.

--- a/include/ap/detail/argument_descriptor.hpp
+++ b/include/ap/detail/argument_descriptor.hpp
@@ -40,41 +40,41 @@ public:
 
     /**
      * @brief Adds a parameter descriptor with the given string value.
-     * @param name The parameter's name.
+     * @param param_name The parameter's name.
      * @param value The parameter's value's string representation.
      */
-    void add_param(const std::string& name, const std::string& value) {
-        this->params.emplace_back(name, value);
+    void add_param(const std::string& param_name, const std::string& value) {
+        this->params.emplace_back(param_name, value);
     }
 
     /**
      * @brief Adds a parameter descriptor with the given value.
      * @tparam T The type of the parameter; must satisfy the @ref ap::detail::c_writable concept.
-     * @param name The parameter's name.
+     * @param param_name The parameter's name.
      * @param value The parameter's value.
      */
     template <c_writable T>
-    void add_param(const std::string& name, const T& value) {
+    void add_param(const std::string& param_name, const T& value) {
         std::ostringstream oss;
         oss << std::boolalpha << value;
-        this->params.emplace_back(name, oss.str());
+        this->params.emplace_back(param_name, oss.str());
     }
 
     /**
      * @brief Adds a range parameter descriptor with the given value.
      * @tparam R The type of the parameter range. The value type of R must satisfy the @ref ap::detail::c_writable concept.
-     * @param name The parameter's name.
+     * @param param_name The parameter's name.
      * @param range The parameter value range.
      * @param delimiter The delimiter used to separate the range values.
      */
     template <std::ranges::range R>
     requires(c_writable<std::ranges::range_value_t<R>>)
     void add_range_param(
-        const std::string& name,
+        const std::string& param_name,
         const R& range,
         const std::string_view delimiter = default_delimiter
     ) {
-        this->params.emplace_back(name, join(range, delimiter));
+        this->params.emplace_back(param_name, join(range, delimiter));
     }
 
     /**

--- a/include/ap/detail/argument_name.hpp
+++ b/include/ap/detail/argument_name.hpp
@@ -33,18 +33,17 @@ struct argument_name {
     argument_name(argument_name&&) = default;
 
     /**
-     * @brief Primary name constructor.
-     * @param primary The primary name of the argument.
-     */
-    argument_name(std::string_view primary) : primary(primary) {}
-
-    /**
      * @brief Primary and secondary name constructor.
      * @param primary The primary name of the argument.
      * @param secondary The secondary (short) name of the argument.
+     * @param flag_char The flag character (used for optional argument names).
      */
-    argument_name(std::string_view primary, std::string_view secondary)
-    : primary(primary), secondary(secondary) {}
+    argument_name(
+        std::string_view primary,
+        std::optional<std::string_view> secondary = std::nullopt,
+        std::optional<char> flag_char = std::nullopt
+    )
+    : primary(primary), secondary(std::move(secondary)), flag_char(std::move(flag_char)) {}
 
     /// @brief Class destructor.
     ~argument_name() = default;
@@ -124,10 +123,9 @@ struct argument_name {
      * @brief Get a string representation of the argument_name.
      * @param flag_char The character used for the argument flag prefix.
      */
-    [[nodiscard]] std::string str(const std::optional<char> flag_char = std::nullopt)
-        const noexcept {
+    [[nodiscard]] std::string str() const noexcept {
         // if flag_char = nullopt, then the fallback character doesn't matter - the string will be empty
-        const std::string fc(flag_char.has_value(), flag_char.value_or(char()));
+        const std::string fc(this->flag_char.has_value(), this->flag_char.value_or(char()));
         return this->secondary
                  ? std::format("{}{}{}, {}{}", fc, fc, this->primary, fc, this->secondary.value())
                  : std::format("{}{}{}", fc, fc, this->primary);
@@ -146,6 +144,7 @@ struct argument_name {
 
     const std::string primary; ///< The primary name of the argument.
     const std::optional<std::string> secondary; ///< The optional (short) name of the argument.
+    const std::optional<char> flag_char; ///< The flag character (used for optional argument names).
 };
 
 } // namespace ap::detail

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -21,23 +21,6 @@ struct argument_token {
     };
     using enum token_type;
 
-    argument_token() = delete;
-
-    argument_token(const argument_token&) = default;
-    argument_token(argument_token&&) = default;
-
-    argument_token& operator=(const argument_token&) = default;
-    argument_token& operator=(argument_token&&) = default;
-
-    /**
-     * @brief Constructor of a command-line argument.
-     * @param type Type type of the token (flag or value).
-     * @param value The value of the argument.
-     */
-    argument_token(const token_type type, const std::string& value) : type(type), value(value) {}
-
-    ~argument_token() = default;
-
     /**
      * @brief Equality operator for comparing argument_token instances.
      * @param other An argument_token instance to compare with.
@@ -45,6 +28,14 @@ struct argument_token {
      */
     bool operator==(const argument_token& other) const noexcept {
         return this->type == other.type and this->value == other.value;
+    }
+
+    /**
+     * @brief Checks whether the `type` member is a flag token type.
+     * @return true if `type` is either `t_flag_primary` or `t_flag_secondary`, false otherwise.
+     */
+    [[nodiscard]] bool is_flag_token() const noexcept {
+        return this->type == t_flag_primary or this->type == t_flag_secondary;
     }
 
     token_type type;

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -38,8 +38,8 @@ struct argument_token {
         return this->type == t_flag_primary or this->type == t_flag_secondary;
     }
 
-    token_type type;
-    std::string value;
+    token_type type; ///< The token's type discrimiator value.
+    std::string value; ///< The actual token's value.
 };
 
 } // namespace ap::detail

--- a/include/ap/detail/concepts.hpp
+++ b/include/ap/detail/concepts.hpp
@@ -22,6 +22,13 @@ template <typename T>
 concept c_readable = requires(T value, std::istream& input_stream) { input_stream >> value; };
 
 /**
+ * @brief The concept is satisfied when `T` can be constructed from `const std::string&`.
+ * @tparam T Type to check.
+ */
+template <typename T>
+concept c_trivially_readable = std::constructible_from<T, const std::string&>;
+
+/**
  * @brief The concept is satisfied when `T` overloads the std::ostream operator `<<`.
  * @tparam T Type to check.
  */
@@ -40,7 +47,7 @@ concept c_arithmetic = std::is_arithmetic_v<T>;
  * @tparam T Type to check.
  */
 template <typename T>
-concept c_argument_value_type = c_readable<T> and std::semiregular<T>;
+concept c_argument_value_type = std::semiregular<T> and (c_trivially_readable<T> or c_readable<T>);
 
 /**
  * @brief Validates that `T` is the same as one of the types defined by `Types`.

--- a/include/ap/detail/str_utility.hpp
+++ b/include/ap/detail/str_utility.hpp
@@ -29,7 +29,6 @@ template <c_writable T>
     return oss.str();
 }
 
-// TODO: add tests
 /// @brief Checks whether a string contains any whitespace characters.
 [[nodiscard]] inline bool contains_whitespaces(std::string_view str) noexcept {
     return std::ranges::any_of(str, [](unsigned char c) { return std::isspace(c); });

--- a/include/ap/detail/str_utility.hpp
+++ b/include/ap/detail/str_utility.hpp
@@ -11,6 +11,7 @@
 
 #include "concepts.hpp"
 
+#include <algorithm>
 #include <sstream>
 #include <string_view>
 
@@ -26,6 +27,12 @@ template <c_writable T>
     std::ostringstream oss;
     oss << value;
     return oss.str();
+}
+
+// TODO: add tests
+/// @brief Checks whether a string contains any whitespace characters.
+[[nodiscard]] inline bool contains_whitespaces(std::string_view str) noexcept {
+    return std::ranges::any_of(str, [](unsigned char c) { return std::isspace(c); });
 }
 
 /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,34 +3,67 @@ cmake_minimum_required(VERSION 3.12)
 
 # Project
 project(cpp-ap-test)
+enable_testing()
 
 # Structure
-set(SOURCE_DIRS "source" "app")
 set(INCLUDE_DIRS "include" "external")
 set(EXECUTABLE_DIR "${CMAKE_CURRENT_BINARY_DIR}")
-
-# Source files
-file(GLOB_RECURSE SOURCES "")
-foreach(SOURCE_DIR ${SOURCE_DIRS})
-    file(GLOB_RECURSE CURRENT_SOURCES ${SOURCE_DIR}/*.cpp)
-    list(APPEND SOURCES ${CURRENT_SOURCES})
-endforeach()
 
 # Set compile options
 set(DEFAULT_CXX_FLAGS "-Werror -Wall -Wextra -Wcast-align -Wconversion -Wunreachable-code -Wuninitialized -pedantic -g -O0")
 if (NOT CMAKE_CXX_FLAGS)
     set(CMAKE_CXX_FLAGS "${DEFAULT_CXX_FLAGS}" CACHE STRING "Default C++ compiler flags" FORCE)
 endif()
-
 message(STATUS "[CMAKE_CXX_FLAGS = ${CMAKE_CXX_FLAGS}]")
+set(COMMON_COMPILE_DEFINITIONS "AP_TESTING")
 
-# Executable
-add_executable(run ${SOURCES})
-set_target_properties(run PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY "${EXECUTABLE_DIR}"
+
+# Decalre test targets
+add_library(doctest_main STATIC app/main.cpp)
+set_target_properties(doctest_main PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
     CXX_EXTENSIONS NO
 )
-target_include_directories(run PRIVATE ${INCLUDE_DIRS})
-target_link_libraries(run PRIVATE cpp-ap-2)
+target_include_directories(doctest_main PUBLIC "external")
+
+macro(add_doctest SOURCE_FILE)
+    # Parse macro arguments
+    get_filename_component(TEST_NAME ${SOURCE_FILE} NAME_WE)
+    set(options)
+    set(oneValueArgs)
+    set(multiValueArgs COMPILE_DEFINITIONS)
+    cmake_parse_arguments(ARGS "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
+
+    # Define the executable
+    add_executable(${TEST_NAME} ${SOURCE_FILE})
+    set_target_properties(${TEST_NAME} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${EXECUTABLE_DIR}"
+        CXX_STANDARD 20
+        CXX_STANDARD_REQUIRED YES
+        CXX_EXTENSIONS NO
+    )
+    target_include_directories(${TEST_NAME} PRIVATE ${INCLUDE_DIRS})
+    target_compile_definitions(${TEST_NAME} PRIVATE ${COMMON_COMPILE_DEFINITIONS})
+    if(ARGS_COMPILE_DEFINITIONS)
+        target_compile_definitions(${TEST_NAME} PRIVATE ${ARGS_COMPILE_DEFINITIONS})
+    endif()
+    target_link_libraries(${TEST_NAME} PRIVATE doctest_main cpp-ap-2)
+
+    # Register with CTest
+    add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})
+endmacro()
+
+add_doctest("source/test_argument_descriptor.cpp")
+add_doctest("source/test_argument_name.cpp")
+add_doctest("source/test_argument_parser_add_argument.cpp")
+add_doctest("source/test_argument_parser_info.cpp")
+add_doctest("source/test_argument_parser_parse_args.cpp")
+add_doctest("source/test_argument_parser_parse_args_unknown_flags_as_values.cpp"
+    COMPILE_DEFINITIONS "AP_UNKNOWN_FLAGS_AS_VALUES"
+)
+add_doctest("source/test_extarnal_libs_config.cpp")
+add_doctest("source/test_nargs_range.cpp")
+add_doctest("source/test_optional_argument.cpp")
+add_doctest("source/test_positional_argument.cpp")
+add_doctest("source/test_str_utility.cpp")

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#define AP_TESTING
-
 #include <ap/argument_parser.hpp>
 
 #include <cstring>
@@ -25,15 +23,15 @@ struct argument_parser_test_fixture {
 
     // test utility functions
     [[nodiscard]] std::string init_arg_flag_primary(std::size_t i) const {
-        return std::format("--test_arg_{}", i);
+        return std::format("--test-arg-{}", i);
     }
 
     [[nodiscard]] std::string init_arg_flag_secondary(std::size_t i) const {
-        return std::format("-ta_{}", i);
+        return std::format("-ta-{}", i);
     }
 
     [[nodiscard]] argument_value_type init_arg_value(std::size_t i) const {
-        return std::format("test_value_{}", i);
+        return std::format("test-value-{}", i);
     }
 
     [[nodiscard]] std::size_t get_args_length(
@@ -92,7 +90,7 @@ struct argument_parser_test_fixture {
         std::size_t i, std::optional<char> flag_char = std::nullopt
     ) const {
         return argument_name(
-            std::format("test_arg_{}", i), std::format("ta_{}", i), std::move(flag_char)
+            std::format("test-arg-{}", i), std::format("ta-{}", i), std::move(flag_char)
         );
     }
 

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -88,8 +88,12 @@ struct argument_parser_test_fixture {
         delete[] argv;
     }
 
-    [[nodiscard]] argument_name init_arg_name(std::size_t i) const {
-        return argument_name{std::format("test_arg_{}", i), std::format("ta_{}", i)};
+    [[nodiscard]] argument_name init_arg_name(
+        std::size_t i, std::optional<char> flag_char = std::nullopt
+    ) const {
+        return argument_name(
+            std::format("test_arg_{}", i), std::format("ta_{}", i), std::move(flag_char)
+        );
     }
 
     template <c_argument_value_type T = std::string>

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#define AP_TESTING
-
 #include <ap/argument/optional.hpp>
 #include <ap/detail/str_utility.hpp>
 

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -107,7 +107,7 @@ struct optional_argument_test_fixture {
 
     template <c_argument_value_type T>
     [[nodiscard]] argument_descriptor get_desc(const optional<T>& arg, const bool verbose) const {
-        return arg.desc(verbose, flag_char);
+        return arg.desc(verbose);
     }
 
     template <c_argument_value_type T>
@@ -119,8 +119,6 @@ struct optional_argument_test_fixture {
     [[nodiscard]] bool is_bypass_required_enabled(const optional<T>& arg) const {
         return arg.bypass_required_enabled();
     }
-
-    static constexpr char flag_char = '-';
 };
 
 } // namespace ap_testing

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -30,7 +30,7 @@ struct positional_argument_test_fixture {
 
     template <c_argument_value_type T>
     [[nodiscard]] argument_descriptor get_desc(const positional<T>& arg, const bool verbose) const {
-        return arg.desc(verbose, flag_char);
+        return arg.desc(verbose);
     }
 
     template <c_argument_value_type T>
@@ -102,8 +102,6 @@ struct positional_argument_test_fixture {
     const std::vector<std::any>& get_values(const positional<T>& arg) const {
         return arg.values();
     }
-
-    static constexpr char flag_char = '-';
 };
 
 } // namespace ap_testing

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#define AP_TESTING
-
 #include <ap/argument/positional.hpp>
 
 using ap::argument::positional;

--- a/tests/source/test_argument_descriptor.cpp
+++ b/tests/source/test_argument_descriptor.cpp
@@ -16,8 +16,6 @@ constexpr std::size_t align_to = 15ull;
 
 } // namespace
 
-TEST_SUITE_BEGIN("test_argument_descriptor");
-
 TEST_CASE("argument_descriptor should construct with name and optional help correctly") {
     sut_type no_help(arg_name, std::nullopt);
     CHECK_EQ(no_help.name, arg_name);
@@ -157,5 +155,3 @@ TEST_CASE("get should fall back to multiline output if string is too wide") {
 
     CHECK_EQ(sut.get(indent_width, max_line_width), expected.str());
 }
-
-TEST_SUITE_END(); // test_argument_descriptor

--- a/tests/source/test_argument_descriptor.cpp
+++ b/tests/source/test_argument_descriptor.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "doctest.h"
 
 #include <ap/detail/argument_descriptor.hpp>

--- a/tests/source/test_argument_name.cpp
+++ b/tests/source/test_argument_name.cpp
@@ -22,8 +22,6 @@ const argument_name arg_name_full_2{primary_2, secondary_2};
 
 } // namespace
 
-TEST_SUITE_BEGIN("test_argument_name");
-
 TEST_CASE("argument_name.primary member should be correctly initialized") {
     CHECK_EQ(arg_name_primary_1.primary, primary_1);
     CHECK_EQ(arg_name_primary_2.primary, primary_2);
@@ -141,5 +139,3 @@ TEST_CASE("operator<< should push correct data to the output stream") {
 
     REQUIRE_EQ(ss.str(), expected_ss.str());
 }
-
-TEST_SUITE_END();

--- a/tests/source/test_argument_name.cpp
+++ b/tests/source/test_argument_name.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "doctest.h"
 
 #include <ap/detail/argument_name.hpp>

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -7,8 +7,6 @@ using namespace ap_testing;
 using namespace ap::argument;
 using ap::invalid_configuration;
 
-TEST_SUITE_BEGIN("test_argument_parser_add_argument");
-
 struct test_argument_parser_add_argument : public argument_parser_test_fixture {
     const char flag_char = '-';
 
@@ -321,5 +319,3 @@ TEST_CASE_FIXTURE(
     REQUIRE(output_arg);
     CHECK(is_optional<std::string>(output_arg.value()));
 }
-
-TEST_SUITE_END();

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -12,6 +12,8 @@ using ap::invalid_configuration;
 TEST_SUITE_BEGIN("test_argument_parser_add_argument");
 
 struct test_argument_parser_add_argument : public argument_parser_test_fixture {
+    const char flag_char = '-';
+
     const std::string_view primary_name_1 = "primary_name_1";
     const std::string_view secondary_name_1 = "s1";
 
@@ -179,7 +181,8 @@ TEST_CASE_FIXTURE(
     SUBCASE("adding argument with a previously used primary name") {
         CHECK_THROWS_WITH_AS(
             sut.add_optional_argument(primary_name_1, secondary_name_2),
-            invalid_configuration::argument_name_used({primary_name_1, secondary_name_2}).what(),
+            invalid_configuration::argument_name_used({primary_name_1, secondary_name_2, flag_char})
+                .what(),
             invalid_configuration
         );
     }
@@ -187,7 +190,8 @@ TEST_CASE_FIXTURE(
     SUBCASE("adding argument with a previously used secondary name") {
         CHECK_THROWS_WITH_AS(
             sut.add_optional_argument(primary_name_2, secondary_name_1),
-            invalid_configuration::argument_name_used({primary_name_2, secondary_name_1}).what(),
+            invalid_configuration::argument_name_used({primary_name_2, secondary_name_1, flag_char})
+                .what(),
             invalid_configuration
         );
     }
@@ -233,7 +237,8 @@ TEST_CASE_FIXTURE(
     SUBCASE("adding argument with a previously used primary name") {
         CHECK_THROWS_WITH_AS(
             sut.add_flag(primary_name_1, secondary_name_2),
-            invalid_configuration::argument_name_used({primary_name_1, secondary_name_2}).what(),
+            invalid_configuration::argument_name_used({primary_name_1, secondary_name_2, flag_char})
+                .what(),
             invalid_configuration
         );
     }
@@ -241,7 +246,8 @@ TEST_CASE_FIXTURE(
     SUBCASE("adding argument with a previously used secondary name") {
         CHECK_THROWS_WITH_AS(
             sut.add_flag(primary_name_2, secondary_name_1),
-            invalid_configuration::argument_name_used({primary_name_2, secondary_name_1}).what(),
+            invalid_configuration::argument_name_used({primary_name_2, secondary_name_1, flag_char})
+                .what(),
             invalid_configuration
         );
     }

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "argument_parser_test_fixture.hpp"
 #include "doctest.h"
 #include "optional_argument_test_fixture.hpp"

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -21,6 +21,7 @@ struct test_argument_parser_add_argument : public argument_parser_test_fixture {
     const std::string_view secondary_name_2 = "s2";
 
     const std::string_view invalid_name_empty = "";
+    const std::string_view invalid_name_whitespace = "invalid name";
     const std::string_view invalid_name_flag_prefix = "-invalid";
     const std::string_view invalid_name_digit = "1invalid";
 };
@@ -35,6 +36,11 @@ TEST_CASE_FIXTURE(
     SUBCASE("The name is empty") {
         primary_name = invalid_name_empty;
         reason = "An argument name cannot be empty.";
+    }
+
+    SUBCASE("The name contains whitespace characters") {
+        primary_name = invalid_name_whitespace;
+        reason = "An argument name cannot contain whitespaces.";
     }
 
     SUBCASE("The name begins with the flag prefix character") {
@@ -75,6 +81,11 @@ TEST_CASE_FIXTURE(
         reason = "An argument name cannot be empty.";
     }
 
+    SUBCASE("The name contains whitespace characters") {
+        primary_name = invalid_name_whitespace;
+        reason = "An argument name cannot contain whitespaces.";
+    }
+
     SUBCASE("The name begins with the flag prefix character") {
         primary_name = invalid_name_flag_prefix;
         reason = "An argument name cannot begin with a flag prefix character (-).";
@@ -113,6 +124,11 @@ TEST_CASE_FIXTURE(
         reason = "An argument name cannot be empty.";
     }
 
+    SUBCASE("The name contains whitespace characters") {
+        secondary_name = invalid_name_whitespace;
+        reason = "An argument name cannot contain whitespaces.";
+    }
+
     SUBCASE("The name begins with the flag prefix character") {
         secondary_name = invalid_name_flag_prefix;
         reason = "An argument name cannot begin with a flag prefix character (-).";
@@ -141,8 +157,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_add_argument,
-    "add_positional_argument should throw only when adding an"
-    "argument with a previously used name"
+    "add_positional_argument should throw when adding an argument with a previously used name"
 ) {
     sut.add_positional_argument(primary_name_1, secondary_name_1);
 
@@ -169,8 +184,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_add_argument,
-    "add_optional_argument should throw only when adding an"
-    "argument with a previously used name"
+    "add_optional_argument should throw when adding an argument with a previously used name"
 ) {
     sut.add_optional_argument(primary_name_1, secondary_name_1);
 
@@ -226,7 +240,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_add_argument,
-    "add_flag should throw only when adding and argument with a previously used name"
+    "add_flag should throw when adding and argument with a previously used name"
 ) {
     sut.add_flag(primary_name_1, secondary_name_1);
 

--- a/tests/source/test_argument_parser_info.cpp
+++ b/tests/source/test_argument_parser_info.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "argument_parser_test_fixture.hpp"
 #include "doctest.h"
 

--- a/tests/source/test_argument_parser_info.cpp
+++ b/tests/source/test_argument_parser_info.cpp
@@ -3,8 +3,6 @@
 
 using namespace ap_testing;
 
-TEST_SUITE_BEGIN("test_argument_parser_info");
-
 struct test_argument_parser_info : public argument_parser_test_fixture {
     const std::string test_name = "test program name";
     const std::string test_description = "test program description";
@@ -41,5 +39,3 @@ TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name
     REQUIRE(stored_program_description);
     CHECK_EQ(stored_program_description.value(), test_description);
 }
-
-TEST_SUITE_END();

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -29,6 +29,8 @@ struct test_argument_parser_parse_args : public argument_parser_test_fixture {
     const std::string optional_primary_name = "optional_arg";
     const std::string optional_secondary_name = "oa";
 
+    const char flag_char = '-';
+
     const std::string empty_str{};
 };
 
@@ -191,7 +193,7 @@ TEST_CASE_FIXTURE(
 ) {
     add_arguments(n_positional_args, n_optional_args);
 
-    const auto required_arg_name = init_arg_name(n_args_total);
+    const auto required_arg_name = init_arg_name(n_args_total, flag_char);
     sut.add_optional_argument(required_arg_name.primary, required_arg_name.secondary.value())
         .required();
 
@@ -216,7 +218,7 @@ TEST_CASE_FIXTURE(
     auto argc = get_argc(n_positional_args, n_optional_args);
     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    const auto range_arg_name = init_arg_name(n_args_total);
+    const auto range_arg_name = init_arg_name(n_args_total, flag_char);
     sut.add_optional_argument(range_arg_name.primary, range_arg_name.secondary.value())
         .nargs(at_least(1ull));
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -8,8 +8,6 @@ using namespace ap::nargs;
 using ap::invalid_configuration;
 using ap::parsing_failure;
 
-TEST_SUITE_BEGIN("test_argument_parser_parse_args");
-
 struct test_argument_parser_parse_args : public argument_parser_test_fixture {
     const std::string_view test_program_name = "test program name";
 
@@ -842,5 +840,3 @@ TEST_CASE_FIXTURE(
 
     free_argv(argc, argv);
 }
-
-TEST_SUITE_END(); // test_argument_parser_parse_args

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "argument_parser_test_fixture.hpp"
 #include "doctest.h"
 #include "utility.hpp"
@@ -225,6 +223,28 @@ TEST_CASE_FIXTURE(
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
         parsing_failure::invalid_nvalues(range_arg_name, std::weak_ordering::less).what(),
+        parsing_failure
+    );
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "parse_args should throw when an unknown argument flag is used"
+) {
+    add_arguments(no_args, no_args);
+
+    constexpr std::size_t n_opt_clargs = 1ull;
+    constexpr std::size_t opt_arg_idx = 0ull;
+
+    auto argc = get_argc(no_args, n_opt_clargs);
+    auto argv = init_argv(no_args, n_opt_clargs);
+
+    const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
+
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(unknown_arg_name).what(),
         parsing_failure
     );
 

--- a/tests/source/test_argument_parser_parse_args_unknown_flags_as_values.cpp
+++ b/tests/source/test_argument_parser_parse_args_unknown_flags_as_values.cpp
@@ -8,8 +8,6 @@ using namespace ap::nargs;
 using ap::invalid_configuration;
 using ap::parsing_failure;
 
-TEST_SUITE_BEGIN("test_argument_parser_parse_args_unknown_flags_as_values");
-
 struct test_argument_parser_parse_args_unknown_flags_as_values
 : public argument_parser_test_fixture {
     const std::string test_program_name = "test program name";
@@ -58,5 +56,3 @@ TEST_CASE_FIXTURE(
 
     free_argv(argc, argv);
 }
-
-TEST_SUITE_END(); // test_argument_parser_parse_args_unknown_flags_as_values

--- a/tests/source/test_argument_parser_parse_args_unknown_flags_as_values.cpp
+++ b/tests/source/test_argument_parser_parse_args_unknown_flags_as_values.cpp
@@ -1,0 +1,44 @@
+#include "argument_parser_test_fixture.hpp"
+#include "doctest.h"
+#include "utility.hpp"
+
+using namespace ap_testing;
+using namespace ap::argument;
+using namespace ap::nargs;
+using ap::invalid_configuration;
+using ap::parsing_failure;
+
+TEST_SUITE_BEGIN("test_argument_parser_parse_args_unknown_flags_as_values");
+
+struct test_argument_parser_parse_args_unknown_flags_as_values
+: public argument_parser_test_fixture {
+    const std::size_t no_args = 0ull;
+};
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args_unknown_flags_as_values,
+    "parse_args should treat an unknown argument flag as a positional value if it's not preceeded "
+    "by any valid argument flags"
+) {
+    CHECK(false);
+
+    // add_arguments(no_args, no_args);
+
+    // constexpr std::size_t n_opt_clargs = 1ull;
+    // constexpr std::size_t opt_arg_idx = 0ull;
+
+    // auto argc = get_argc(no_args, n_opt_clargs);
+    // auto argv = init_argv(no_args, n_opt_clargs);
+
+    // const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
+
+    // CHECK_THROWS_WITH_AS(
+    //     sut.parse_args(argc, argv),
+    //     parsing_failure::unknown_argument(unknown_arg_name).what(),
+    //     parsing_failure
+    // );
+
+    // free_argv(argc, argv);
+}
+
+TEST_SUITE_END(); // test_argument_parser_parse_args_unknown_flags_as_values

--- a/tests/source/test_extarnal_libs_config.cpp
+++ b/tests/source/test_extarnal_libs_config.cpp
@@ -2,8 +2,6 @@
 
 #include <stdexcept>
 
-TEST_SUITE_BEGIN("test_doctest_config");
-
 namespace {
 
 int add(int a, int b) {
@@ -39,5 +37,3 @@ TEST_CASE("division by zero") {
     int denominator = 0;
     CHECK_THROWS_AS(divide(numerator, denominator), std::logic_error);
 }
-
-TEST_SUITE_END(); // test_doctest_config

--- a/tests/source/test_nargs_range.cpp
+++ b/tests/source/test_nargs_range.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "doctest.h"
 
 #include <ap/nargs/range.hpp>

--- a/tests/source/test_nargs_range.cpp
+++ b/tests/source/test_nargs_range.cpp
@@ -18,8 +18,6 @@ constexpr range::count_type max_bound = std::numeric_limits<range::count_type>::
 
 } // namespace
 
-TEST_SUITE_BEGIN("test_nargs_range");
-
 TEST_CASE("is_bound should return true only if at least one bound is set") {
     CHECK_FALSE(any().is_bound());
 
@@ -116,5 +114,3 @@ TEST_CASE("range builders should return correct range objects") {
         REQUIRE(std::is_eq(sut.ordering(max_bound)));
     }
 }
-
-TEST_SUITE_END(); // test_nargs_range

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -15,11 +15,12 @@ using ap::detail::parameter_descriptor;
 
 namespace {
 
+constexpr char flag_char = '-';
 constexpr std::string_view primary_name = "test";
 constexpr std::string_view secondary_name = "t";
 
-const argument_name arg_name(primary_name, secondary_name);
-const argument_name arg_name_primary(primary_name);
+const argument_name arg_name(primary_name, secondary_name, flag_char);
+const argument_name arg_name_primary(primary_name, std::nullopt, flag_char);
 
 constexpr std::string_view help_msg = "test help msg";
 
@@ -89,14 +90,14 @@ TEST_CASE_FIXTURE(
     auto sut = sut_type(arg_name);
 
     auto desc = get_desc(sut, verbose);
-    REQUIRE_EQ(desc.name, get_name(sut).str(flag_char));
+    REQUIRE_EQ(desc.name, get_name(sut).str());
     CHECK_FALSE(desc.help);
     CHECK(desc.params.empty());
 
     // with a help msg
     sut.help(help_msg);
     desc = get_desc(sut, verbose);
-    REQUIRE_EQ(desc.name, get_name(sut).str(flag_char));
+    REQUIRE_EQ(desc.name, get_name(sut).str());
     CHECK(desc.help);
     CHECK_EQ(desc.help.value(), help_msg);
     CHECK(desc.params.empty());
@@ -111,7 +112,7 @@ TEST_CASE_FIXTURE(
     auto sut = sut_type(arg_name);
 
     auto desc = get_desc(sut, verbose);
-    REQUIRE_EQ(desc.name, get_name(sut).str(flag_char));
+    REQUIRE_EQ(desc.name, get_name(sut).str());
     CHECK_FALSE(desc.help);
     CHECK(desc.params.empty());
 

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -40,8 +40,6 @@ const range non_default_range = range{1ull, choices.size()};
 
 } // namespace
 
-TEST_SUITE_BEGIN("test_optional_argument");
-
 TEST_CASE_FIXTURE(
     optional_argument_test_fixture, "name() should return the proper argument_name instance"
 ) {
@@ -576,5 +574,3 @@ TEST_CASE_FIXTURE(
     set_value_force(sut, invalid_choice);
     CHECK(std::is_gt(nvalues_ordering(sut)));
 }
-
-TEST_SUITE_END();

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "doctest.h"
 #include "optional_argument_test_fixture.hpp"
 

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "doctest.h"
 #include "positional_argument_test_fixture.hpp"
 

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -32,8 +32,6 @@ constexpr sut_value_type invalid_choice = 4;
 
 } // namespace
 
-TEST_SUITE_BEGIN("test_positional_argument");
-
 TEST_CASE_FIXTURE(
     positional_argument_test_fixture, "name() should return the proper argument_name instance"
 ) {
@@ -482,5 +480,3 @@ TEST_CASE_FIXTURE(
 
     CHECK(std::is_eq(nvalues_ordering(sut)));
 }
-
-TEST_SUITE_END();

--- a/tests/source/test_str_utility.cpp
+++ b/tests/source/test_str_utility.cpp
@@ -4,6 +4,8 @@
 
 #include <ap/detail/str_utility.hpp>
 
+#include <array>
+#include <format>
 #include <vector>
 
 using namespace ap::detail;
@@ -12,9 +14,38 @@ namespace {
 
 constexpr std::string_view delimiter = ",";
 
+struct dummy_writable {
+    int x;
+    int y;
+};
+
+std::ostream& operator<<(std::ostream& os, const dummy_writable& dw) {
+    os << dw.x << "," << dw.y;
+    return os;
+}
+
 } // namespace
 
 TEST_SUITE_BEGIN("test_str_utility");
+
+TEST_CASE("as_string should convert the given writable object to string") {
+    int value = 5;
+    CHECK_EQ(as_string(value), std::to_string(value));
+
+    dummy_writable dw{3, 14};
+    std::ostringstream dw_oss;
+    dw_oss << dw;
+    CHECK_EQ(as_string(dw), dw_oss.str());
+}
+
+TEST_CASE("contains_whitespace should return true for strings containing at least one whitespace "
+          "characted") {
+    CHECK_FALSE(contains_whitespaces("str-without-whitespaces"));
+
+    constexpr std::array<char, 6> whitespace_chars = {' ', '\t', '\n', '\v', '\f', '\r'};
+    for (char c : whitespace_chars)
+        CHECK(contains_whitespaces(std::format("begin{}end", c)));
+}
 
 TEST_CASE("join should return an empty string for an empty range") {
     std::vector<int> range{};

--- a/tests/source/test_str_utility.cpp
+++ b/tests/source/test_str_utility.cpp
@@ -1,5 +1,3 @@
-#define AP_TESTING
-
 #include "doctest.h"
 
 #include <ap/detail/str_utility.hpp>

--- a/tests/source/test_str_utility.cpp
+++ b/tests/source/test_str_utility.cpp
@@ -24,8 +24,6 @@ std::ostream& operator<<(std::ostream& os, const dummy_writable& dw) {
 
 } // namespace
 
-TEST_SUITE_BEGIN("test_str_utility");
-
 TEST_CASE("as_string should convert the given writable object to string") {
     int value = 5;
     CHECK_EQ(as_string(value), std::to_string(value));
@@ -59,5 +57,3 @@ TEST_CASE("join should return a proper range representation for a multi element 
     std::vector<int> range = {1, 2, 3};
     CHECK_EQ(join(range, delimiter), "1,2,3");
 }
-
-TEST_SUITE_END(); // test_str_utility


### PR DESCRIPTION
- Aligned argument value setting to use direct `value_type` object initialization from `std::string` values if possible (arguments, the value type of which cannot be constructed from `std::string` will use the `istream>>` operator as in previous versions)

  NOTE: This fixes the issue, where passing a mulit-word optional argument's value, e.g.
    `./program --option "single value with spaces"`
  would result in storing only the first word of the value ("single" in this case)

- Altered the behavior of unknown argument flag handling: a `parsing_failre` exception is thrown instead of handling it as a value argument token

- Added the `AP_UNKNOWN_FLAGS_AS_VALUES` option support: using this option changes the unknown argument flag handling strategy back to treating it as a value

- Modified the test building to compile each test file into a separate executable registered with CTest

- Corrected the argument value type requirements description in the tutorial document
