### PR TITLE
YT-CPPAP-48: Add support for argument hiding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.5.1
+    VERSION 2.5.2
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.5.1
+PROJECT_NUMBER         = 2.5.2
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp-ap",
-    version = "2.5.1",
+    version = "2.5.2",
 )

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -195,7 +195,36 @@ parser.add_positional_argument<std::size_t>("number", "n")
       .help("a positive integer value");
 ```
 
-#### 2. `required` - If this option is set for an argument and it's value is not passed in the command-line, an exception will be thrown.
+#### 2. `hidden` - If this option is set for an argument, then it will not be included in the program description.
+
+By default all arguments are visible, but this can be modified using the `hidden(bool)` setter as follows:
+
+```cpp
+parser.program_name("hidden-test")
+      .program_description("A simple program")
+      .default_optional_arguments({ap::argument::default_optional::help});
+
+parser.add_optional_argument("hidden")
+      .hidden()
+      .help("A simple hidden argument");
+parser.add_optional_argument("visible")
+      .help("A simple visible argument");
+
+parser.try_parse_args(argc, argv);
+
+/*
+> ./hidden-test --help
+Program: hidden-test
+
+  A simple program
+
+Optional arguments:
+
+  --help, -h : Display the help message
+  --visible  : A simple visible argument
+```
+
+#### 3. `required` - If this option is set for an argument and it's value is not passed in the command-line, an exception will be thrown.
 
 > [!NOTE]
 >
@@ -262,7 +291,7 @@ Command                                 Result
 */
 ```
 
-#### 3. `bypass_required` - If this option is set for an argument, the `required` option for other arguments will be discarded if the bypassing argument is used in the command-line.
+#### 4. `bypass_required` - If this option is set for an argument, the `required` option for other arguments will be discarded if the bypassing argument is used in the command-line.
 
 > [!NOTE]
 >
@@ -298,7 +327,7 @@ std::ofstream os(parser.value("output"));
 os << data << std::endl;
 ```
 
-#### 4. `default_value` - The default value for an argument which will be used if no values for this argument are parsed
+#### 5. `default_value` - The default value for an argument which will be used if no values for this argument are parsed
 
 > [!WARNING]
 >
@@ -352,7 +381,7 @@ Command                                 Result
 >
 > The setter of the `default_value` parameter accepts any type that is convertible to the argument's value type.
 
-#### 5. `choices` - A list of valid argument values.
+#### 6. `choices` - A list of valid argument values.
 
 The `choices` parameter takes as an argument an instance of `std::initializer_list` or any `std::ranges::range` type such that its value type is convertible to the argument's `value_type`.
 
@@ -365,7 +394,7 @@ parser.add_optional_argument<char>("method", "m").choices({'a', 'b', 'c'});
 >
 > The `choices` function can be used only if the argument's `value_type` is equality comparable (defines the `==` operator).
 
-#### 6. Value actions - Function performed after parsing an argument's value.
+#### 7. Value actions - Function performed after parsing an argument's value.
 Actions are represented as functions, which take the argument's value as an argument. The available action types are:
 
 - `observe` actions | `void(const value_type&)` - applied to the parsed value. No value is returned - this action type is used to perform some logic on the parsed value without modifying it.

--- a/include/ap/argument/optional.hpp
+++ b/include/ap/argument/optional.hpp
@@ -63,10 +63,20 @@ public:
     }
 
     /**
-     * @brief Set the `required` parameter of the optional argument
-     * @param r The parameter value.
+     * @brief Set the `hidden` attribute for the positional argument.
+     * @param h The attribute value.
+     * @return Reference to the positional argument.
+     */
+    optional& hidden(const bool h = true) noexcept {
+        this->_hidden = h;
+        return *this;
+    }
+
+    /**
+     * @brief Set the `required` attribute of the optional argument
+     * @param r The attribute value.
      * @return Reference to the optional argument.
-     * @attention Setting the `required` parameter to true disables the `bypass_required` flag.
+     * @attention Setting the `required` attribute to true disables the `bypass_required` attribute.
      */
     optional& required(const bool r = true) noexcept {
         this->_required = r;
@@ -76,10 +86,10 @@ public:
     }
 
     /**
-     * @brief Enable/disable bypassing the `required` flag for the optional argument.
-     * @param br The parameter value.
+     * @brief Enable/disable bypassing the `required` attribute for the optional argument.
+     * @param br The attribute value.
      * @return Reference to the optional argument.
-     * @attention Setting the `bypass_required` option to true disables the `required` flag.
+     * @attention Setting the `bypass_required` option to true disables the `required` attribute.
      */
     optional& bypass_required(const bool br = true) noexcept {
         this->_bypass_required = br;
@@ -172,7 +182,7 @@ public:
      * @brief Set the default value for the optional argument.
      * @param default_value The default value to set.
      * @return Reference to the optional argument.
-     * @attention Setting the default value disables the `required` flag.
+     * @attention Setting the default value disables the `required` attribute.
      */
     optional& default_value(const std::convertible_to<value_type> auto& default_value) noexcept {
         this->_default_value = std::make_any<value_type>(default_value);
@@ -247,7 +257,7 @@ private:
         return this->_count > 0;
     }
 
-    /// @return The number of times the optional argument flag has been used.
+    /// @return The number of times the optional argument attribute has been used.
     [[nodiscard]] std::size_t count() const noexcept override {
         return this->_count;
     }

--- a/include/ap/argument/positional.hpp
+++ b/include/ap/argument/positional.hpp
@@ -60,10 +60,20 @@ public:
     }
 
     /**
-     * @brief Set the `required` flag of the positional argument
-     * @param r The parameter value.
+     * @brief Set the `hidden` attribute for the positional argument.
+     * @param h The attribute value.
      * @return Reference to the positional argument.
-     * @attention Setting the `required` parameter to true disables the `bypass_required` flag.
+     */
+    positional& hidden(const bool h = true) noexcept {
+        this->_hidden = h;
+        return *this;
+    }
+
+    /**
+     * @brief Set the `required` attribute of the positional argument
+     * @param r The attribute value.
+     * @return Reference to the positional argument.
+     * @attention Setting the `required` attribute to true disables the `bypass_required` attribute.
      */
     positional& required(const bool r = true) noexcept {
         this->_required = r;
@@ -73,10 +83,10 @@ public:
     }
 
     /**
-     * @brief Enable/disable bypassing the `required` flag for the positional argument.
-     * @param br The parameter value.
+     * @brief Enable/disable bypassing the `required` attributeattribute for the positional argument.
+     * @param br The attribute value.
      * @return Reference to the positional argument.
-     * @attention Setting the `bypass_required` parameter to true disables the `required` flag.
+     * @attention Setting the `bypass_required` attribute to true disables the `required` attribute.
      */
     positional& bypass_required(const bool br = true) noexcept {
         this->_bypass_required = br;
@@ -118,7 +128,7 @@ public:
      * @brief Set the default value for the positional argument.
      * @param default_value The default value to set.
      * @return Reference to the positional argument.
-     * @attention Setting the default value disables the `required` flag.
+     * @attention Setting the default value disables the `required` attribute.
      */
     positional& default_value(const std::convertible_to<value_type> auto& default_value) noexcept {
         this->_default_value = std::make_any<value_type>(default_value);

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -879,15 +879,18 @@ private:
      * @param args The argument list to print.
      */
     void _print(std::ostream& os, const arg_ptr_list_t& args, const bool verbose) const noexcept {
+        auto visible_args =
+            std::views::filter(args, [](const auto& arg) { return not arg->is_hidden(); });
+
         if (verbose) {
-            for (const auto& arg : args)
+            for (const auto& arg : visible_args)
                 os << '\n' << arg->desc(verbose).get(this->_indent_width) << '\n';
         }
         else {
             std::vector<detail::argument_descriptor> descriptors;
             descriptors.reserve(args.size());
 
-            for (const auto& arg : args)
+            for (const auto& arg : visible_args)
                 descriptors.emplace_back(arg->desc(verbose));
 
             std::size_t max_arg_name_length = 0ull;

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -43,6 +43,11 @@ protected:
         return this->_help_msg;
     }
 
+    /// @return `true` if the argument is hidden, `false` otherwise
+    [[nodiscard]] bool is_hidden() const noexcept {
+        return this->_hidden;
+    }
+
     /// @return `true` if the argument is required, `false` otherwise
     [[nodiscard]] bool is_required() const noexcept {
         return this->_required;
@@ -101,6 +106,7 @@ protected:
 
     bool _required : 1;
     bool _bypass_required : 1 = false;
+    bool _hidden : 1 = false;
 };
 
 /**

--- a/include/ap/exceptions.hpp
+++ b/include/ap/exceptions.hpp
@@ -131,12 +131,12 @@ struct type_error : public argument_parser_exception {
         ));
     }
 
-    template <typename T>
+    template <typename InvalidType>
     static type_error invalid_value_type(const detail::argument_name& arg_name) noexcept {
         return type_error(std::format(
             "Invalid value type specified for argument [{}] = {}.",
             arg_name.str(),
-            detail::get_demangled_type_name<T>()
+            detail::get_demangled_type_name<InvalidType>()
         ));
     }
 };

--- a/tests/include/optional_argument_test_fixture.hpp
+++ b/tests/include/optional_argument_test_fixture.hpp
@@ -109,6 +109,11 @@ struct optional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
+    [[nodiscard]] bool is_hidden(const optional<T>& arg) const {
+        return arg.is_hidden();
+    }
+
+    template <c_argument_value_type T>
     [[nodiscard]] bool is_required(const optional<T>& arg) const {
         return arg.is_required();
     }

--- a/tests/include/positional_argument_test_fixture.hpp
+++ b/tests/include/positional_argument_test_fixture.hpp
@@ -32,6 +32,11 @@ struct positional_argument_test_fixture {
     }
 
     template <c_argument_value_type T>
+    [[nodiscard]] bool is_hidden(const positional<T>& arg) const {
+        return arg.is_hidden();
+    }
+
+    template <c_argument_value_type T>
     [[nodiscard]] bool is_required(const positional<T>& arg) const {
         return arg.is_required();
     }

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -163,6 +163,17 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(implicit_value_it->value, std::to_string(implicit_value));
 }
 
+TEST_CASE_FIXTURE(
+    optional_argument_test_fixture,
+    "is_hidden() should return false by default or the value passed in the attribute setter"
+) {
+    auto sut = sut_type(arg_name_primary);
+    REQUIRE_FALSE(is_hidden(sut));
+
+    sut.hidden();
+    CHECK(is_hidden(sut));
+}
+
 TEST_CASE_FIXTURE(optional_argument_test_fixture, "is_required() should return false by default") {
     auto sut = sut_type(arg_name_primary);
     CHECK_FALSE(is_required(sut));

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -141,6 +141,17 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(default_value_it->value, std::to_string(default_value));
 }
 
+TEST_CASE_FIXTURE(
+    positional_argument_test_fixture,
+    "is_hidden() should return false by default or the value passed in the attribute setter"
+) {
+    auto sut = sut_type(arg_name_primary);
+    REQUIRE_FALSE(is_hidden(sut));
+
+    sut.hidden();
+    CHECK(is_hidden(sut));
+}
+
 TEST_CASE_FIXTURE(positional_argument_test_fixture, "is_required() should return true by default") {
     auto sut = sut_type(arg_name_primary);
     CHECK(is_required(sut));


### PR DESCRIPTION
Added the `hidden` attribute setter to the positional and optional argument classes. 
If an argument is declared hidden, it will not be included in the program description generated by the argument parser.