### PR TITLE
YT-CPPAP-49: Use demandgled type names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@
 *.exe
 Testing/
 
+# bazel files
+bazel-*
+*.bazel.lock
+
 # documentation files
 /documentation
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.5.0
+    VERSION 2.5.1
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.5.0
+PROJECT_NUMBER         = 2.5.1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp-ap",
-    version = "2.5.0",
+    version = "2.5.1",
 )

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -54,7 +54,7 @@ set_target_properties(my_project PROPERTIES
     CXX_STANDARD_REQUIRED YES
 )
 
-# Link against the cpp-ap (v2) library
+# Link against the cpp-ap library
 target_link_libraries(my_project PRIVATE cpp-ap)
 ```
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -365,7 +365,7 @@ public:
             return std::any_cast<T>(arg_value);
         }
         catch (const std::bad_any_cast&) {
-            throw type_error::invalid_value_type(arg_opt->get().name(), typeid(T));
+            throw type_error::invalid_value_type<T>(arg_opt->get().name());
         }
     }
 
@@ -393,7 +393,7 @@ public:
             return T{std::forward<U>(fallback_value)};
         }
         catch (const std::bad_any_cast&) {
-            throw type_error::invalid_value_type(arg_opt->get().name(), typeid(T));
+            throw type_error::invalid_value_type<T>(arg_opt->get().name());
         }
     }
 
@@ -426,7 +426,7 @@ public:
             return values;
         }
         catch (const std::bad_any_cast&) {
-            throw type_error::invalid_value_type(arg.name(), typeid(T));
+            throw type_error::invalid_value_type<T>(arg.name());
         }
     }
 

--- a/include/ap/detail/typing_utility.hpp
+++ b/include/ap/detail/typing_utility.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string_view>
+#include <source_location>
+
+namespace ap::detail {
+
+template <typename T>
+constexpr std::string_view get_demangled_type_name() {
+#if defined(__clang__) || defined(__GNUC__)
+    constexpr std::string_view func_name = __PRETTY_FUNCTION__;
+    constexpr std::string_view begin_key = "T = ";
+    constexpr std::string_view end_key = ";]";
+
+    auto start_pos = func_name.find(begin_key) + begin_key.size();
+    auto end_pos = func_name.find_first_of(end_key, start_pos);
+    return func_name.substr(start_pos, end_pos - start_pos);
+#elif defined(_MSC_VER)
+    constexpr std::string_view func_name = __FUNCSIG__;
+    constexpr std::string_view begin_key = "type_name<";
+    constexpr char end_key = '>';
+
+    auto start_pos = func_name.find(begin_key) + begin_key.size();
+    auto end_pos = func_name.find(end_key, start_pos);
+    return func_name.substr(start_pos, end_pos - start_pos);
+#else
+    return typeid(T).name();
+#endif
+}
+
+} // namespace ap::detail

--- a/include/ap/detail/typing_utility.hpp
+++ b/include/ap/detail/typing_utility.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
-#include <string_view>
 #include <source_location>
+#include <string_view>
 
 namespace ap::detail {
 

--- a/include/ap/detail/typing_utility.hpp
+++ b/include/ap/detail/typing_utility.hpp
@@ -1,3 +1,7 @@
+// Copyright (c) 2023-2025 Jakub Musiał
+// This file is part of the CPP-AP project (https://github.com/SpectraL519/cpp-ap).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
 #pragma once
 
 #include <source_location>

--- a/include/ap/exceptions.hpp
+++ b/include/ap/exceptions.hpp
@@ -8,6 +8,7 @@
 
 #include "ap/detail/argument_name.hpp"
 #include "ap/detail/str_utility.hpp"
+#include "ap/detail/typing_utility.hpp"
 
 #include <format>
 
@@ -127,6 +128,15 @@ struct type_error : public argument_parser_exception {
             "Invalid value type specified for argument [{}] = {}.",
             arg_name.str(),
             value_type.name()
+        ));
+    }
+
+    template <typename T>
+    static type_error invalid_value_type(const detail::argument_name& arg_name) noexcept {
+        return type_error(std::format(
+            "Invalid value type specified for argument [{}] = {}.",
+            arg_name.str(),
+            detail::get_demangled_type_name<T>()
         ));
     }
 };


### PR DESCRIPTION
- Implemented type name demangling functionality
- Added the parametrized `type_error` class builder functions which use the type demangling functionality