### PR TITLE
YT-CPPAP-46: Add compound argument flags support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 2.5.3
+    VERSION 2.6.0
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.5.3
+PROJECT_NUMBER         = 2.6.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp-ap",
-    version = "2.5.3",
+    version = "2.6.0",
 )

--- a/README.md
+++ b/README.md
@@ -56,6 +56,8 @@ Command-line argument parser for C++20
   - [Argument Parameters](/docs/tutorial.md#argument-parameters)
   - [Default Arguments](/docs/tutorial.md#default-arguments)
   - [Parsing Arguments](/docs/tutorial.md#parsing-arguments)
+    - [Argument Parsing Rules](/docs/tutorial.md#argument-parsing-rules)
+    - [Compound Arguments](/docs/tutorial.md#compound-arguments)
   - [Retrieving Argument Values](/docs/tutorial.md#retrieving-argument-values)
   - [Examples](/docs/tutorial.md#examples)
 - [Dev notes](/docs/dev_notes.md#dev-notes)

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -10,6 +10,8 @@
 - [Predefined Parameter Values](#predefined-parameter-values)
 - [Default Arguments](#default-arguments)
 - [Parsing Arguments](#parsing-arguments)
+  - [Argument Parsing Rules](#argument-parsing-rules)
+  - [Compound Arguments](#compound-arguments)
 - [Retrieving Argument Values](#retrieving-argument-values)
 - [Examples](#examples)
 
@@ -120,7 +122,10 @@ parser.program_name("Name of the program")
 > You can specify the program version using a string (like in the example above) or using the `ap::version` structure:
 >
 > ```cpp
-> parser.program_version({ .major = 0u, .minor = 0u, .patch = 0u })
+> parser.program_version({0u, 0u, 0u})
+> parser.program_version({ .major = 1u, .minor = 1u, .patch = 1u });
+> ap::version ver{2u, 2u, 2u};
+> parser.program_version(ver);
 > ```
 >
 > **NOTE:** The `ap::version` struct
@@ -883,6 +888,12 @@ int main(int argc, char* argv[]) {
 > [!IMPORTANT]
 >
 > The parser's behavior depends on the argument definitions - see [Argument Parameters](#argument-parameters) section.
+
+<br />
+
+### Compound Arguments:
+
+TODO
 
 <br/>
 <br/>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -941,7 +941,9 @@ Numbers: 1, 2, 3
 
 > [!IMPORTANT]
 >
-> The argument parser will try to assign the values following a compound argument flag to the argument represented by the last character of the compound flag.
+> - If there exists an argument whose secondary name matches a possible compound of other arguments, the parser will still treat the flag as a flag of the **single matching argument**, not as multiple flags.
+> - The argument parser will try to assign the values following a compound argument flag to the argument represented by the **last character** of the compound flag.
+
 
 <br/>
 <br/>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -822,41 +822,37 @@ int main(int argc, char* argv[]) {
 
   ```shell
   ./power 2
-  # out:
-  # no exponent values given
+  no exponent values given
   ```
 
   ```shell
   ./power
-  # out:
-  # [ERROR] : No values parsed for a required argument [base]
-  # Program: power calculator
-  #
-  #   Calculates the value of an expression: base ^ exponent
-  #
-  # Positional arguments:
-  #
-  #   base : the exponentation base value
-  #
-  # Optional arguments:
-  #
-  #   --exponent, -e : the exponent value
-  #   --help, -h     : Display the help message
+  [ERROR] : No values parsed for a required argument [base]
+  Program: power calculator
+
+    Calculates the value of an expression: base ^ exponent
+
+  Positional arguments:
+
+    base : the exponentation base value
+
+  Optional arguments:
+
+    --exponent, -e : the exponent value
+    --help, -h     : Display the help message
   ```
 
 > [!IMPORTANT]
 >
 > For each positional argument there must be **exactly one value**.
 
-- Optional arguments are parsed only with a flag:
+- Optional arguments are parsed only with a flag. The values passed after an argument flag will be treated as the values of the last optional argument that preceeds them. If no argument flag preceeds a value argument, then it will be treated as an **unknown** value.
 
   ```shell
-  ./power 2 --exponent 1 2 3
-  # equivalent to: ./power 2 -e 1 2 3
-  # out:
-  # 2 ^ 1 = 2
-  # 2 ^ 2 = 4
-  # 2 ^ 3 = 8
+  ./power 2 --exponent 1 2 3 # equivalent to: ./power 2 -e 1 2 3
+  2 ^ 1 = 2
+  2 ^ 2 = 4
+  2 ^ 3 = 8
   ```
 
   You can use the flag for each command-line value:
@@ -869,31 +865,83 @@ int main(int argc, char* argv[]) {
 
   ```shell
   ./power 2 1 2 3
-  # out:
-  # [ERROR] : Failed to deduce the argument for values [1, 2, 3]
-  # Program: power calculator
-  #
-  #   Calculates the value of an expression: base ^ exponent
-  #
-  # Positional arguments:
-  #
-  #   base : the exponentation base value
-  #
-  # Optional arguments:
-  #
-  #   --exponent, -e : the exponent value
-  #   --help, -h     : Display the help message
+  [ERROR] : Failed to deduce the argument for values [1, 2, 3]
+  Program: power calculator
+
+    Calculates the value of an expression: base ^ exponent
+
+  Positional arguments:
+
+    base : the exponentation base value
+
+  Optional arguments:
+
+    --exponent, -e : the exponent value
+    --help, -h     : Display the help message
   ```
 
-> [!IMPORTANT]
+> [!WARNING]
 >
-> The parser's behavior depends on the argument definitions - see [Argument Parameters](#argument-parameters) section.
+> If an optional argument has the `nargs` parameter set with an upper bound, then the values that succeed this argument's flag will be assigned to this argument only until the specified upper bound is reached. Further values will be treated as **unknown** values.
+>
+> **Example:**
+>
+> ```cpp
+> parser.add_optional_argument<int>("exponent", "e").nargs(ap::nargs::up_to(3))
+> ```
+> ```shell
+> ./power 2 -e 1 2 3 4 5
+> [ERROR] : Failed to deduce the argument for values [4, 5]
+> Program: power calculator
+>
+>   Calculates the value of an expression: base ^ exponent
+>
+> Positional arguments:
+>
+>   base : the exponentation base value
+>
+> Optional arguments:
+>
+>   --exponent, -e : the exponent value
+>   --help, -h     : Display the help message
+> ```
 
 <br />
 
 ### Compound Arguments:
 
-TODO
+Compound argument flags are **secondary** argument flags of which **every** character matches the secondary name of an optional argument.
+
+Example:
+
+```cpp
+parser.add_optional_argument("verbose", "v")
+      .nargs(0)
+      .help("Increase verbosity level");
+
+parser.add_flag("option", "o")
+      .help("Enable an option flag");
+
+parser.add_optional_argument<int>("numbers", "n")
+      .help("Provide integer values");
+
+parser.try_parse_args(argc, argv);
+
+std::cout << "Verbosity level: " << parser.count("verbose")
+          << "\nOption used: " << std::boolalpha << parser.value<bool>("use-option")
+          << "\nNumbers: " << join(parser.values<int>("numbers"), ", ") // join is an imaginary function :)
+          << std::endl;
+
+/*
+> ./program -vvon 1 2 3
+Verbosity level: 2
+Option used: true
+Numbers: 1, 2, 3
+```
+
+> [!IMPORTANT]
+>
+> The argument parser will try to assign the values following a compound argument flag to the argument represented by the last character of the compound flag.
 
 <br/>
 <br/>

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -103,16 +103,30 @@ To use the argument parser in your code you need to use the `ap::argument_parser
 
 The parameters you can specify for a parser's instance are:
 
-- Program name and description - used in the parser's configuration output (`std::cout << parser`).
+- The program's name, version and description - used in the parser's configuration output (`std::cout << parser`).
 - Verbosity mode - `false` by default; if set to `true` the parser's configuration output will include more detailed info about arguments' parameters in addition to their names and help messages.
 - [Arguments](#adding-arguments) - specify the values/options accepted by the program.
 
 ```cpp
 ap::argument_parser parser;
 parser.program_name("Name of the program")
+      .program_version("alhpa")
       .program_description("Description of the program")
       .verbose();
 ```
+
+> [!TIP]
+>
+> You can specify the program version using a string (like in the example above) or using the `ap::version` structure:
+>
+> ```cpp
+> parser.program_version({ .major = 0u, .minor = 0u, .patch = 0u })
+> ```
+>
+> **NOTE:** The `ap::version` struct
+> - contains the three members - `major`, `minor`, `patch` - all of which are of type `std::uint32_t`,
+> - defines a `std::string str() const` method which returns a `v{major}.{minor}.{path}` version string,
+> - defines the `std::ostream& operator<<` for stream insertion.
 
 <br/>
 <br/>

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -14,6 +14,7 @@
 #include "argument/positional.hpp"
 #include "detail/argument_token.hpp"
 #include "detail/concepts.hpp"
+#include "version.hpp"
 
 #include <algorithm>
 #include <format>
@@ -59,7 +60,27 @@ public:
      * @return Reference to the argument parser.
      */
     argument_parser& program_name(std::string_view name) noexcept {
-        this->_program_name = name;
+        this->_program_name.emplace(name);
+        return *this;
+    }
+
+    /**
+     * @brief Set the program version.
+     * @param version The version of the program.
+     * @return Reference to the argument parser.
+     */
+    argument_parser& program_version(const version& version) noexcept {
+        this->_program_version.emplace(version.str());
+        return *this;
+    }
+
+    /**
+     * @brief Set the program version.
+     * @param version The version of the program.
+     * @return Reference to the argument parser.
+     */
+    argument_parser& program_version(std::string_view version) noexcept {
+        this->_program_version.emplace(version);
         return *this;
     }
 
@@ -69,7 +90,7 @@ public:
      * @return Reference to the argument parser.
      */
     argument_parser& program_description(std::string_view description) noexcept {
-        this->_program_description = description;
+        this->_program_description.emplace(description);
         return *this;
     }
 
@@ -457,13 +478,17 @@ public:
      * @param os Output stream.
      */
     void print_config(const bool verbose, std::ostream& os = std::cout) const noexcept {
-        if (this->_program_name)
-            os << "Program: " << this->_program_name.value() << std::endl;
+        if (this->_program_name) {
+            os << "Program: " << this->_program_name.value();
+            if (this->_program_version)
+                os << " (" << this->_program_version.value() << ')';
+            os << '\n';
+        }
 
         if (this->_program_description)
-            os << "\n"
+            os << '\n'
                << std::string(this->_indent_width, ' ') << this->_program_description.value()
-               << std::endl;
+               << '\n';
 
         if (not this->_positional_args.empty()) {
             os << "\nPositional arguments:\n";
@@ -926,6 +951,7 @@ private:
     }
 
     std::optional<std::string> _program_name;
+    std::optional<std::string> _program_version;
     std::optional<std::string> _program_description;
     bool _verbose = false;
 

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -707,7 +707,6 @@ private:
     }
 
     /**
-     * !!! UPDATE
      * @brief Check if a flag token is valid based on its value.
      * @attention Sets the `arg` member of the token if an argument with the given name (token's value) is present.
      * @param tok The argument token to validate.

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -662,7 +662,7 @@ private:
     void _tokenize_arg(arg_token_list_t& toks, const std::string_view arg_value) {
         auto tok = this->_build_token(arg_value);
 
-        if (not tok.is_flag_token() or this->_is_valid_flag(tok)) {
+        if (not tok.is_flag_token() or this->_validate_flag_token(tok)) {
             toks.emplace_back(std::move(tok));
             return;
         }
@@ -709,10 +709,11 @@ private:
     /**
      * !!! UPDATE
      * @brief Check if a flag token is valid based on its value.
-     * @param tok The processed argument token.
-     * @return true if the token's value matches an argument name specified within the parser, false otherwise.
+     * @attention Sets the `arg` member of the token if an argument with the given name (token's value) is present.
+     * @param tok The argument token to validate.
+     * @return true if the given token represents a valid argument flag.
      */
-    [[nodiscard]] bool _is_valid_flag(detail::argument_token& tok) noexcept {
+    [[nodiscard]] bool _validate_flag_token(detail::argument_token& tok) noexcept {
         const auto opt_arg_it = this->_find_opt_arg(tok);
         if (opt_arg_it == this->_optional_args.end())
             return false;
@@ -722,10 +723,10 @@ private:
     }
 
     /**
-     * @brief ...
-     * @param
-     * @param
-     * @return
+     * @brief Tries to split a secondary flag token into separate flag token (one for each character of the token's value).
+     * @param tok The token to be processed.
+     * @return A vector of new argument tokens.
+     * @note If ANY of the characters in the token's value does not match an argument, an empty vector will be returned.
      */
     [[nodiscard]] std::vector<detail::argument_token> _try_split_compound_flag(
         const detail::argument_token& tok
@@ -740,7 +741,7 @@ private:
             detail::argument_token ctok{
                 detail::argument_token::t_flag_secondary, std::string(1ull, c)
             };
-            if (not this->_is_valid_flag(ctok)) {
+            if (not this->_validate_flag_token(ctok)) {
                 compound_toks.clear();
                 return compound_toks;
             }

--- a/include/ap/detail/argument_descriptor.hpp
+++ b/include/ap/detail/argument_descriptor.hpp
@@ -177,7 +177,7 @@ private:
             max_param_name_len = std::max(max_param_name_len, param.name.size());
 
         for (const auto& param : this->params) {
-            oss << "\n"
+            oss << '\n'
                 << std::string(indent_width * 2, ' ') << "- "
                 << std::setw(static_cast<int>(max_param_name_len)) << std::left << param.name
                 << " = " << param.value;

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -6,13 +6,20 @@
 
 #pragma once
 
+#include "argument_base.hpp"
+#include "typing_utility.hpp"
+
 #include <cstdint>
+#include <functional>
+#include <optional>
 #include <string>
 
 namespace ap::detail {
 
 /// @brief Structure representing a single command-line argument token.
 struct argument_token {
+    using arg_ptr_opt_t = uptr_opt_t<detail::argument_base>;
+
     /// @brief The token type discriminator.
     enum class token_type : std::uint8_t {
         t_flag_primary, ///< Represents the primary (--) flag argument.
@@ -40,6 +47,7 @@ struct argument_token {
 
     token_type type; ///< The token's type discrimiator value.
     std::string value; ///< The actual token's value.
+    arg_ptr_opt_t arg = std::nullopt; ///< The corresponding argument.
 };
 
 } // namespace ap::detail

--- a/include/ap/detail/typing_utility.hpp
+++ b/include/ap/detail/typing_utility.hpp
@@ -4,10 +4,16 @@
 
 #pragma once
 
+#include <functional>
+#include <memory>
+#include <optional>
 #include <source_location>
 #include <string_view>
 
 namespace ap::detail {
+
+template <typename T>
+using uptr_opt_t = std::optional<std::reference_wrapper<std::unique_ptr<T>>>;
 
 template <typename T>
 constexpr std::string_view get_demangled_type_name() {

--- a/include/ap/version.hpp
+++ b/include/ap/version.hpp
@@ -1,0 +1,30 @@
+// Copyright (c) 2023-2025 Jakub Musiał
+// This file is part of the CPP-AP project (https://github.com/SpectraL519/cpp-ap).
+// Licensed under the MIT License. See the LICENSE file in the project root for full license information.
+
+#pragma once
+
+#include <format>
+#include <iostream>
+
+namespace ap {
+
+/// @brief A helper structure used to represent a program's version.
+struct version {
+    std::uint32_t major; ///< The major version number.
+    std::uint32_t minor; ///< The minor version number.
+    std::uint32_t patch; ///< The patch number.
+
+    /// @brief Converts the structure into a string in the `v{major}.{minor}.{path}` format
+    [[nodiscard]] std::string str() const noexcept {
+        return std::format("v{}.{}.{}", this->major, this->minor, this->patch);
+    }
+
+    /// @brief The stream insertion operator.
+    friend std::ostream& operator<<(std::ostream& os, const version& v) {
+        os << v.str();
+        return os;
+    }
+};
+
+} // namespace ap

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -110,7 +110,7 @@ struct argument_parser_test_fixture {
 
     [[nodiscard]] arg_token_list_t init_arg_tokens(
         std::size_t n_positional_args, std::size_t n_optional_args
-    ) const {
+    ) {
         arg_token_list_t arg_tokens;
         arg_tokens.reserve(get_args_length(n_positional_args, n_optional_args));
 
@@ -119,9 +119,14 @@ struct argument_parser_test_fixture {
 
         for (std::size_t i = 0ull; i < n_optional_args; ++i) {
             const auto arg_idx = n_positional_args + i;
-            arg_tokens.push_back(argument_token{
-                argument_token::t_flag_primary, init_arg_name(arg_idx).primary.value()
-            });
+            const auto arg_name = init_arg_name(arg_idx).primary.value();
+
+            argument_token flag_tok{argument_token::t_flag_primary, arg_name};
+            const auto opt_arg_it = sut._find_opt_arg(flag_tok);
+            if (opt_arg_it != sut._optional_args.end())
+                flag_tok.arg.emplace(*opt_arg_it);
+
+            arg_tokens.push_back(std::move(flag_tok));
             arg_tokens.push_back(argument_token{argument_token::t_value, init_arg_value(arg_idx)});
         }
 
@@ -142,7 +147,7 @@ struct argument_parser_test_fixture {
     }
 
     // private function callers
-    [[nodiscard]] arg_token_list_t tokenize(int argc, char* argv[]) const {
+    [[nodiscard]] arg_token_list_t tokenize(int argc, char* argv[]) {
         return sut._tokenize(std::span(argv + 1, static_cast<std::size_t>(argc - 1)));
     }
 

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -128,7 +128,7 @@ struct argument_parser_test_fixture {
         return arg_tokens;
     }
 
-    // argument_parser private function accessors
+    // argument_parser private member accessors
     [[nodiscard]] const std::optional<std::string>& get_program_name() const {
         return sut._program_name;
     }
@@ -137,6 +137,11 @@ struct argument_parser_test_fixture {
         return sut._program_description;
     }
 
+    [[nodiscard]] const std::optional<std::string>& get_program_version() const {
+        return sut._program_version;
+    }
+
+    // private function callers
     [[nodiscard]] arg_token_list_t tokenize(int argc, char* argv[]) const {
         return sut._tokenize(std::span(argv + 1, static_cast<std::size_t>(argc - 1)));
     }

--- a/tests/source/test_argument_parser_info.cpp
+++ b/tests/source/test_argument_parser_info.cpp
@@ -6,7 +6,7 @@ using namespace ap_testing;
 struct test_argument_parser_info : public argument_parser_test_fixture {
     const std::string test_name = "test program name";
     const std::string test_description = "test program description";
-    const ap::version test_version = {1u, 2u, 3u};
+    const ap::version test_version{1u, 2u, 3u};
     const std::string test_str_version = "alpha";
 };
 

--- a/tests/source/test_argument_parser_info.cpp
+++ b/tests/source/test_argument_parser_info.cpp
@@ -6,6 +6,8 @@ using namespace ap_testing;
 struct test_argument_parser_info : public argument_parser_test_fixture {
     const std::string test_name = "test program name";
     const std::string test_description = "test program description";
+    const ap::version test_version = {1u, 2u, 3u};
+    const std::string test_str_version = "alpha";
 };
 
 TEST_CASE_FIXTURE(
@@ -22,6 +24,25 @@ TEST_CASE_FIXTURE(test_argument_parser_info, "name() should set the program name
 
     REQUIRE(stored_program_name);
     CHECK_EQ(stored_program_name.value(), test_name);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_info, "parser's program version member should be nullopt by default"
+) {
+    const auto stored_program_version = get_program_version();
+    CHECK_FALSE(stored_program_version);
+}
+
+TEST_CASE_FIXTURE(test_argument_parser_info, "version() should set the program version member") {
+    sut.program_version(test_version);
+    auto stored_program_version = get_program_version();
+    REQUIRE(stored_program_version);
+    CHECK_EQ(stored_program_version.value(), test_version.str());
+
+    sut.program_version(test_str_version);
+    stored_program_version = get_program_version();
+    REQUIRE(stored_program_version);
+    CHECK_EQ(stored_program_version.value(), test_str_version);
 }
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -39,50 +39,50 @@ struct test_argument_parser_parse_args : public argument_parser_test_fixture {
 
 // _tokenize
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "_tokenize should return an empty vector for no command-line arguments"
-// ) {
-//     const auto argc = get_argc(no_args, no_args);
-//     auto argv = init_argv(no_args, no_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "_tokenize should return an empty vector for no command-line arguments"
+) {
+    const auto argc = get_argc(no_args, no_args);
+    auto argv = init_argv(no_args, no_args);
 
-//     const auto args = tokenize(argc, argv);
+    const auto args = tokenize(argc, argv);
 
-//     CHECK(args.empty());
+    CHECK(args.empty());
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args, "_tokenize should return a vector of correct arguments"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "_tokenize should return a vector of correct arguments"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
 
-//     const auto arg_tokens = tokenize(argc, argv);
+    const auto arg_tokens = tokenize(argc, argv);
 
-//     REQUIRE_EQ(arg_tokens.size(), get_args_length(n_positional_args, n_optional_args));
+    REQUIRE_EQ(arg_tokens.size(), get_args_length(n_positional_args, n_optional_args));
 
-//     for (std::size_t i = 0; i < n_positional_args; ++i) {
-//         REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_value);
-//         CHECK_EQ(arg_tokens.at(i).value, init_arg_value(i));
-//     }
+    for (std::size_t i = 0; i < n_positional_args; ++i) {
+        REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_value);
+        CHECK_EQ(arg_tokens.at(i).value, init_arg_value(i));
+    }
 
-//     std::size_t opt_arg_idx = n_positional_args;
-//     for (std::size_t i = n_positional_args; i < arg_tokens.size(); i += 2ull) {
-//         REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag_primary);
-//         CHECK(init_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
+    std::size_t opt_arg_idx = n_positional_args;
+    for (std::size_t i = n_positional_args; i < arg_tokens.size(); i += 2ull) {
+        REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag_primary);
+        CHECK(init_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
 
-//         REQUIRE_EQ(arg_tokens.at(i + 1ull).type, argument_token::t_value);
-//         CHECK_EQ(arg_tokens.at(i + 1ull).value, init_arg_value(opt_arg_idx));
+        REQUIRE_EQ(arg_tokens.at(i + 1ull).type, argument_token::t_value);
+        CHECK_EQ(arg_tokens.at(i + 1ull).value, init_arg_value(opt_arg_idx));
 
-//         ++opt_arg_idx;
-//     }
+        ++opt_arg_idx;
+    }
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
 // _parse_args_impl
 
@@ -103,834 +103,834 @@ TEST_CASE_FIXTURE(
     );
 }
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "_parse_args_impl should not throw when the arguments are correct"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-//     const auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
-//     CHECK_NOTHROW(parse_args_impl(arg_tokens));
-// }
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "_parse_args_impl should not throw when the arguments are correct"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+    const auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
+    CHECK_NOTHROW(parse_args_impl(arg_tokens));
+}
 
 // _get_argument
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "_get_argument should return nullopt if there is no argument with given name present"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-//     CHECK_FALSE(get_argument(invalid_arg_name));
-// }
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "_get_argument should return nullopt if there is no argument with given name present"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+    CHECK_FALSE(get_argument(invalid_arg_name));
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "_get_argument should return valid argument if there is an argument with the given name"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "_get_argument should return valid argument if there is an argument with the given name"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     for (std::size_t i = 0ull; i < n_positional_args; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         CHECK(get_argument(arg_name.primary.value()));
-//         CHECK(get_argument(arg_name.secondary.value()));
-//     }
-// }
+    for (std::size_t i = 0ull; i < n_positional_args; ++i) {
+        const auto arg_name = init_arg_name(i);
+        CHECK(get_argument(arg_name.primary.value()));
+        CHECK(get_argument(arg_name.secondary.value()));
+    }
+}
 
 // parse_args
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should throw when there is not enough positional values"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when there is not enough positional values"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv_vec = init_argv_vec(n_positional_args, n_optional_args);
+    auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv_vec = init_argv_vec(n_positional_args, n_optional_args);
 
-//     // remove the last positional value
-//     --argc;
-//     argv_vec.erase(std::next(argv_vec.begin(), static_cast<std::ptrdiff_t>(last_pos_arg_idx)));
+    // remove the last positional value
+    --argc;
+    argv_vec.erase(std::next(argv_vec.begin(), static_cast<std::ptrdiff_t>(last_pos_arg_idx)));
 
-//     auto argv = to_char_2d_array(argv_vec);
+    auto argv = to_char_2d_array(argv_vec);
 
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         parsing_failure::required_argument_not_parsed({init_arg_name(last_pos_arg_idx)}).what(),
-//         parsing_failure
-//     );
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::required_argument_not_parsed({init_arg_name(last_pos_arg_idx)}).what(),
+        parsing_failure
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should throw if a required positional argument is defined after a non-require "
-//     "posisitonal argument"
-// ) {
-//     const auto non_required_arg_name = init_arg_name(0ull);
-//     sut.add_positional_argument(
-//            non_required_arg_name.primary.value(), non_required_arg_name.secondary.value()
-//     )
-//         .required(false);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw if a required positional argument is defined after a non-require "
+    "posisitonal argument"
+) {
+    const auto non_required_arg_name = init_arg_name(0ull);
+    sut.add_positional_argument(
+           non_required_arg_name.primary.value(), non_required_arg_name.secondary.value()
+    )
+        .required(false);
 
-//     const auto required_arg_name = init_arg_name(1ull);
-//     sut.add_positional_argument(
-//         required_arg_name.primary.value(), required_arg_name.secondary.value()
-//     );
+    const auto required_arg_name = init_arg_name(1ull);
+    sut.add_positional_argument(
+        required_arg_name.primary.value(), required_arg_name.secondary.value()
+    );
 
-//     const auto argc = get_argc(no_args, no_args);
-//     auto argv = init_argv(no_args, no_args);
+    const auto argc = get_argc(no_args, no_args);
+    auto argv = init_argv(no_args, no_args);
 
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         invalid_configuration::positional::required_after_non_required(
-//             required_arg_name, non_required_arg_name
-//         )
-//             .what(),
-//         invalid_configuration
-//     );
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        invalid_configuration::positional::required_after_non_required(
+            required_arg_name, non_required_arg_name
+        )
+            .what(),
+        invalid_configuration
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should throw when there is no value specified for a required optional argument"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when there is no value specified for a required optional argument"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     const auto required_arg_name = init_arg_name(n_args_total, flag_char);
-//     sut.add_optional_argument(
-//            required_arg_name.primary.value(), required_arg_name.secondary.value()
-//     )
-//         .required();
+    const auto required_arg_name = init_arg_name(n_args_total, flag_char);
+    sut.add_optional_argument(
+           required_arg_name.primary.value(), required_arg_name.secondary.value()
+    )
+        .required();
 
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
 
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         parsing_failure::required_argument_not_parsed(required_arg_name).what(),
-//         parsing_failure
-//     );
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::required_argument_not_parsed(required_arg_name).what(),
+        parsing_failure
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should throw when an optional argument's nvalues is not in a specified range"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when an optional argument's nvalues is not in a specified range"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
+    auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
 
-//     const auto range_arg_name = init_arg_name(n_args_total, flag_char);
-//     sut.add_optional_argument(range_arg_name.primary.value(), range_arg_name.secondary.value())
-//         .nargs(at_least(1ull));
+    const auto range_arg_name = init_arg_name(n_args_total, flag_char);
+    sut.add_optional_argument(range_arg_name.primary.value(), range_arg_name.secondary.value())
+        .nargs(at_least(1ull));
 
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         parsing_failure::invalid_nvalues(range_arg_name, std::weak_ordering::less).what(),
-//         parsing_failure
-//     );
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::invalid_nvalues(range_arg_name, std::weak_ordering::less).what(),
+        parsing_failure
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args, "parse_args should throw when an unknown argument flag is used"
-// ) {
-//     add_arguments(no_args, no_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "parse_args should throw when an unknown argument flag is used"
+) {
+    add_arguments(no_args, no_args);
 
-//     constexpr std::size_t n_opt_clargs = 1ull;
-//     constexpr std::size_t opt_arg_idx = 0ull;
+    constexpr std::size_t n_opt_clargs = 1ull;
+    constexpr std::size_t opt_arg_idx = 0ull;
 
-//     auto argc = get_argc(no_args, n_opt_clargs);
-//     auto argv = init_argv(no_args, n_opt_clargs);
+    auto argc = get_argc(no_args, n_opt_clargs);
+    auto argv = init_argv(no_args, n_opt_clargs);
 
-//     const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
+    const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
 
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         parsing_failure::unknown_argument(unknown_arg_name).what(),
-//         parsing_failure
-//     );
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(unknown_arg_name).what(),
+        parsing_failure
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should throw when an optional argument's flag uses the correct name but an "
-//     "incorrect flag prefix"
-// ) {
-//     constexpr std::size_t n_opt_args = 1ull;
-//     constexpr std::size_t opt_arg_idx = 0ull;
-//     add_arguments(no_args, n_opt_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when an optional argument's flag uses the correct name but an "
+    "incorrect flag prefix"
+) {
+    constexpr std::size_t n_opt_args = 1ull;
+    constexpr std::size_t opt_arg_idx = 0ull;
+    add_arguments(no_args, n_opt_args);
 
-//     auto argc = get_argc(no_args, n_opt_args);
-//     auto argv_vec = init_argv_vec(no_args, n_opt_args);
+    auto argc = get_argc(no_args, n_opt_args);
+    auto argv_vec = init_argv_vec(no_args, n_opt_args);
 
-//     const auto opt_arg_name = init_arg_name(opt_arg_idx);
+    const auto opt_arg_name = init_arg_name(opt_arg_idx);
 
-//     std::string invalid_flag;
+    std::string invalid_flag;
 
-//     SUBCASE("primary name with a secondary flag prefix") {
-//         invalid_flag = "-" + opt_arg_name.primary.value();
-//     }
-//     SUBCASE("secondary name with a primary flag prefix") {
-//         invalid_flag = "--" + opt_arg_name.secondary.value();
-//     }
+    SUBCASE("primary name with a secondary flag prefix") {
+        invalid_flag = "-" + opt_arg_name.primary.value();
+    }
+    SUBCASE("secondary name with a primary flag prefix") {
+        invalid_flag = "--" + opt_arg_name.secondary.value();
+    }
 
-//     CAPTURE(invalid_flag);
+    CAPTURE(invalid_flag);
 
-//     auto arg_flag_it = std::ranges::find(argv_vec, init_arg_flag_primary(opt_arg_idx));
-//     if (arg_flag_it == argv_vec.end())
-//         FAIL("could not find the optional argument flag");
+    auto arg_flag_it = std::ranges::find(argv_vec, init_arg_flag_primary(opt_arg_idx));
+    if (arg_flag_it == argv_vec.end())
+        FAIL("could not find the optional argument flag");
 
-//     *arg_flag_it = invalid_flag;
-//     auto argv = to_char_2d_array(argv_vec);
+    *arg_flag_it = invalid_flag;
+    auto argv = to_char_2d_array(argv_vec);
 
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         parsing_failure::unknown_argument(invalid_flag).what(),
-//         parsing_failure
-//     );
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(invalid_flag).what(),
+        parsing_failure
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should not throw if the number of positional values are correct and all required "
-//     "optional arguments have values"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should not throw if the number of positional values are correct and all required "
+    "optional arguments have values"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     const auto required_arg_name = init_arg_name(n_args_total);
-//     sut.add_optional_argument(
-//            required_arg_name.primary.value(), required_arg_name.secondary.value()
-//     )
-//         .required();
+    const auto required_arg_name = init_arg_name(n_args_total);
+    sut.add_optional_argument(
+           required_arg_name.primary.value(), required_arg_name.secondary.value()
+    )
+        .required();
 
-//     int argc;
-//     char** argv;
+    int argc;
+    char** argv;
 
-//     SUBCASE("all arguments have values") {
-//         const auto n_optional_args_curr = n_optional_args + 1ull;
-//         argc = get_argc(n_positional_args, n_optional_args_curr);
-//         argv = init_argv(n_positional_args, n_optional_args_curr);
-//     }
-//     SUBCASE("only the necessary arguments have values") {
-//         const auto n_optional_args_curr = 1ull;
+    SUBCASE("all arguments have values") {
+        const auto n_optional_args_curr = n_optional_args + 1ull;
+        argc = get_argc(n_positional_args, n_optional_args_curr);
+        argv = init_argv(n_positional_args, n_optional_args_curr);
+    }
+    SUBCASE("only the necessary arguments have values") {
+        const auto n_optional_args_curr = 1ull;
 
-//         argc = get_argc(n_positional_args, n_optional_args_curr);
+        argc = get_argc(n_positional_args, n_optional_args_curr);
 
-//         auto argv_vec = init_argv_vec(n_positional_args, n_optional_args_curr);
-//         argv_vec[static_cast<std::size_t>(argc - 2)] = init_arg_flag_primary(n_args_total).c_str();
-//         argv_vec[static_cast<std::size_t>(argc - 1)] = init_arg_value(n_args_total).c_str();
+        auto argv_vec = init_argv_vec(n_positional_args, n_optional_args_curr);
+        argv_vec[static_cast<std::size_t>(argc - 2)] = init_arg_flag_primary(n_args_total).c_str();
+        argv_vec[static_cast<std::size_t>(argc - 1)] = init_arg_value(n_args_total).c_str();
 
-//         argv = to_char_2d_array(argv_vec);
-//     }
+        argv = to_char_2d_array(argv_vec);
+    }
 
-//     CAPTURE(argc);
-//     CAPTURE(argv);
+    CAPTURE(argc);
+    CAPTURE(argv);
 
-//     CHECK_NOTHROW(sut.parse_args(argc, argv));
+    CHECK_NOTHROW(sut.parse_args(argc, argv));
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should not throw if there is an positional argument which has the bypass_required "
-//     "option enabled and is used"
-// ) {
-//     const std::size_t n_positional_args = 1ull;
-//     const auto bypass_required_arg_name = init_arg_name(n_positional_args - 1ull).primary.value();
-//     sut.add_positional_argument(bypass_required_arg_name).bypass_required();
-//     const std::string bypass_required_arg_value = "bypass_required_arg_value";
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should not throw if there is an positional argument which has the bypass_required "
+    "option enabled and is used"
+) {
+    const std::size_t n_positional_args = 1ull;
+    const auto bypass_required_arg_name = init_arg_name(n_positional_args - 1ull).primary.value();
+    sut.add_positional_argument(bypass_required_arg_name).bypass_required();
+    const std::string bypass_required_arg_value = "bypass_required_arg_value";
 
-//     for (std::size_t i = 0ull; i < n_optional_args; ++i)
-//         sut.add_optional_argument(init_arg_name(n_positional_args + i).primary.value()).required();
+    for (std::size_t i = 0ull; i < n_optional_args; ++i)
+        sut.add_optional_argument(init_arg_name(n_positional_args + i).primary.value()).required();
 
-//     std::vector<std::string> argv_vec{"program", bypass_required_arg_value};
-//     const int argc = static_cast<int>(argv_vec.size());
-//     const auto argv = to_char_2d_array(argv_vec);
+    std::vector<std::string> argv_vec{"program", bypass_required_arg_value};
+    const int argc = static_cast<int>(argv_vec.size());
+    const auto argv = to_char_2d_array(argv_vec);
 
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-//     CHECK_EQ(sut.value(bypass_required_arg_name), bypass_required_arg_value);
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+    CHECK_EQ(sut.value(bypass_required_arg_name), bypass_required_arg_value);
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "parse_args should not throw if there is an optional argument which has the bypass_required "
-//     "option enabled and is used"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should not throw if there is an optional argument which has the bypass_required "
+    "option enabled and is used"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     const auto bypass_required_arg_name = init_arg_name(n_args_total);
-//     sut.add_optional_argument<bool>(
-//            bypass_required_arg_name.primary.value(), bypass_required_arg_name.secondary.value()
-//     )
-//         .default_value(false)
-//         .implicit_value(true)
-//         .bypass_required();
+    const auto bypass_required_arg_name = init_arg_name(n_args_total);
+    sut.add_optional_argument<bool>(
+           bypass_required_arg_name.primary.value(), bypass_required_arg_name.secondary.value()
+    )
+        .default_value(false)
+        .implicit_value(true)
+        .bypass_required();
 
-//     std::string arg_flag;
+    std::string arg_flag;
 
-//     SUBCASE("primary flag") {
-//         arg_flag = init_arg_flag_primary(n_args_total);
-//     }
-//     SUBCASE("secondary flag") {
-//         arg_flag = init_arg_flag_secondary(n_args_total);
-//     }
+    SUBCASE("primary flag") {
+        arg_flag = init_arg_flag_primary(n_args_total);
+    }
+    SUBCASE("secondary flag") {
+        arg_flag = init_arg_flag_secondary(n_args_total);
+    }
 
-//     CAPTURE(arg_flag);
+    CAPTURE(arg_flag);
 
-//     std::vector<std::string> argv_vec{"program", arg_flag};
-//     const int argc = static_cast<int>(argv_vec.size());
-//     const auto argv = to_char_2d_array(argv_vec);
+    std::vector<std::string> argv_vec{"program", arg_flag};
+    const int argc = static_cast<int>(argv_vec.size());
+    const auto argv = to_char_2d_array(argv_vec);
 
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-//     CHECK(sut.value<bool>(bypass_required_arg_name.primary.value()));
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+    CHECK(sut.value<bool>(bypass_required_arg_name.primary.value()));
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
 // has_value
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "has_value should return false if there is no argument with given name present"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "has_value should return false if there is no argument with given name present"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
 
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-//     CHECK_FALSE(sut.has_value(invalid_arg_name));
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+    CHECK_FALSE(sut.has_value(invalid_arg_name));
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args, "has_value should return false when an argument has no values"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "has_value should return false when an argument has no values"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         CHECK_FALSE(sut.has_value(arg_name.primary.value()));
-//         CHECK_FALSE(sut.has_value(arg_name.secondary.value()));
-//     }
-// }
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        CHECK_FALSE(sut.has_value(arg_name.primary.value()));
+        CHECK_FALSE(sut.has_value(arg_name.secondary.value()));
+    }
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "has_value should return true if a value has been parsed for the argument"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "has_value should return true if a value has been parsed for the argument"
+) {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     const int argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
+    const int argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
 
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
 
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         CHECK(sut.has_value(arg_name.primary.value()));
-//         CHECK(sut.has_value(arg_name.secondary.value()));
-//     }
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        CHECK(sut.has_value(arg_name.primary.value()));
+        CHECK(sut.has_value(arg_name.secondary.value()));
+    }
 
-//     free_argv(argc, argv);
-// }
-
-// value
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value() should throw if there is no argument with given name present"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-//     CHECK_THROWS_AS(discard_result(sut.value(invalid_arg_name)), ap::lookup_failure);
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value() should throw if no value has been parsed for an argument"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         CHECK_THROWS_AS(discard_result(sut.value(arg_name.primary.value())), std::logic_error);
-//         CHECK_THROWS_AS(discard_result(sut.value(arg_name.secondary.value())), std::logic_error);
-//     }
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value() should throw if an argument has a value but the given type is invalid"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
-
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-
-//     using invalid_value_type = int;
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-
-//         REQUIRE(sut.has_value(arg_name.primary.value()));
-//         CHECK_THROWS_AS(
-//             discard_result(sut.value<invalid_value_type>(arg_name.primary.value())), ap::type_error
-//         );
-//     }
-
-//     free_argv(argc, argv);
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value() should return a correct value when the argument name is valid and its value has been "
-//     "parsed"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
-
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         const auto arg_value = init_arg_value(i);
-
-//         REQUIRE(sut.has_value(arg_name.primary.value()));
-//         CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
-//         CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
-//     }
-
-//     free_argv(argc, argv);
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value() should return a correct value for an optional argument when the name is valid and the "
-//     "argument has a predefined value"
-// ) {
-//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
-//             .default_value(init_arg_value(i));
-//     }
-
-//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         const auto arg_value = init_arg_value(i);
-
-//         REQUIRE(sut.has_value(arg_name.primary.value()));
-//         CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
-//         CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
-//     }
-// }
-
-// value_or
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value_or() should throw if there is no argument with given name present"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-//     CHECK_THROWS_AS(discard_result(sut.value_or(invalid_arg_name, empty_str)), ap::lookup_failure);
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value_or() should throw if an argument has a value but the given type is invalid"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
-
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-
-//     using invalid_value_type = int;
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-
-//         REQUIRE(sut.has_value(arg_name.primary.value()));
-//         CHECK_THROWS_AS(
-//             discard_result(
-//                 sut.value_or<invalid_value_type>(arg_name.primary.value(), invalid_value_type{})
-//             ),
-//             ap::type_error
-//         );
-//     }
-
-//     free_argv(argc, argv);
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value_or() should return a correct value when the argument name is valid and its value has "
-//     "been parsed"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-
-//     const auto argc = get_argc(n_positional_args, n_optional_args);
-//     auto argv = init_argv(n_positional_args, n_optional_args);
-
-//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         const auto arg_value = init_arg_value(i);
-
-//         REQUIRE(sut.has_value(arg_name.primary.value()));
-//         CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
-//         CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
-//     }
-
-//     free_argv(argc, argv);
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value_or() should return a correct value for an optional argument when the name is valid and "
-//     "the argument has a predefined value"
-// ) {
-//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
-//             .default_value(init_arg_value(i));
-//     }
-
-//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         const auto arg_value = init_arg_value(i);
-
-//         REQUIRE(sut.has_value(arg_name.primary.value()));
-//         CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
-//         CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
-//     }
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value_or() should return an instance of the specified type initialized from the given default "
-//     "value if no value has been parsed for an argument and it doesn't have a predefined value "
-//     "(optional)"
-// ) {
-//     using value_type = int;
-//     using default_value_type = short;
-
-//     add_arguments<value_type>(n_positional_args, n_optional_args);
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         const default_value_type default_value = 2 * static_cast<default_value_type>(i);
-
-//         CHECK_EQ(sut.value_or<value_type>(arg_name.primary.value(), default_value), default_value);
-//         CHECK_EQ(
-//             sut.value_or<value_type>(arg_name.secondary.value(), default_value), default_value
-//         );
-//     }
-// }
-
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "value_or() should return the given default value if no value has been parsed for an argument "
-//     "and it doesn't have a predefined value (optional)"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         const auto default_value = init_arg_value(i);
-
-//         CHECK_EQ(sut.value_or(arg_name.primary.value(), default_value), default_value);
-//         CHECK_EQ(sut.value_or(arg_name.secondary.value(), default_value), default_value);
-//     }
-// }
+    free_argv(argc, argv);
+}
 
 // count
 
-// TEST_CASE_FIXTURE(test_argument_parser_parse_args, "count should return 0 by default") {
-//     add_arguments(n_positional_args, n_optional_args);
+TEST_CASE_FIXTURE(test_argument_parser_parse_args, "count should return 0 by default") {
+    add_arguments(n_positional_args, n_optional_args);
 
-//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
-//         const auto arg_name = init_arg_name(i);
-//         CHECK_EQ(sut.count(arg_name.primary.value()), 0ull);
-//         CHECK_EQ(sut.count(arg_name.secondary.value()), 0ull);
-//     }
-// }
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        CHECK_EQ(sut.count(arg_name.primary.value()), 0ull);
+        CHECK_EQ(sut.count(arg_name.secondary.value()), 0ull);
+    }
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "count should return 0 if there is no argument with given name present"
-// ) {
-//     add_arguments(n_positional_args, n_optional_args);
-//     CHECK_EQ(sut.count(invalid_arg_name), 0ull);
-// }
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "count should return 0 if there is no argument with given name present"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+    CHECK_EQ(sut.count(invalid_arg_name), 0ull);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args, "count should return the number of argument's flag usage"
-// ) {
-//     // prepare sut
-//     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
-//     sut.add_optional_argument(optional_primary_name, optional_secondary_name)
-//         .nargs(ap::nargs::any());
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "count should return the number of argument's flag usage"
+) {
+    // prepare sut
+    sut.add_positional_argument(positional_primary_name, positional_secondary_name);
+    sut.add_optional_argument(optional_primary_name, optional_secondary_name)
+        .nargs(ap::nargs::any());
 
-//     // expected values
-//     const std::size_t positional_count = 1ull;
-//     const std::size_t optional_count = 4ull;
+    // expected values
+    const std::size_t positional_count = 1ull;
+    const std::size_t optional_count = 4ull;
 
-//     // prepare argc and argv
-//     std::vector<std::string> argv_vec{"program", "positional_arg_value"};
+    // prepare argc and argv
+    std::vector<std::string> argv_vec{"program", "positional_arg_value"};
 
-//     const std::string optional_arg_flag = "--" + optional_primary_name;
-//     const std::string optional_arg_value = optional_primary_name + "_value";
-//     for (std::size_t i = 0ull; i < optional_count; ++i) {
-//         argv_vec.push_back(optional_arg_flag);
-//         if (i % 2ull == 0)
-//             argv_vec.push_back(optional_arg_value);
-//     }
+    const std::string optional_arg_flag = "--" + optional_primary_name;
+    const std::string optional_arg_value = optional_primary_name + "_value";
+    for (std::size_t i = 0ull; i < optional_count; ++i) {
+        argv_vec.push_back(optional_arg_flag);
+        if (i % 2ull == 0)
+            argv_vec.push_back(optional_arg_value);
+    }
 
-//     const int argc = static_cast<int>(argv_vec.size());
-//     auto argv = to_char_2d_array(argv_vec);
+    const int argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
 
-//     // parse args
-//     sut.parse_args(argc, argv);
+    // parse args
+    sut.parse_args(argc, argv);
 
-//     // test count
-//     CHECK_EQ(sut.count(positional_primary_name), positional_count);
-//     CHECK_EQ(sut.count(optional_primary_name), optional_count);
+    // test count
+    CHECK_EQ(sut.count(positional_primary_name), positional_count);
+    CHECK_EQ(sut.count(optional_primary_name), optional_count);
 
-//     // free argv
-//     free_argv(argc, argv);
-// }
+    // free argv
+    free_argv(argc, argv);
+}
+
+// value
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value() should throw if there is no argument with given name present"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+    CHECK_THROWS_AS(discard_result(sut.value(invalid_arg_name)), ap::lookup_failure);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value() should throw if no value has been parsed for an argument"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        CHECK_THROWS_AS(discard_result(sut.value(arg_name.primary.value())), std::logic_error);
+        CHECK_THROWS_AS(discard_result(sut.value(arg_name.secondary.value())), std::logic_error);
+    }
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value() should throw if an argument has a value but the given type is invalid"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
+
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+
+    using invalid_value_type = int;
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+
+        REQUIRE(sut.has_value(arg_name.primary.value()));
+        CHECK_THROWS_AS(
+            discard_result(sut.value<invalid_value_type>(arg_name.primary.value())), ap::type_error
+        );
+    }
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value() should return a correct value when the argument name is valid and its value has been "
+    "parsed"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
+
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        const auto arg_value = init_arg_value(i);
+
+        REQUIRE(sut.has_value(arg_name.primary.value()));
+        CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
+        CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
+    }
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value() should return a correct value for an optional argument when the name is valid and the "
+    "argument has a predefined value"
+) {
+    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+        const auto arg_name = init_arg_name(i);
+        sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
+            .default_value(init_arg_value(i));
+    }
+
+    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+        const auto arg_name = init_arg_name(i);
+        const auto arg_value = init_arg_value(i);
+
+        REQUIRE(sut.has_value(arg_name.primary.value()));
+        CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
+        CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
+    }
+}
+
+// value_or
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value_or() should throw if there is no argument with given name present"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+    CHECK_THROWS_AS(discard_result(sut.value_or(invalid_arg_name, empty_str)), ap::lookup_failure);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value_or() should throw if an argument has a value but the given type is invalid"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
+
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+
+    using invalid_value_type = int;
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+
+        REQUIRE(sut.has_value(arg_name.primary.value()));
+        CHECK_THROWS_AS(
+            discard_result(
+                sut.value_or<invalid_value_type>(arg_name.primary.value(), invalid_value_type{})
+            ),
+            ap::type_error
+        );
+    }
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value_or() should return a correct value when the argument name is valid and its value has "
+    "been parsed"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+
+    const auto argc = get_argc(n_positional_args, n_optional_args);
+    auto argv = init_argv(n_positional_args, n_optional_args);
+
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        const auto arg_value = init_arg_value(i);
+
+        REQUIRE(sut.has_value(arg_name.primary.value()));
+        CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
+        CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
+    }
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value_or() should return a correct value for an optional argument when the name is valid and "
+    "the argument has a predefined value"
+) {
+    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+        const auto arg_name = init_arg_name(i);
+        sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
+            .default_value(init_arg_value(i));
+    }
+
+    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+        const auto arg_name = init_arg_name(i);
+        const auto arg_value = init_arg_value(i);
+
+        REQUIRE(sut.has_value(arg_name.primary.value()));
+        CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
+        CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
+    }
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value_or() should return an instance of the specified type initialized from the given default "
+    "value if no value has been parsed for an argument and it doesn't have a predefined value "
+    "(optional)"
+) {
+    using value_type = int;
+    using default_value_type = short;
+
+    add_arguments<value_type>(n_positional_args, n_optional_args);
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        const default_value_type default_value = 2 * static_cast<default_value_type>(i);
+
+        CHECK_EQ(sut.value_or<value_type>(arg_name.primary.value(), default_value), default_value);
+        CHECK_EQ(
+            sut.value_or<value_type>(arg_name.secondary.value(), default_value), default_value
+        );
+    }
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "value_or() should return the given default value if no value has been parsed for an argument "
+    "and it doesn't have a predefined value (optional)"
+) {
+    add_arguments(n_positional_args, n_optional_args);
+
+    for (std::size_t i = 0ull; i < n_args_total; ++i) {
+        const auto arg_name = init_arg_name(i);
+        const auto default_value = init_arg_value(i);
+
+        CHECK_EQ(sut.value_or(arg_name.primary.value(), default_value), default_value);
+        CHECK_EQ(sut.value_or(arg_name.secondary.value(), default_value), default_value);
+    }
+}
 
 // values
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "values() should throw when calling with a positional argument's name"
-// ) {
-//     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "values() should throw when calling with a positional argument's name"
+) {
+    sut.add_positional_argument(positional_primary_name, positional_secondary_name);
 
-//     CHECK_THROWS_AS(discard_result(sut.values(positional_primary_name)), std::logic_error);
-//     CHECK_THROWS_AS(discard_result(sut.values(positional_secondary_name)), std::logic_error);
-// }
+    CHECK_THROWS_AS(discard_result(sut.values(positional_primary_name)), std::logic_error);
+    CHECK_THROWS_AS(discard_result(sut.values(positional_secondary_name)), std::logic_error);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "values() should return an empty vector if an argument has no values"
-// ) {
-//     sut.add_optional_argument(optional_primary_name, optional_secondary_name);
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "values() should return an empty vector if an argument has no values"
+) {
+    sut.add_optional_argument(optional_primary_name, optional_secondary_name);
 
-//     SUBCASE("calling with argument's primary name") {
-//         const auto& values = sut.values(optional_primary_name);
-//         CHECK(values.empty());
-//     }
+    SUBCASE("calling with argument's primary name") {
+        const auto& values = sut.values(optional_primary_name);
+        CHECK(values.empty());
+    }
 
-//     SUBCASE("calling with argument's secondary name") {
-//         const auto& values = sut.values(optional_secondary_name);
-//         CHECK(values.empty());
-//     }
-// }
+    SUBCASE("calling with argument's secondary name") {
+        const auto& values = sut.values(optional_secondary_name);
+        CHECK(values.empty());
+    }
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "values() should throw when an argument has values but the given type is invalid"
-// ) {
-//     sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "values() should throw when an argument has values but the given type is invalid"
+) {
+    sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
 
-//     // prepare argc & argv
-//     const std::string optional_arg_flag = "--" + optional_primary_name;
-//     const std::string optional_arg_value = optional_primary_name + "_value";
-//     std::vector<std::string> argv_vec{
-//         "program", optional_arg_flag, optional_arg_value, optional_arg_value
-//     };
+    // prepare argc & argv
+    const std::string optional_arg_flag = "--" + optional_primary_name;
+    const std::string optional_arg_value = optional_primary_name + "_value";
+    std::vector<std::string> argv_vec{
+        "program", optional_arg_flag, optional_arg_value, optional_arg_value
+    };
 
-//     const int argc = static_cast<int>(argv_vec.size());
-//     auto argv = to_char_2d_array(argv_vec);
+    const int argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
 
-//     // parse args
-//     sut.parse_args(argc, argv);
+    // parse args
+    sut.parse_args(argc, argv);
 
-//     CHECK_THROWS_AS(
-//         discard_result(sut.values<invalid_argument_value_type>(optional_primary_name)),
-//         ap::type_error
-//     );
-//     CHECK_THROWS_AS(
-//         discard_result(sut.values<invalid_argument_value_type>(optional_secondary_name)),
-//         ap::type_error
-//     );
+    CHECK_THROWS_AS(
+        discard_result(sut.values<invalid_argument_value_type>(optional_primary_name)),
+        ap::type_error
+    );
+    CHECK_THROWS_AS(
+        discard_result(sut.values<invalid_argument_value_type>(optional_secondary_name)),
+        ap::type_error
+    );
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "values() should return a vector containing a predefined value if an optional argument if no "
-//     "values for an argument have been parsed"
-// ) {
-//     const std::string default_value = "default_value";
-//     const std::string implicit_value = "implicit_value";
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "values() should return a vector containing a predefined value if an optional argument if no "
+    "values for an argument have been parsed"
+) {
+    const std::string default_value = "default_value";
+    const std::string implicit_value = "implicit_value";
 
-//     sut.add_optional_argument(optional_primary_name, optional_secondary_name)
-//         .default_value(default_value)
-//         .implicit_value(implicit_value);
+    sut.add_optional_argument(optional_primary_name, optional_secondary_name)
+        .default_value(default_value)
+        .implicit_value(implicit_value);
 
-//     // prepare argc & argv
-//     std::vector<std::string> argv_vec{"program"};
-//     std::string expected_value;
+    // prepare argc & argv
+    std::vector<std::string> argv_vec{"program"};
+    std::string expected_value;
 
-//     SUBCASE("default_value") {
-//         expected_value = default_value;
-//     }
+    SUBCASE("default_value") {
+        expected_value = default_value;
+    }
 
-//     SUBCASE("implicit_value") {
-//         expected_value = implicit_value;
+    SUBCASE("implicit_value") {
+        expected_value = implicit_value;
 
-//         const auto optional_arg_flag = "--" + optional_primary_name;
-//         argv_vec.push_back(optional_arg_flag);
-//     }
+        const auto optional_arg_flag = "--" + optional_primary_name;
+        argv_vec.push_back(optional_arg_flag);
+    }
 
-//     CAPTURE(expected_value);
+    CAPTURE(expected_value);
 
-//     const int argc = static_cast<int>(argv_vec.size());
-//     auto argv = to_char_2d_array(argv_vec);
+    const int argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
 
-//     // parse args
-//     sut.parse_args(argc, argv);
+    // parse args
+    sut.parse_args(argc, argv);
 
-//     const auto& stored_values = sut.values(optional_primary_name);
+    const auto& stored_values = sut.values(optional_primary_name);
 
-//     REQUIRE_EQ(stored_values.size(), 1);
-//     CHECK_EQ(stored_values.front(), expected_value);
+    REQUIRE_EQ(stored_values.size(), 1);
+    CHECK_EQ(stored_values.front(), expected_value);
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "values() should return a correct vector of values when there is an argument with "
-//     "a given name and has parsed values"
-// ) {
-//     sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "values() should return a correct vector of values when there is an argument with "
+    "a given name and has parsed values"
+) {
+    sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
 
-//     // prepare argc & argv
-//     const std::string optional_arg_flag = "--" + optional_primary_name;
-//     const std::string optional_arg_value = optional_primary_name + "_value";
+    // prepare argc & argv
+    const std::string optional_arg_flag = "--" + optional_primary_name;
+    const std::string optional_arg_value = optional_primary_name + "_value";
 
-//     std::vector<std::string> optional_arg_values{
-//         optional_arg_value + "_1", optional_arg_value + "_2", optional_arg_value + "_3"
-//     };
+    std::vector<std::string> optional_arg_values{
+        optional_arg_value + "_1", optional_arg_value + "_2", optional_arg_value + "_3"
+    };
 
-//     std::vector<std::string> argv_vec{"program", optional_arg_flag};
-//     for (const auto& value : optional_arg_values)
-//         argv_vec.push_back(value);
+    std::vector<std::string> argv_vec{"program", optional_arg_flag};
+    for (const auto& value : optional_arg_values)
+        argv_vec.push_back(value);
 
-//     const int argc = static_cast<int>(argv_vec.size());
-//     auto argv = to_char_2d_array(argv_vec);
+    const int argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
 
-//     // parse args
-//     sut.parse_args(argc, argv);
+    // parse args
+    sut.parse_args(argc, argv);
 
-//     const auto& stored_values = sut.values(optional_primary_name);
+    const auto& stored_values = sut.values(optional_primary_name);
 
-//     REQUIRE_EQ(stored_values.size(), optional_arg_values.size());
-//     for (std::size_t i = 0ull; i < stored_values.size(); ++i)
-//         CHECK_EQ(stored_values[i], optional_arg_values[i]);
+    REQUIRE_EQ(stored_values.size(), optional_arg_values.size());
+    for (std::size_t i = 0ull; i < stored_values.size(); ++i)
+        CHECK_EQ(stored_values[i], optional_arg_values[i]);
 
-//     free_argv(argc, argv);
-// }
+    free_argv(argc, argv);
+}
 
 // compound flags
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args,
-//     "argument_parser should throw if an invalid compound flag is used"
-// ) {
-//     // add arguments
-//     sut.add_optional_argument("first-arg", "f");
-//     sut.add_optional_argument("second-arg", "s");
-//     sut.add_optional_argument("third-arg", "t");
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "argument_parser should throw if an invalid compound flag is used"
+) {
+    // add arguments
+    sut.add_optional_argument("first-arg", "f");
+    sut.add_optional_argument("second-arg", "s");
+    sut.add_optional_argument("third-arg", "t");
 
-//     const std::string invalid_flag = "-abc";
-//     std::vector<std::string> argv_vec{"program", invalid_flag};
+    const std::string invalid_flag = "-abc";
+    std::vector<std::string> argv_vec{"program", invalid_flag};
 
-//     const int argc = static_cast<int>(argv_vec.size());
-//     auto argv = to_char_2d_array(argv_vec);
+    const int argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
 
-//     // parse args
-//     CHECK_THROWS_WITH_AS(
-//         sut.parse_args(argc, argv),
-//         parsing_failure::unknown_argument(invalid_flag).what(),
-//         parsing_failure
-//     );
+    // parse args
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(invalid_flag).what(),
+        parsing_failure
+    );
 
-//     // validate argument usage counts
-//     CHECK_EQ(sut.count("first-arg"), 0ull);
-//     CHECK_EQ(sut.count("second-arg"), 0ull);
-//     CHECK_EQ(sut.count("third-arg"), 0ull);
+    // validate argument usage counts
+    CHECK_EQ(sut.count("first-arg"), 0ull);
+    CHECK_EQ(sut.count("second-arg"), 0ull);
+    CHECK_EQ(sut.count("third-arg"), 0ull);
 
-//     // cleanup
-//     free_argv(argc, argv);
-// }
+    // cleanup
+    free_argv(argc, argv);
+}
 
-// TEST_CASE_FIXTURE(
-//     test_argument_parser_parse_args, "argument_parser should properly handle valid compound flags"
-// ) {
-//     // add arguments
-//     sut.add_optional_argument("first-arg", "f");
-//     sut.add_optional_argument("second-arg", "s");
-//     sut.add_optional_argument("third-arg", "t");
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args, "argument_parser should properly handle valid compound flags"
+) {
+    // add arguments
+    sut.add_optional_argument("first-arg", "f");
+    sut.add_optional_argument("second-arg", "s");
+    sut.add_optional_argument("third-arg", "t");
 
-//     std::size_t first_arg_count, second_arg_count, third_arg_count;
-//     std::string compound_flag;
+    std::size_t first_arg_count, second_arg_count, third_arg_count;
+    std::string compound_flag;
 
-//     // prepare argc & argv
-//     SUBCASE("one usage of each argument") {
-//         compound_flag = "-fst";
-//         first_arg_count = second_arg_count = third_arg_count = 1ull;
-//     }
-//     SUBCASE("complex usage") {
-//         compound_flag = "-ffstfst";
-//         first_arg_count = 3ull;
-//         second_arg_count = third_arg_count = 2ull;
-//     }
+    // prepare argc & argv
+    SUBCASE("one usage of each argument") {
+        compound_flag = "-fst";
+        first_arg_count = second_arg_count = third_arg_count = 1ull;
+    }
+    SUBCASE("complex usage") {
+        compound_flag = "-ffstfst";
+        first_arg_count = 3ull;
+        second_arg_count = third_arg_count = 2ull;
+    }
 
-//     CAPTURE(first_arg_count);
-//     CAPTURE(second_arg_count);
-//     CAPTURE(third_arg_count);
-//     CAPTURE(compound_flag);
+    CAPTURE(first_arg_count);
+    CAPTURE(second_arg_count);
+    CAPTURE(third_arg_count);
+    CAPTURE(compound_flag);
 
-//     std::vector<std::string> argv_vec{"program", compound_flag};
+    std::vector<std::string> argv_vec{"program", compound_flag};
 
-//     const int argc = static_cast<int>(argv_vec.size());
-//     auto argv = to_char_2d_array(argv_vec);
+    const int argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
 
-//     // parse args
-//     sut.parse_args(argc, argv);
+    // parse args
+    sut.parse_args(argc, argv);
 
-//     // validate argument usage counts
-//     CHECK_EQ(sut.count("first-arg"), first_arg_count);
-//     CHECK_EQ(sut.count("second-arg"), second_arg_count);
-//     CHECK_EQ(sut.count("third-arg"), third_arg_count);
+    // validate argument usage counts
+    CHECK_EQ(sut.count("first-arg"), first_arg_count);
+    CHECK_EQ(sut.count("second-arg"), second_arg_count);
+    CHECK_EQ(sut.count("third-arg"), third_arg_count);
 
-//     // cleanup
-//     free_argv(argc, argv);
-// }
+    // cleanup
+    free_argv(argc, argv);
+}

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -39,50 +39,50 @@ struct test_argument_parser_parse_args : public argument_parser_test_fixture {
 
 // _tokenize
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "_tokenize should return an empty vector for no command-line arguments"
-) {
-    const auto argc = get_argc(no_args, no_args);
-    auto argv = init_argv(no_args, no_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "_tokenize should return an empty vector for no command-line arguments"
+// ) {
+//     const auto argc = get_argc(no_args, no_args);
+//     auto argv = init_argv(no_args, no_args);
 
-    const auto args = tokenize(argc, argv);
+//     const auto args = tokenize(argc, argv);
 
-    CHECK(args.empty());
+//     CHECK(args.empty());
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args, "_tokenize should return a vector of correct arguments"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args, "_tokenize should return a vector of correct arguments"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    const auto arg_tokens = tokenize(argc, argv);
+//     const auto arg_tokens = tokenize(argc, argv);
 
-    REQUIRE_EQ(arg_tokens.size(), get_args_length(n_positional_args, n_optional_args));
+//     REQUIRE_EQ(arg_tokens.size(), get_args_length(n_positional_args, n_optional_args));
 
-    for (std::size_t i = 0; i < n_positional_args; ++i) {
-        REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_value);
-        CHECK_EQ(arg_tokens.at(i).value, init_arg_value(i));
-    }
+//     for (std::size_t i = 0; i < n_positional_args; ++i) {
+//         REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_value);
+//         CHECK_EQ(arg_tokens.at(i).value, init_arg_value(i));
+//     }
 
-    std::size_t opt_arg_idx = n_positional_args;
-    for (std::size_t i = n_positional_args; i < arg_tokens.size(); i += 2ull) {
-        REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag_primary);
-        CHECK(init_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
+//     std::size_t opt_arg_idx = n_positional_args;
+//     for (std::size_t i = n_positional_args; i < arg_tokens.size(); i += 2ull) {
+//         REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag_primary);
+//         CHECK(init_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
 
-        REQUIRE_EQ(arg_tokens.at(i + 1ull).type, argument_token::t_value);
-        CHECK_EQ(arg_tokens.at(i + 1ull).value, init_arg_value(opt_arg_idx));
+//         REQUIRE_EQ(arg_tokens.at(i + 1ull).type, argument_token::t_value);
+//         CHECK_EQ(arg_tokens.at(i + 1ull).value, init_arg_value(opt_arg_idx));
 
-        ++opt_arg_idx;
-    }
+//         ++opt_arg_idx;
+//     }
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
 // _parse_args_impl
 
@@ -103,834 +103,834 @@ TEST_CASE_FIXTURE(
     );
 }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "_parse_args_impl should not throw when the arguments are correct"
-) {
-    add_arguments(n_positional_args, n_optional_args);
-    const auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
-    CHECK_NOTHROW(parse_args_impl(arg_tokens));
-}
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "_parse_args_impl should not throw when the arguments are correct"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
+//     const auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
+//     CHECK_NOTHROW(parse_args_impl(arg_tokens));
+// }
 
 // _get_argument
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "_get_argument should return nullopt if there is no argument with given name present"
-) {
-    add_arguments(n_positional_args, n_optional_args);
-    CHECK_FALSE(get_argument(invalid_arg_name));
-}
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "_get_argument should return nullopt if there is no argument with given name present"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
+//     CHECK_FALSE(get_argument(invalid_arg_name));
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "_get_argument should return valid argument if there is an argument with the given name"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "_get_argument should return valid argument if there is an argument with the given name"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    for (std::size_t i = 0ull; i < n_positional_args; ++i) {
-        const auto arg_name = init_arg_name(i);
-        CHECK(get_argument(arg_name.primary.value()));
-        CHECK(get_argument(arg_name.secondary.value()));
-    }
-}
+//     for (std::size_t i = 0ull; i < n_positional_args; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         CHECK(get_argument(arg_name.primary.value()));
+//         CHECK(get_argument(arg_name.secondary.value()));
+//     }
+// }
 
 // parse_args
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should throw when there is not enough positional values"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should throw when there is not enough positional values"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv_vec = init_argv_vec(n_positional_args, n_optional_args);
+//     auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv_vec = init_argv_vec(n_positional_args, n_optional_args);
 
-    // remove the last positional value
-    --argc;
-    argv_vec.erase(std::next(argv_vec.begin(), static_cast<std::ptrdiff_t>(last_pos_arg_idx)));
+//     // remove the last positional value
+//     --argc;
+//     argv_vec.erase(std::next(argv_vec.begin(), static_cast<std::ptrdiff_t>(last_pos_arg_idx)));
 
-    auto argv = to_char_2d_array(argv_vec);
+//     auto argv = to_char_2d_array(argv_vec);
 
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        parsing_failure::required_argument_not_parsed({init_arg_name(last_pos_arg_idx)}).what(),
-        parsing_failure
-    );
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         parsing_failure::required_argument_not_parsed({init_arg_name(last_pos_arg_idx)}).what(),
+//         parsing_failure
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should throw if a required positional argument is defined after a non-require "
-    "posisitonal argument"
-) {
-    const auto non_required_arg_name = init_arg_name(0ull);
-    sut.add_positional_argument(
-           non_required_arg_name.primary.value(), non_required_arg_name.secondary.value()
-    )
-        .required(false);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should throw if a required positional argument is defined after a non-require "
+//     "posisitonal argument"
+// ) {
+//     const auto non_required_arg_name = init_arg_name(0ull);
+//     sut.add_positional_argument(
+//            non_required_arg_name.primary.value(), non_required_arg_name.secondary.value()
+//     )
+//         .required(false);
 
-    const auto required_arg_name = init_arg_name(1ull);
-    sut.add_positional_argument(
-        required_arg_name.primary.value(), required_arg_name.secondary.value()
-    );
+//     const auto required_arg_name = init_arg_name(1ull);
+//     sut.add_positional_argument(
+//         required_arg_name.primary.value(), required_arg_name.secondary.value()
+//     );
 
-    const auto argc = get_argc(no_args, no_args);
-    auto argv = init_argv(no_args, no_args);
+//     const auto argc = get_argc(no_args, no_args);
+//     auto argv = init_argv(no_args, no_args);
 
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        invalid_configuration::positional::required_after_non_required(
-            required_arg_name, non_required_arg_name
-        )
-            .what(),
-        invalid_configuration
-    );
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         invalid_configuration::positional::required_after_non_required(
+//             required_arg_name, non_required_arg_name
+//         )
+//             .what(),
+//         invalid_configuration
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should throw when there is no value specified for a required optional argument"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should throw when there is no value specified for a required optional argument"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto required_arg_name = init_arg_name(n_args_total, flag_char);
-    sut.add_optional_argument(
-           required_arg_name.primary.value(), required_arg_name.secondary.value()
-    )
-        .required();
+//     const auto required_arg_name = init_arg_name(n_args_total, flag_char);
+//     sut.add_optional_argument(
+//            required_arg_name.primary.value(), required_arg_name.secondary.value()
+//     )
+//         .required();
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        parsing_failure::required_argument_not_parsed(required_arg_name).what(),
-        parsing_failure
-    );
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         parsing_failure::required_argument_not_parsed(required_arg_name).what(),
+//         parsing_failure
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should throw when an optional argument's nvalues is not in a specified range"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should throw when an optional argument's nvalues is not in a specified range"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    const auto range_arg_name = init_arg_name(n_args_total, flag_char);
-    sut.add_optional_argument(range_arg_name.primary.value(), range_arg_name.secondary.value())
-        .nargs(at_least(1ull));
+//     const auto range_arg_name = init_arg_name(n_args_total, flag_char);
+//     sut.add_optional_argument(range_arg_name.primary.value(), range_arg_name.secondary.value())
+//         .nargs(at_least(1ull));
 
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        parsing_failure::invalid_nvalues(range_arg_name, std::weak_ordering::less).what(),
-        parsing_failure
-    );
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         parsing_failure::invalid_nvalues(range_arg_name, std::weak_ordering::less).what(),
+//         parsing_failure
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args, "parse_args should throw when an unknown argument flag is used"
-) {
-    add_arguments(no_args, no_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args, "parse_args should throw when an unknown argument flag is used"
+// ) {
+//     add_arguments(no_args, no_args);
 
-    constexpr std::size_t n_opt_clargs = 1ull;
-    constexpr std::size_t opt_arg_idx = 0ull;
+//     constexpr std::size_t n_opt_clargs = 1ull;
+//     constexpr std::size_t opt_arg_idx = 0ull;
 
-    auto argc = get_argc(no_args, n_opt_clargs);
-    auto argv = init_argv(no_args, n_opt_clargs);
+//     auto argc = get_argc(no_args, n_opt_clargs);
+//     auto argv = init_argv(no_args, n_opt_clargs);
 
-    const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
+//     const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
 
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        parsing_failure::unknown_argument(unknown_arg_name).what(),
-        parsing_failure
-    );
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         parsing_failure::unknown_argument(unknown_arg_name).what(),
+//         parsing_failure
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should throw when an optional argument's flag uses the correct name but an "
-    "incorrect flag prefix"
-) {
-    constexpr std::size_t n_opt_args = 1ull;
-    constexpr std::size_t opt_arg_idx = 0ull;
-    add_arguments(no_args, n_opt_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should throw when an optional argument's flag uses the correct name but an "
+//     "incorrect flag prefix"
+// ) {
+//     constexpr std::size_t n_opt_args = 1ull;
+//     constexpr std::size_t opt_arg_idx = 0ull;
+//     add_arguments(no_args, n_opt_args);
 
-    auto argc = get_argc(no_args, n_opt_args);
-    auto argv_vec = init_argv_vec(no_args, n_opt_args);
+//     auto argc = get_argc(no_args, n_opt_args);
+//     auto argv_vec = init_argv_vec(no_args, n_opt_args);
 
-    const auto opt_arg_name = init_arg_name(opt_arg_idx);
+//     const auto opt_arg_name = init_arg_name(opt_arg_idx);
 
-    std::string invalid_flag;
+//     std::string invalid_flag;
 
-    SUBCASE("primary name with a secondary flag prefix") {
-        invalid_flag = "-" + opt_arg_name.primary.value();
-    }
-    SUBCASE("secondary name with a primary flag prefix") {
-        invalid_flag = "--" + opt_arg_name.secondary.value();
-    }
+//     SUBCASE("primary name with a secondary flag prefix") {
+//         invalid_flag = "-" + opt_arg_name.primary.value();
+//     }
+//     SUBCASE("secondary name with a primary flag prefix") {
+//         invalid_flag = "--" + opt_arg_name.secondary.value();
+//     }
 
-    CAPTURE(invalid_flag);
+//     CAPTURE(invalid_flag);
 
-    auto arg_flag_it = std::ranges::find(argv_vec, init_arg_flag_primary(opt_arg_idx));
-    if (arg_flag_it == argv_vec.end())
-        FAIL("could not find the optional argument flag");
+//     auto arg_flag_it = std::ranges::find(argv_vec, init_arg_flag_primary(opt_arg_idx));
+//     if (arg_flag_it == argv_vec.end())
+//         FAIL("could not find the optional argument flag");
 
-    *arg_flag_it = invalid_flag;
-    auto argv = to_char_2d_array(argv_vec);
+//     *arg_flag_it = invalid_flag;
+//     auto argv = to_char_2d_array(argv_vec);
 
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        parsing_failure::unknown_argument(invalid_flag).what(),
-        parsing_failure
-    );
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         parsing_failure::unknown_argument(invalid_flag).what(),
+//         parsing_failure
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should not throw if the number of positional values are correct and all required "
-    "optional arguments have values"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should not throw if the number of positional values are correct and all required "
+//     "optional arguments have values"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto required_arg_name = init_arg_name(n_args_total);
-    sut.add_optional_argument(
-           required_arg_name.primary.value(), required_arg_name.secondary.value()
-    )
-        .required();
+//     const auto required_arg_name = init_arg_name(n_args_total);
+//     sut.add_optional_argument(
+//            required_arg_name.primary.value(), required_arg_name.secondary.value()
+//     )
+//         .required();
 
-    int argc;
-    char** argv;
+//     int argc;
+//     char** argv;
 
-    SUBCASE("all arguments have values") {
-        const auto n_optional_args_curr = n_optional_args + 1ull;
-        argc = get_argc(n_positional_args, n_optional_args_curr);
-        argv = init_argv(n_positional_args, n_optional_args_curr);
-    }
-    SUBCASE("only the necessary arguments have values") {
-        const auto n_optional_args_curr = 1ull;
+//     SUBCASE("all arguments have values") {
+//         const auto n_optional_args_curr = n_optional_args + 1ull;
+//         argc = get_argc(n_positional_args, n_optional_args_curr);
+//         argv = init_argv(n_positional_args, n_optional_args_curr);
+//     }
+//     SUBCASE("only the necessary arguments have values") {
+//         const auto n_optional_args_curr = 1ull;
 
-        argc = get_argc(n_positional_args, n_optional_args_curr);
+//         argc = get_argc(n_positional_args, n_optional_args_curr);
 
-        auto argv_vec = init_argv_vec(n_positional_args, n_optional_args_curr);
-        argv_vec[static_cast<std::size_t>(argc - 2)] = init_arg_flag_primary(n_args_total).c_str();
-        argv_vec[static_cast<std::size_t>(argc - 1)] = init_arg_value(n_args_total).c_str();
+//         auto argv_vec = init_argv_vec(n_positional_args, n_optional_args_curr);
+//         argv_vec[static_cast<std::size_t>(argc - 2)] = init_arg_flag_primary(n_args_total).c_str();
+//         argv_vec[static_cast<std::size_t>(argc - 1)] = init_arg_value(n_args_total).c_str();
 
-        argv = to_char_2d_array(argv_vec);
-    }
+//         argv = to_char_2d_array(argv_vec);
+//     }
 
-    CAPTURE(argc);
-    CAPTURE(argv);
+//     CAPTURE(argc);
+//     CAPTURE(argv);
 
-    CHECK_NOTHROW(sut.parse_args(argc, argv));
+//     CHECK_NOTHROW(sut.parse_args(argc, argv));
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should not throw if there is an positional argument which has the bypass_required "
-    "option enabled and is used"
-) {
-    const std::size_t n_positional_args = 1ull;
-    const auto bypass_required_arg_name = init_arg_name(n_positional_args - 1ull).primary.value();
-    sut.add_positional_argument(bypass_required_arg_name).bypass_required();
-    const std::string bypass_required_arg_value = "bypass_required_arg_value";
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should not throw if there is an positional argument which has the bypass_required "
+//     "option enabled and is used"
+// ) {
+//     const std::size_t n_positional_args = 1ull;
+//     const auto bypass_required_arg_name = init_arg_name(n_positional_args - 1ull).primary.value();
+//     sut.add_positional_argument(bypass_required_arg_name).bypass_required();
+//     const std::string bypass_required_arg_value = "bypass_required_arg_value";
 
-    for (std::size_t i = 0ull; i < n_optional_args; ++i)
-        sut.add_optional_argument(init_arg_name(n_positional_args + i).primary.value()).required();
+//     for (std::size_t i = 0ull; i < n_optional_args; ++i)
+//         sut.add_optional_argument(init_arg_name(n_positional_args + i).primary.value()).required();
 
-    std::vector<std::string> argv_vec{"program", bypass_required_arg_value};
-    const int argc = static_cast<int>(argv_vec.size());
-    const auto argv = to_char_2d_array(argv_vec);
+//     std::vector<std::string> argv_vec{"program", bypass_required_arg_value};
+//     const int argc = static_cast<int>(argv_vec.size());
+//     const auto argv = to_char_2d_array(argv_vec);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    CHECK_EQ(sut.value(bypass_required_arg_name), bypass_required_arg_value);
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     CHECK_EQ(sut.value(bypass_required_arg_name), bypass_required_arg_value);
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "parse_args should not throw if there is an optional argument which has the bypass_required "
-    "option enabled and is used"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "parse_args should not throw if there is an optional argument which has the bypass_required "
+//     "option enabled and is used"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto bypass_required_arg_name = init_arg_name(n_args_total);
-    sut.add_optional_argument<bool>(
-           bypass_required_arg_name.primary.value(), bypass_required_arg_name.secondary.value()
-    )
-        .default_value(false)
-        .implicit_value(true)
-        .bypass_required();
+//     const auto bypass_required_arg_name = init_arg_name(n_args_total);
+//     sut.add_optional_argument<bool>(
+//            bypass_required_arg_name.primary.value(), bypass_required_arg_name.secondary.value()
+//     )
+//         .default_value(false)
+//         .implicit_value(true)
+//         .bypass_required();
 
-    std::string arg_flag;
+//     std::string arg_flag;
 
-    SUBCASE("primary flag") {
-        arg_flag = init_arg_flag_primary(n_args_total);
-    }
-    SUBCASE("secondary flag") {
-        arg_flag = init_arg_flag_secondary(n_args_total);
-    }
+//     SUBCASE("primary flag") {
+//         arg_flag = init_arg_flag_primary(n_args_total);
+//     }
+//     SUBCASE("secondary flag") {
+//         arg_flag = init_arg_flag_secondary(n_args_total);
+//     }
 
-    CAPTURE(arg_flag);
+//     CAPTURE(arg_flag);
 
-    std::vector<std::string> argv_vec{"program", arg_flag};
-    const int argc = static_cast<int>(argv_vec.size());
-    const auto argv = to_char_2d_array(argv_vec);
+//     std::vector<std::string> argv_vec{"program", arg_flag};
+//     const int argc = static_cast<int>(argv_vec.size());
+//     const auto argv = to_char_2d_array(argv_vec);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    CHECK(sut.value<bool>(bypass_required_arg_name.primary.value()));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     CHECK(sut.value<bool>(bypass_required_arg_name.primary.value()));
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
 // has_value
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "has_value should return false if there is no argument with given name present"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "has_value should return false if there is no argument with given name present"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
-    CHECK_FALSE(sut.has_value(invalid_arg_name));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     CHECK_FALSE(sut.has_value(invalid_arg_name));
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args, "has_value should return false when an argument has no values"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args, "has_value should return false when an argument has no values"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        CHECK_FALSE(sut.has_value(arg_name.primary.value()));
-        CHECK_FALSE(sut.has_value(arg_name.secondary.value()));
-    }
-}
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         CHECK_FALSE(sut.has_value(arg_name.primary.value()));
+//         CHECK_FALSE(sut.has_value(arg_name.secondary.value()));
+//     }
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "has_value should return true if a value has been parsed for the argument"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "has_value should return true if a value has been parsed for the argument"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const int argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const int argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        CHECK(sut.has_value(arg_name.primary.value()));
-        CHECK(sut.has_value(arg_name.secondary.value()));
-    }
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         CHECK(sut.has_value(arg_name.primary.value()));
+//         CHECK(sut.has_value(arg_name.secondary.value()));
+//     }
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
 // value
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value() should throw if there is no argument with given name present"
-) {
-    add_arguments(n_positional_args, n_optional_args);
-    CHECK_THROWS_AS(discard_result(sut.value(invalid_arg_name)), ap::lookup_failure);
-}
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value() should throw if there is no argument with given name present"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
+//     CHECK_THROWS_AS(discard_result(sut.value(invalid_arg_name)), ap::lookup_failure);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value() should throw if no value has been parsed for an argument"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value() should throw if no value has been parsed for an argument"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        CHECK_THROWS_AS(discard_result(sut.value(arg_name.primary.value())), std::logic_error);
-        CHECK_THROWS_AS(discard_result(sut.value(arg_name.secondary.value())), std::logic_error);
-    }
-}
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         CHECK_THROWS_AS(discard_result(sut.value(arg_name.primary.value())), std::logic_error);
+//         CHECK_THROWS_AS(discard_result(sut.value(arg_name.secondary.value())), std::logic_error);
+//     }
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value() should throw if an argument has a value but the given type is invalid"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value() should throw if an argument has a value but the given type is invalid"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
 
-    using invalid_value_type = int;
+//     using invalid_value_type = int;
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
 
-        REQUIRE(sut.has_value(arg_name.primary.value()));
-        CHECK_THROWS_AS(
-            discard_result(sut.value<invalid_value_type>(arg_name.primary.value())), ap::type_error
-        );
-    }
+//         REQUIRE(sut.has_value(arg_name.primary.value()));
+//         CHECK_THROWS_AS(
+//             discard_result(sut.value<invalid_value_type>(arg_name.primary.value())), ap::type_error
+//         );
+//     }
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value() should return a correct value when the argument name is valid and its value has been "
-    "parsed"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value() should return a correct value when the argument name is valid and its value has been "
+//     "parsed"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        const auto arg_value = init_arg_value(i);
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         const auto arg_value = init_arg_value(i);
 
-        REQUIRE(sut.has_value(arg_name.primary.value()));
-        CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
-        CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
-    }
+//         REQUIRE(sut.has_value(arg_name.primary.value()));
+//         CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
+//         CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
+//     }
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value() should return a correct value for an optional argument when the name is valid and the "
-    "argument has a predefined value"
-) {
-    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-        const auto arg_name = init_arg_name(i);
-        sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
-            .default_value(init_arg_value(i));
-    }
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value() should return a correct value for an optional argument when the name is valid and the "
+//     "argument has a predefined value"
+// ) {
+//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
+//             .default_value(init_arg_value(i));
+//     }
 
-    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-        const auto arg_name = init_arg_name(i);
-        const auto arg_value = init_arg_value(i);
+//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         const auto arg_value = init_arg_value(i);
 
-        REQUIRE(sut.has_value(arg_name.primary.value()));
-        CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
-        CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
-    }
-}
+//         REQUIRE(sut.has_value(arg_name.primary.value()));
+//         CHECK_EQ(sut.value(arg_name.primary.value()), arg_value);
+//         CHECK_EQ(sut.value(arg_name.secondary.value()), arg_value);
+//     }
+// }
 
 // value_or
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value_or() should throw if there is no argument with given name present"
-) {
-    add_arguments(n_positional_args, n_optional_args);
-    CHECK_THROWS_AS(discard_result(sut.value_or(invalid_arg_name, empty_str)), ap::lookup_failure);
-}
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value_or() should throw if there is no argument with given name present"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
+//     CHECK_THROWS_AS(discard_result(sut.value_or(invalid_arg_name, empty_str)), ap::lookup_failure);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value_or() should throw if an argument has a value but the given type is invalid"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value_or() should throw if an argument has a value but the given type is invalid"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
 
-    using invalid_value_type = int;
+//     using invalid_value_type = int;
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
 
-        REQUIRE(sut.has_value(arg_name.primary.value()));
-        CHECK_THROWS_AS(
-            discard_result(
-                sut.value_or<invalid_value_type>(arg_name.primary.value(), invalid_value_type{})
-            ),
-            ap::type_error
-        );
-    }
+//         REQUIRE(sut.has_value(arg_name.primary.value()));
+//         CHECK_THROWS_AS(
+//             discard_result(
+//                 sut.value_or<invalid_value_type>(arg_name.primary.value(), invalid_value_type{})
+//             ),
+//             ap::type_error
+//         );
+//     }
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value_or() should return a correct value when the argument name is valid and its value has "
-    "been parsed"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value_or() should return a correct value when the argument name is valid and its value has "
+//     "been parsed"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    const auto argc = get_argc(n_positional_args, n_optional_args);
-    auto argv = init_argv(n_positional_args, n_optional_args);
+//     const auto argc = get_argc(n_positional_args, n_optional_args);
+//     auto argv = init_argv(n_positional_args, n_optional_args);
 
-    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+//     REQUIRE_NOTHROW(sut.parse_args(argc, argv));
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        const auto arg_value = init_arg_value(i);
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         const auto arg_value = init_arg_value(i);
 
-        REQUIRE(sut.has_value(arg_name.primary.value()));
-        CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
-        CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
-    }
+//         REQUIRE(sut.has_value(arg_name.primary.value()));
+//         CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
+//         CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
+//     }
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value_or() should return a correct value for an optional argument when the name is valid and "
-    "the argument has a predefined value"
-) {
-    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-        const auto arg_name = init_arg_name(i);
-        sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
-            .default_value(init_arg_value(i));
-    }
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value_or() should return a correct value for an optional argument when the name is valid and "
+//     "the argument has a predefined value"
+// ) {
+//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         sut.add_optional_argument(arg_name.primary.value(), arg_name.secondary.value())
+//             .default_value(init_arg_value(i));
+//     }
 
-    for (std::size_t i = 0ull; i < n_optional_args; ++i) {
-        const auto arg_name = init_arg_name(i);
-        const auto arg_value = init_arg_value(i);
+//     for (std::size_t i = 0ull; i < n_optional_args; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         const auto arg_value = init_arg_value(i);
 
-        REQUIRE(sut.has_value(arg_name.primary.value()));
-        CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
-        CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
-    }
-}
+//         REQUIRE(sut.has_value(arg_name.primary.value()));
+//         CHECK_EQ(sut.value_or(arg_name.primary.value(), empty_str), arg_value);
+//         CHECK_EQ(sut.value_or(arg_name.secondary.value(), empty_str), arg_value);
+//     }
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value_or() should return an instance of the specified type initialized from the given default "
-    "value if no value has been parsed for an argument and it doesn't have a predefined value "
-    "(optional)"
-) {
-    using value_type = int;
-    using default_value_type = short;
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value_or() should return an instance of the specified type initialized from the given default "
+//     "value if no value has been parsed for an argument and it doesn't have a predefined value "
+//     "(optional)"
+// ) {
+//     using value_type = int;
+//     using default_value_type = short;
 
-    add_arguments<value_type>(n_positional_args, n_optional_args);
+//     add_arguments<value_type>(n_positional_args, n_optional_args);
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        const default_value_type default_value = 2 * static_cast<default_value_type>(i);
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         const default_value_type default_value = 2 * static_cast<default_value_type>(i);
 
-        CHECK_EQ(sut.value_or<value_type>(arg_name.primary.value(), default_value), default_value);
-        CHECK_EQ(
-            sut.value_or<value_type>(arg_name.secondary.value(), default_value), default_value
-        );
-    }
-}
+//         CHECK_EQ(sut.value_or<value_type>(arg_name.primary.value(), default_value), default_value);
+//         CHECK_EQ(
+//             sut.value_or<value_type>(arg_name.secondary.value(), default_value), default_value
+//         );
+//     }
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "value_or() should return the given default value if no value has been parsed for an argument "
-    "and it doesn't have a predefined value (optional)"
-) {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "value_or() should return the given default value if no value has been parsed for an argument "
+//     "and it doesn't have a predefined value (optional)"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        const auto default_value = init_arg_value(i);
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         const auto default_value = init_arg_value(i);
 
-        CHECK_EQ(sut.value_or(arg_name.primary.value(), default_value), default_value);
-        CHECK_EQ(sut.value_or(arg_name.secondary.value(), default_value), default_value);
-    }
-}
+//         CHECK_EQ(sut.value_or(arg_name.primary.value(), default_value), default_value);
+//         CHECK_EQ(sut.value_or(arg_name.secondary.value(), default_value), default_value);
+//     }
+// }
 
 // count
 
-TEST_CASE_FIXTURE(test_argument_parser_parse_args, "count should return 0 by default") {
-    add_arguments(n_positional_args, n_optional_args);
+// TEST_CASE_FIXTURE(test_argument_parser_parse_args, "count should return 0 by default") {
+//     add_arguments(n_positional_args, n_optional_args);
 
-    for (std::size_t i = 0ull; i < n_args_total; ++i) {
-        const auto arg_name = init_arg_name(i);
-        CHECK_EQ(sut.count(arg_name.primary.value()), 0ull);
-        CHECK_EQ(sut.count(arg_name.secondary.value()), 0ull);
-    }
-}
+//     for (std::size_t i = 0ull; i < n_args_total; ++i) {
+//         const auto arg_name = init_arg_name(i);
+//         CHECK_EQ(sut.count(arg_name.primary.value()), 0ull);
+//         CHECK_EQ(sut.count(arg_name.secondary.value()), 0ull);
+//     }
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "count should return 0 if there is no argument with given name present"
-) {
-    add_arguments(n_positional_args, n_optional_args);
-    CHECK_EQ(sut.count(invalid_arg_name), 0ull);
-}
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "count should return 0 if there is no argument with given name present"
+// ) {
+//     add_arguments(n_positional_args, n_optional_args);
+//     CHECK_EQ(sut.count(invalid_arg_name), 0ull);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args, "count should return the number of argument's flag usage"
-) {
-    // prepare sut
-    sut.add_positional_argument(positional_primary_name, positional_secondary_name);
-    sut.add_optional_argument(optional_primary_name, optional_secondary_name)
-        .nargs(ap::nargs::any());
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args, "count should return the number of argument's flag usage"
+// ) {
+//     // prepare sut
+//     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
+//     sut.add_optional_argument(optional_primary_name, optional_secondary_name)
+//         .nargs(ap::nargs::any());
 
-    // expected values
-    const std::size_t positional_count = 1ull;
-    const std::size_t optional_count = 4ull;
+//     // expected values
+//     const std::size_t positional_count = 1ull;
+//     const std::size_t optional_count = 4ull;
 
-    // prepare argc and argv
-    std::vector<std::string> argv_vec{"program", "positional_arg_value"};
+//     // prepare argc and argv
+//     std::vector<std::string> argv_vec{"program", "positional_arg_value"};
 
-    const std::string optional_arg_flag = "--" + optional_primary_name;
-    const std::string optional_arg_value = optional_primary_name + "_value";
-    for (std::size_t i = 0ull; i < optional_count; ++i) {
-        argv_vec.push_back(optional_arg_flag);
-        if (i % 2ull == 0)
-            argv_vec.push_back(optional_arg_value);
-    }
+//     const std::string optional_arg_flag = "--" + optional_primary_name;
+//     const std::string optional_arg_value = optional_primary_name + "_value";
+//     for (std::size_t i = 0ull; i < optional_count; ++i) {
+//         argv_vec.push_back(optional_arg_flag);
+//         if (i % 2ull == 0)
+//             argv_vec.push_back(optional_arg_value);
+//     }
 
-    const int argc = static_cast<int>(argv_vec.size());
-    auto argv = to_char_2d_array(argv_vec);
+//     const int argc = static_cast<int>(argv_vec.size());
+//     auto argv = to_char_2d_array(argv_vec);
 
-    // parse args
-    sut.parse_args(argc, argv);
+//     // parse args
+//     sut.parse_args(argc, argv);
 
-    // test count
-    CHECK_EQ(sut.count(positional_primary_name), positional_count);
-    CHECK_EQ(sut.count(optional_primary_name), optional_count);
+//     // test count
+//     CHECK_EQ(sut.count(positional_primary_name), positional_count);
+//     CHECK_EQ(sut.count(optional_primary_name), optional_count);
 
-    // free argv
-    free_argv(argc, argv);
-}
+//     // free argv
+//     free_argv(argc, argv);
+// }
 
 // values
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "values() should throw when calling with a positional argument's name"
-) {
-    sut.add_positional_argument(positional_primary_name, positional_secondary_name);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "values() should throw when calling with a positional argument's name"
+// ) {
+//     sut.add_positional_argument(positional_primary_name, positional_secondary_name);
 
-    CHECK_THROWS_AS(discard_result(sut.values(positional_primary_name)), std::logic_error);
-    CHECK_THROWS_AS(discard_result(sut.values(positional_secondary_name)), std::logic_error);
-}
+//     CHECK_THROWS_AS(discard_result(sut.values(positional_primary_name)), std::logic_error);
+//     CHECK_THROWS_AS(discard_result(sut.values(positional_secondary_name)), std::logic_error);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "values() should return an empty vector if an argument has no values"
-) {
-    sut.add_optional_argument(optional_primary_name, optional_secondary_name);
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "values() should return an empty vector if an argument has no values"
+// ) {
+//     sut.add_optional_argument(optional_primary_name, optional_secondary_name);
 
-    SUBCASE("calling with argument's primary name") {
-        const auto& values = sut.values(optional_primary_name);
-        CHECK(values.empty());
-    }
+//     SUBCASE("calling with argument's primary name") {
+//         const auto& values = sut.values(optional_primary_name);
+//         CHECK(values.empty());
+//     }
 
-    SUBCASE("calling with argument's secondary name") {
-        const auto& values = sut.values(optional_secondary_name);
-        CHECK(values.empty());
-    }
-}
+//     SUBCASE("calling with argument's secondary name") {
+//         const auto& values = sut.values(optional_secondary_name);
+//         CHECK(values.empty());
+//     }
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "values() should throw when an argument has values but the given type is invalid"
-) {
-    sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "values() should throw when an argument has values but the given type is invalid"
+// ) {
+//     sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
 
-    // prepare argc & argv
-    const std::string optional_arg_flag = "--" + optional_primary_name;
-    const std::string optional_arg_value = optional_primary_name + "_value";
-    std::vector<std::string> argv_vec{
-        "program", optional_arg_flag, optional_arg_value, optional_arg_value
-    };
+//     // prepare argc & argv
+//     const std::string optional_arg_flag = "--" + optional_primary_name;
+//     const std::string optional_arg_value = optional_primary_name + "_value";
+//     std::vector<std::string> argv_vec{
+//         "program", optional_arg_flag, optional_arg_value, optional_arg_value
+//     };
 
-    const int argc = static_cast<int>(argv_vec.size());
-    auto argv = to_char_2d_array(argv_vec);
+//     const int argc = static_cast<int>(argv_vec.size());
+//     auto argv = to_char_2d_array(argv_vec);
 
-    // parse args
-    sut.parse_args(argc, argv);
+//     // parse args
+//     sut.parse_args(argc, argv);
 
-    CHECK_THROWS_AS(
-        discard_result(sut.values<invalid_argument_value_type>(optional_primary_name)),
-        ap::type_error
-    );
-    CHECK_THROWS_AS(
-        discard_result(sut.values<invalid_argument_value_type>(optional_secondary_name)),
-        ap::type_error
-    );
+//     CHECK_THROWS_AS(
+//         discard_result(sut.values<invalid_argument_value_type>(optional_primary_name)),
+//         ap::type_error
+//     );
+//     CHECK_THROWS_AS(
+//         discard_result(sut.values<invalid_argument_value_type>(optional_secondary_name)),
+//         ap::type_error
+//     );
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "values() should return a vector containing a predefined value if an optional argument if no "
-    "values for an argument have been parsed"
-) {
-    const std::string default_value = "default_value";
-    const std::string implicit_value = "implicit_value";
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "values() should return a vector containing a predefined value if an optional argument if no "
+//     "values for an argument have been parsed"
+// ) {
+//     const std::string default_value = "default_value";
+//     const std::string implicit_value = "implicit_value";
 
-    sut.add_optional_argument(optional_primary_name, optional_secondary_name)
-        .default_value(default_value)
-        .implicit_value(implicit_value);
+//     sut.add_optional_argument(optional_primary_name, optional_secondary_name)
+//         .default_value(default_value)
+//         .implicit_value(implicit_value);
 
-    // prepare argc & argv
-    std::vector<std::string> argv_vec{"program"};
-    std::string expected_value;
+//     // prepare argc & argv
+//     std::vector<std::string> argv_vec{"program"};
+//     std::string expected_value;
 
-    SUBCASE("default_value") {
-        expected_value = default_value;
-    }
+//     SUBCASE("default_value") {
+//         expected_value = default_value;
+//     }
 
-    SUBCASE("implicit_value") {
-        expected_value = implicit_value;
+//     SUBCASE("implicit_value") {
+//         expected_value = implicit_value;
 
-        const auto optional_arg_flag = "--" + optional_primary_name;
-        argv_vec.push_back(optional_arg_flag);
-    }
+//         const auto optional_arg_flag = "--" + optional_primary_name;
+//         argv_vec.push_back(optional_arg_flag);
+//     }
 
-    CAPTURE(expected_value);
+//     CAPTURE(expected_value);
 
-    const int argc = static_cast<int>(argv_vec.size());
-    auto argv = to_char_2d_array(argv_vec);
+//     const int argc = static_cast<int>(argv_vec.size());
+//     auto argv = to_char_2d_array(argv_vec);
 
-    // parse args
-    sut.parse_args(argc, argv);
+//     // parse args
+//     sut.parse_args(argc, argv);
 
-    const auto& stored_values = sut.values(optional_primary_name);
+//     const auto& stored_values = sut.values(optional_primary_name);
 
-    REQUIRE_EQ(stored_values.size(), 1);
-    CHECK_EQ(stored_values.front(), expected_value);
+//     REQUIRE_EQ(stored_values.size(), 1);
+//     CHECK_EQ(stored_values.front(), expected_value);
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "values() should return a correct vector of values when there is an argument with "
-    "a given name and has parsed values"
-) {
-    sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "values() should return a correct vector of values when there is an argument with "
+//     "a given name and has parsed values"
+// ) {
+//     sut.add_optional_argument(optional_primary_name, optional_secondary_name).nargs(at_least(1));
 
-    // prepare argc & argv
-    const std::string optional_arg_flag = "--" + optional_primary_name;
-    const std::string optional_arg_value = optional_primary_name + "_value";
+//     // prepare argc & argv
+//     const std::string optional_arg_flag = "--" + optional_primary_name;
+//     const std::string optional_arg_value = optional_primary_name + "_value";
 
-    std::vector<std::string> optional_arg_values{
-        optional_arg_value + "_1", optional_arg_value + "_2", optional_arg_value + "_3"
-    };
+//     std::vector<std::string> optional_arg_values{
+//         optional_arg_value + "_1", optional_arg_value + "_2", optional_arg_value + "_3"
+//     };
 
-    std::vector<std::string> argv_vec{"program", optional_arg_flag};
-    for (const auto& value : optional_arg_values)
-        argv_vec.push_back(value);
+//     std::vector<std::string> argv_vec{"program", optional_arg_flag};
+//     for (const auto& value : optional_arg_values)
+//         argv_vec.push_back(value);
 
-    const int argc = static_cast<int>(argv_vec.size());
-    auto argv = to_char_2d_array(argv_vec);
+//     const int argc = static_cast<int>(argv_vec.size());
+//     auto argv = to_char_2d_array(argv_vec);
 
-    // parse args
-    sut.parse_args(argc, argv);
+//     // parse args
+//     sut.parse_args(argc, argv);
 
-    const auto& stored_values = sut.values(optional_primary_name);
+//     const auto& stored_values = sut.values(optional_primary_name);
 
-    REQUIRE_EQ(stored_values.size(), optional_arg_values.size());
-    for (std::size_t i = 0ull; i < stored_values.size(); ++i)
-        CHECK_EQ(stored_values[i], optional_arg_values[i]);
+//     REQUIRE_EQ(stored_values.size(), optional_arg_values.size());
+//     for (std::size_t i = 0ull; i < stored_values.size(); ++i)
+//         CHECK_EQ(stored_values[i], optional_arg_values[i]);
 
-    free_argv(argc, argv);
-}
+//     free_argv(argc, argv);
+// }
 
 // compound flags
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args,
-    "argument_parser should throw if an invalid compound flag is used"
-) {
-    // add arguments
-    sut.add_optional_argument("first-arg", "f");
-    sut.add_optional_argument("second-arg", "s");
-    sut.add_optional_argument("third-arg", "t");
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args,
+//     "argument_parser should throw if an invalid compound flag is used"
+// ) {
+//     // add arguments
+//     sut.add_optional_argument("first-arg", "f");
+//     sut.add_optional_argument("second-arg", "s");
+//     sut.add_optional_argument("third-arg", "t");
 
-    const std::string invalid_flag = "-abc";
-    std::vector<std::string> argv_vec{"program", invalid_flag};
+//     const std::string invalid_flag = "-abc";
+//     std::vector<std::string> argv_vec{"program", invalid_flag};
 
-    const int argc = static_cast<int>(argv_vec.size());
-    auto argv = to_char_2d_array(argv_vec);
+//     const int argc = static_cast<int>(argv_vec.size());
+//     auto argv = to_char_2d_array(argv_vec);
 
-    // parse args
-    CHECK_THROWS_WITH_AS(
-        sut.parse_args(argc, argv),
-        parsing_failure::unknown_argument(invalid_flag).what(),
-        parsing_failure
-    );
+//     // parse args
+//     CHECK_THROWS_WITH_AS(
+//         sut.parse_args(argc, argv),
+//         parsing_failure::unknown_argument(invalid_flag).what(),
+//         parsing_failure
+//     );
 
-    // validate argument usage counts
-    CHECK_EQ(sut.count("first-arg"), 0ull);
-    CHECK_EQ(sut.count("second-arg"), 0ull);
-    CHECK_EQ(sut.count("third-arg"), 0ull);
+//     // validate argument usage counts
+//     CHECK_EQ(sut.count("first-arg"), 0ull);
+//     CHECK_EQ(sut.count("second-arg"), 0ull);
+//     CHECK_EQ(sut.count("third-arg"), 0ull);
 
-    // cleanup
-    free_argv(argc, argv);
-}
+//     // cleanup
+//     free_argv(argc, argv);
+// }
 
-TEST_CASE_FIXTURE(
-    test_argument_parser_parse_args, "argument_parser should properly handle valid compound flags"
-) {
-    // add arguments
-    sut.add_optional_argument("first-arg", "f");
-    sut.add_optional_argument("second-arg", "s");
-    sut.add_optional_argument("third-arg", "t");
+// TEST_CASE_FIXTURE(
+//     test_argument_parser_parse_args, "argument_parser should properly handle valid compound flags"
+// ) {
+//     // add arguments
+//     sut.add_optional_argument("first-arg", "f");
+//     sut.add_optional_argument("second-arg", "s");
+//     sut.add_optional_argument("third-arg", "t");
 
-    std::size_t first_arg_count, second_arg_count, third_arg_count;
-    std::string compound_flag;
+//     std::size_t first_arg_count, second_arg_count, third_arg_count;
+//     std::string compound_flag;
 
-    // prepare argc & argv
-    SUBCASE("one usage of each argument") {
-        compound_flag = "-fst";
-        first_arg_count = second_arg_count = third_arg_count = 1ull;
-    }
-    SUBCASE("complex usage") {
-        compound_flag = "-ffstfst";
-        first_arg_count = 3ull;
-        second_arg_count = third_arg_count = 2ull;
-    }
+//     // prepare argc & argv
+//     SUBCASE("one usage of each argument") {
+//         compound_flag = "-fst";
+//         first_arg_count = second_arg_count = third_arg_count = 1ull;
+//     }
+//     SUBCASE("complex usage") {
+//         compound_flag = "-ffstfst";
+//         first_arg_count = 3ull;
+//         second_arg_count = third_arg_count = 2ull;
+//     }
 
-    CAPTURE(first_arg_count);
-    CAPTURE(second_arg_count);
-    CAPTURE(third_arg_count);
-    CAPTURE(compound_flag);
+//     CAPTURE(first_arg_count);
+//     CAPTURE(second_arg_count);
+//     CAPTURE(third_arg_count);
+//     CAPTURE(compound_flag);
 
-    std::vector<std::string> argv_vec{"program", compound_flag};
+//     std::vector<std::string> argv_vec{"program", compound_flag};
 
-    const int argc = static_cast<int>(argv_vec.size());
-    auto argv = to_char_2d_array(argv_vec);
+//     const int argc = static_cast<int>(argv_vec.size());
+//     auto argv = to_char_2d_array(argv_vec);
 
-    // parse args
-    sut.parse_args(argc, argv);
+//     // parse args
+//     sut.parse_args(argc, argv);
 
-    // validate argument usage counts
-    CHECK_EQ(sut.count("first-arg"), first_arg_count);
-    CHECK_EQ(sut.count("second-arg"), second_arg_count);
-    CHECK_EQ(sut.count("third-arg"), third_arg_count);
+//     // validate argument usage counts
+//     CHECK_EQ(sut.count("first-arg"), first_arg_count);
+//     CHECK_EQ(sut.count("second-arg"), second_arg_count);
+//     CHECK_EQ(sut.count("third-arg"), third_arg_count);
 
-    // cleanup
-    free_argv(argc, argv);
-}
+//     // cleanup
+//     free_argv(argc, argv);
+// }


### PR DESCRIPTION
Modified the command-line tokenization logic to try to split unknown secondary flag arguments into multiple secondary argument flag tokens (one for each character of the unknown flag).

Example: If the program defines an argument with a secondary name `v`, then `-vvv` would be equivalent to `-v -v -v`, unless the program also defines a `-vvv` argument.

Additional:
- Added support for declaring the program version
- Optimized argument lookup during argument tokenization and parsing stages