### PR TITLE
[none] Bazel build system support

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+build --enable_platform_specific_config
+
+build:linux --cxxopt=-std=c++20
+build:windows --cxxopt=/std:c++20

--- a/.github/workflows/clang.yaml
+++ b/.github/workflows/clang.yaml
@@ -26,14 +26,14 @@ jobs:
           CC:  clang-17
           CXX: clang++-17
         run: |
-          cmake -B build -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+          cmake -B build_clang -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false
 
       - name: Build tests
         run: |
-          cmake --build build/ -j 4
+          cmake --build build_clang/ -j 4
         continue-on-error: false
 
       - name: Run tests
         run: |
-          ctest --test-dir build/tests/ -V
+          ctest --test-dir build_clang/tests/ -V

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -9,6 +9,8 @@ on:
       - cpp-ap-demo
       - include/**
       - CMakeLists.txt
+      - MODULE.bazel
+      - BUILD.bazel
   pull_request:
     branches:
       - master
@@ -25,7 +27,7 @@ jobs:
           fetch-depth: 0
           submodules: recursive
 
-      - name: Sync submodules to HTTPS
+      - name: Sync submodules
         run: git submodule sync --recursive
 
       - name: Update submodules
@@ -40,9 +42,22 @@ jobs:
             echo "branch=$(echo ${GITHUB_REF#refs/heads/})" >> $GITHUB_OUTPUT
           fi
 
-      - name: Build cpp-ap-demo
+      - name: Build cpp-ap-demo (CMake)
         run: |
           cd cpp-ap-demo
-          cmake -B build -DAP_TAG=${{ steps.branch-name.outputs.branch }}
-          cd build
-          make -j 4
+          cmake -B build_cmake -DAP_TAG=${{ steps.branch-name.outputs.branch }}
+          cmake --build build_cmake/ -j 4
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Build cpp-ap-demo (Bazel)
+        run: |
+          cd cpp-ap-demo
+          BRANCH="${{ steps.branch-name.outputs.branch }}"
+          sed -i "s/branch = \".*\"/branch = \"$BRANCH\"/" MODULE.bazel
+          bazel build //:all_demos

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -95,7 +95,7 @@ jobs:
         run: |
           cd cpp-ap-demo
           cmake -B build_cmake -DAP_TAG=${{ steps.branch-name.outputs.branch }}
-          cmake --build build_cmake/ --config Release
+          cmake --build build_cmake/ --config Release -j 4
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.15.0

--- a/.github/workflows/demo.yaml
+++ b/.github/workflows/demo.yaml
@@ -16,8 +16,8 @@ on:
       - master
 
 jobs:
-  build-demo:
-    name: Build cpp-ap-demo
+  build-demo-linux:
+    name: Build cpp-ap-demo (Linux)
     runs-on: ubuntu-24.04
 
     steps:
@@ -60,4 +60,53 @@ jobs:
           cd cpp-ap-demo
           BRANCH="${{ steps.branch-name.outputs.branch }}"
           sed -i "s/branch = \".*\"/branch = \"$BRANCH\"/" MODULE.bazel
+          bazel build //:all_demos
+
+  build-demo-windows:
+    name: Build cpp-ap-demo (Windows)
+    runs-on: windows-2022
+
+    steps:
+      - name: Check out current branch
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+
+      - name: Sync submodules
+        run: git submodule sync --recursive
+        shell: bash
+
+      - name: Update submodules
+        run: git submodule update --init --recursive
+        shell: bash
+
+      - name: Determine Current Branch
+        id: branch-name
+        run: |
+          if ("${{ github.event_name }}" -eq "pull_request") {
+            "branch=${{ github.event.pull_request.head.ref }}" >> $env:GITHUB_OUTPUT
+          } else {
+            $branch = "${env:GITHUB_REF}".Replace("refs/heads/", "")
+            "branch=$branch" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Build cpp-ap-demo (CMake)
+        run: |
+          cd cpp-ap-demo
+          cmake -B build_cmake -DAP_TAG=${{ steps.branch-name.outputs.branch }}
+          cmake --build build_cmake/ --config Release
+
+      - name: Setup Bazel
+        uses: bazel-contrib/setup-bazel@0.15.0
+        with:
+          bazelisk-cache: true
+          disk-cache: ${{ github.workflow }}
+          repository-cache: true
+
+      - name: Build cpp-ap-demo (Bazel)
+        run: |
+          cd cpp-ap-demo
+          $BRANCH="${{ steps.branch-name.outputs.branch }}"
+          (Get-Content MODULE.bazel) -replace 'branch = ".*"', "branch = `"$BRANCH`"" | Set-Content MODULE.bazel
           bazel build //:all_demos

--- a/.github/workflows/gcc.yaml
+++ b/.github/workflows/gcc.yaml
@@ -26,14 +26,14 @@ jobs:
           CC:  gcc-13
           CXX: g++-13
         run: |
-          cmake -B build -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
+          cmake -B build_gcc -DBUILD_TESTS=ON -DCMAKE_CXX_COMPILER=$CXX -DCMAKE_C_COMPILER=$CC
         continue-on-error: false
 
       - name: Build tests
         run: |
-          cmake --build build/ -j 4
+          cmake --build build_gcc/ -j 4
         continue-on-error: false
 
       - name: Run tests
         run: |
-          ctest --test-dir build/tests/ -V
+          ctest --test-dir build_gcc/tests/ -V

--- a/.github/workflows/msvc.yaml
+++ b/.github/workflows/msvc.yaml
@@ -23,15 +23,15 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -B build_win -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=ON
+          cmake -B build_msvc -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=ON
         shell: powershell
 
       - name: Build tests
         run: |
-          cmake --build build_win --config Debug --parallel
+          cmake --build build_msvc --config Debug --parallel
         shell: powershell
 
       - name: Run tests
         run: |
-          ctest --test-dir build_win/tests -V -C Debug
+          ctest --test-dir build_msvc/tests -V -C Debug
         shell: powershell

--- a/.github/workflows/msvc.yaml
+++ b/.github/workflows/msvc.yaml
@@ -23,15 +23,15 @@ jobs:
 
       - name: Configure CMake
         run: |
-          cmake -B build -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=ON
+          cmake -B build_win -G "Visual Studio 17 2022" -A x64 -DBUILD_TESTS=ON
         shell: powershell
 
       - name: Build tests
         run: |
-          cmake --build build --config Debug --parallel
+          cmake --build build_win --config Debug --parallel
         shell: powershell
 
       - name: Run tests
         run: |
-          ctest --test-dir build/tests -V -C Debug
+          ctest --test-dir build_win/tests -V -C Debug
         shell: powershell

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,6 @@
+cc_library(
+    name = "cpp_ap",
+    hdrs = glob(["include/**/*.hpp"]),
+    includes = ["include"],
+    visibility = ["//visibility:public"],
+)

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,5 @@
 cc_library(
-    name = "cpp_ap",
+    name = "cpp-ap",
     hdrs = glob(["include/**/*.hpp"]),
     includes = ["include"],
     cxxopts = ["-std=c++20"],

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,5 +2,6 @@ cc_library(
     name = "cpp_ap",
     hdrs = glob(["include/**/*.hpp"]),
     includes = ["include"],
+    cxxopts = ["-std=c++20"],
     visibility = ["//visibility:public"],
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.4.1
+    VERSION 2.5.0
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX
@@ -17,12 +17,12 @@ project(cpp-ap
 option(BUILD_TESTS "Build project tests" OFF)
 
 # The library target
-add_library(cpp-ap-2 INTERFACE)
-target_include_directories(cpp-ap-2 INTERFACE
+add_library(cpp-ap INTERFACE)
+target_include_directories(cpp-ap INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>
 )
-set_target_properties(cpp-ap-2 PROPERTIES
+set_target_properties(cpp-ap PROPERTIES
     CXX_STANDARD 20
     CXX_STANDARD_REQUIRED YES
 )
@@ -31,37 +31,37 @@ set_target_properties(cpp-ap-2 PROPERTIES
 include(GNUInstallDirs)
 include(CMakePackageConfigHelpers)
 
-set(INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/cpp-ap-2)
+set(INSTALL_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/cpp-ap)
 
 # Install the headers
 install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/include/
         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 # Install the library target
-install(TARGETS cpp-ap-2 EXPORT cpp-ap-2-targets)
+install(TARGETS cpp-ap EXPORT cpp-ap-targets)
 
 # Create a config file for find_package
 configure_package_config_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpp-ap-2-config.cmake.in
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config.cmake
+    ${CMAKE_CURRENT_SOURCE_DIR}/cmake/cpp-ap-config.cmake.in
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config.cmake
     INSTALL_DESTINATION ${INSTALL_DIR}
 )
 
 write_basic_package_version_file(
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config-version.cmake
     VERSION ${PROJECT_VERSION}
     COMPATIBILITY ExactVersion
 )
 
 install(FILES
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config.cmake
-    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-config-version.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config.cmake
+    ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-config-version.cmake
     DESTINATION ${INSTALL_DIR}
 )
 
-install(EXPORT cpp-ap-2-targets
-    FILE cpp-ap-2-targets.cmake
-    NAMESPACE cpp-ap-2::
+install(EXPORT cpp-ap-targets
+    FILE cpp-ap-targets.cmake
+    NAMESPACE cpp-ap::
     DESTINATION ${INSTALL_DIR}
 )
 
@@ -71,9 +71,9 @@ if (CPP_AP_IS_TOP_LEVEL_PROJECT AND BUILD_TESTS)
 endif()
 
 # Exporting from the build tree
-export(EXPORT cpp-ap-2-targets
-    FILE ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-2-targets.cmake
-    NAMESPACE cpp-ap-2::
+export(EXPORT cpp-ap-targets
+    FILE ${CMAKE_CURRENT_BINARY_DIR}/cpp-ap-targets.cmake
+    NAMESPACE cpp-ap::
 )
 
-export(PACKAGE cpp-ap-2)
+export(PACKAGE cpp-ap)

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.4.1
+PROJECT_NUMBER         = 2.5.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
-    name = "cpp_ap",
+    name = "cpp-ap",
     version = "2.5.0",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp_ap",
-    version = "2.5.0",
+    version = "2.4.2",
 )

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,0 +1,4 @@
+module(
+    name = "cpp_ap",
+    version = "2.5.0",
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp_ap",
-    version = "2.4.2",
+    version = "2.5.0",
 )

--- a/README.md
+++ b/README.md
@@ -7,12 +7,6 @@
 
 Command-line argument parser for C++20
 
-TODO:
-- documentation workflow should verify the version in MODULE.bazel
-- add instructions for usiong cpp-ap with bazel
-- cpp-ap demo should use `master` as the default branch
-- update cpp-ap-demo readme
-
 <br />
 
 <div align="center">

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h1>
-  CPP-AP-2
+  CPP-AP
   <a href="https://github.com/SpectraL519/cpp-ap" target="_blank">
     <i class="fa fa-github" style="font-size: 1.3em; margin-left: 6px; position: relative; top: -0.08em;"></i>
   </a>

--- a/README.md
+++ b/README.md
@@ -7,6 +7,12 @@
 
 Command-line argument parser for C++20
 
+TODO:
+- documentation workflow should verify the version in MODULE.bazel
+- add instructions for usiong cpp-ap with bazel
+- cpp-ap demo should use `master` as the default branch
+- update cpp-ap-demo readme
+
 <br />
 
 <div align="center">

--- a/cmake/cpp-ap-config.cmake.in
+++ b/cmake/cpp-ap-config.cmake.in
@@ -4,4 +4,4 @@ include(CMakeFindDependencyMacro)
 
 set_and_check(CPP_AP_INCLUDE_DIR "@PACKAGE_INSTALL_PREFIX@/@CMAKE_INSTALL_INCLUDEDIR@")
 
-include("${CMAKE_CURRENT_LIST_DIR}/cpp-ap-2-targets.cmake")
+include("${CMAKE_CURRENT_LIST_DIR}/cpp-ap-targets.cmake")

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -54,7 +54,7 @@ set_target_properties(my_project PROPERTIES
 )
 
 # Link against the cpp-ap (v2) library
-target_link_libraries(my_project PRIVATE cpp-ap-2)
+target_link_libraries(my_project PRIVATE cpp-ap)
 ```
 
 ### Downloading the Library
@@ -657,7 +657,7 @@ The `argument_parser` class also defines the `void parse_args(int argc, char* ar
 >
 > To do this add the following in you `CMakeLists.txt` file:
 > ```cmake
-> target_compile_definitions(cpp-ap-2 PRIVATE AP_UNKNOWN_FLAGS_AS_VALUES)
+> target_compile_definitions(cpp-ap PRIVATE AP_UNKNOWN_FLAGS_AS_VALUES)
 > ```
 > or simply add:
 > ```cpp

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -2,7 +2,7 @@
 
 - [Setting Up CPP-AP](#setting-up-cpp-ap)
   - [CMake Integration](#cmake-integration)
-  - [Bazel Build System]()
+  - [Bazel Build System](#bazel-build-system)
   - [Downloading the Library](#downloading-the-library)
 - [The Parser Class](#the-parser-class)
 - [Adding Arguments](#adding-arguments)
@@ -76,12 +76,9 @@ And then add the `"@cpp-ap//:cpp-ap"` dependency for the target you want to use 
 
 ```bazel
 # BUILD.bazel
-
 cc_binary(
     name = "my_app",
-    srcs = [
-        "application.cpp",
-    ],
+    srcs = ["application.cpp"],
     includes = ["include"],
     deps = ["@cpp-ap//:cpp-ap"],
     cxxopts = ["-std=c++20"],

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -66,13 +66,13 @@ To use the `CPP-AP` in a [Bazel](https://bazel.build/) project add the following
 git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 
 git_repository(
-    name = "cpp_ap",
+    name = "cpp-ap",
     remote = "https://github.com/SpectraL519/cpp-ap.git",
     branch = "master", # here you can specify the desired tag or branch name
 )
 ```
 
-And then add the `"@cpp_ap//:cpp_ap"` dependency for the target you want to use `CPP-AP` for by adding it to the `deps` list. For instance:
+And then add the `"@cpp-ap//:cpp-ap"` dependency for the target you want to use `CPP-AP` for by adding it to the `deps` list. For instance:
 
 ```bazel
 # BUILD.bazel
@@ -83,7 +83,7 @@ cc_binary(
         "application.cpp",
     ],
     includes = ["include"],
-    deps = ["@cpp_ap//:cpp_ap"],
+    deps = ["@cpp-ap//:cpp-ap"],
     cxxopts = ["-std=c++20"],
     visibility = ["//visibility:public"],
 )

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -2,6 +2,7 @@
 
 - [Setting Up CPP-AP](#setting-up-cpp-ap)
   - [CMake Integration](#cmake-integration)
+  - [Bazel Build System]()
   - [Downloading the Library](#downloading-the-library)
 - [The Parser Class](#the-parser-class)
 - [Adding Arguments](#adding-arguments)
@@ -40,7 +41,7 @@ include(FetchContent)
 FetchContent_Declare(
     cpp-ap
     GIT_REPOSITORY https://github.com/SpectraL519/cpp-ap.git
-    GIT_TAG master # here you can specify the desired tag or branch
+    GIT_TAG master # here you can specify the desired tag or branch name
 )
 
 FetchContent_MakeAvailable(cpp-ap)
@@ -55,6 +56,37 @@ set_target_properties(my_project PROPERTIES
 
 # Link against the cpp-ap (v2) library
 target_link_libraries(my_project PRIVATE cpp-ap)
+```
+
+### Bazel Build System
+
+To use the `CPP-AP` in a [Bazel](https://bazel.build/) project add the following in the `MODULE.bazel` (or `WORKSPACE.bazel`) file:
+
+```bazel
+git_repository = use_repo_rule("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
+git_repository(
+    name = "cpp_ap",
+    remote = "https://github.com/SpectraL519/cpp-ap.git",
+    branch = "master", # here you can specify the desired tag or branch name
+)
+```
+
+And then add the `"@cpp_ap//:cpp_ap"` dependency for the target you want to use `CPP-AP` for by adding it to the `deps` list. For instance:
+
+```bazel
+# BUILD.bazel
+
+cc_binary(
+    name = "my_app",
+    srcs = [
+        "application.cpp",
+    ],
+    includes = ["include"],
+    deps = ["@cpp_ap//:cpp_ap"],
+    cxxopts = ["-std=c++20"],
+    visibility = ["//visibility:public"],
+)
 ```
 
 ### Downloading the Library

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -364,7 +364,7 @@ public:
         try {
             return std::any_cast<T>(arg_value);
         }
-        catch (const std::bad_any_cast& err) {
+        catch (const std::bad_any_cast&) {
             throw type_error::invalid_value_type(arg_opt->get().name(), typeid(T));
         }
     }
@@ -425,7 +425,7 @@ public:
             );
             return values;
         }
-        catch (const std::bad_any_cast& err) {
+        catch (const std::bad_any_cast&) {
             throw type_error::invalid_value_type(arg.name(), typeid(T));
         }
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -57,7 +57,7 @@ macro(add_doctest SOURCE_FILE)
     if(ARGS_COMPILE_DEFINITIONS)
         target_compile_definitions(${TEST_NAME} PRIVATE ${ARGS_COMPILE_DEFINITIONS})
     endif()
-    target_link_libraries(${TEST_NAME} PRIVATE doctest_main cpp-ap-2)
+    target_link_libraries(${TEST_NAME} PRIVATE doctest_main cpp-ap)
 
     # Register with CTest
     add_test(NAME ${TEST_NAME} COMMAND ${TEST_NAME})


### PR DESCRIPTION
- Added the `MODULE.bazel`, `BUILD.bazel` and `.bazelrc` configuration files
- Aligned the `check_version` script to verify the Bazel module version
- Reverted the naming of the CMake library target back to `cpp-ap` instead of `cpp-ap-2` to better match the naming of the Bazel module
- Updated the `cpp-ap-demo` submodule: added the Bazel configuration files to enable building the demo projects using Bazel
- Updated the `demo` workflow to build the demo projects using both CMake and Bazel and on both Linux and Windows platforms