### PR TITLE
YT-CPPAP-62: Argument parsing improvement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 3.0.0.2
+    VERSION 3.0.0.3
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0.2
+PROJECT_NUMBER         = 3.0.0.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp-ap",
-    version = "3.0.0.2",
+    version = "3.0.0.3",
 )

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -889,11 +889,6 @@ private:
         std::vector<std::string>& unknown_args,
         const bool handle_unknown = true
     ) {
-        std::cout << "Arg tokens:\n";
-        for (const auto& t : arg_tokens)
-            std::cout << " - " << t.value << '\n';
-        std::cout << std::endl;
-
         // set the current argument indicators
         arg_ptr_t curr_arg_opt = nullptr;
         arg_ptr_list_iter_t curr_positional_arg_it = this->_positional_args.begin();
@@ -931,76 +926,48 @@ private:
         const bool handle_unknown,
         const detail::argument_token& tok
     ) {
-        std::cout << "Processing token: " << tok.value << '\n';
-
         switch (tok.type) {
         case detail::argument_token::t_flag_primary:
             [[fallthrough]];
         case detail::argument_token::t_flag_secondary: {
             if (not tok.is_valid_flag_token()) {
-                std::cout << " - invalid flag token\n";
                 if (handle_unknown) {
                     throw parsing_failure::unrecognized_argument(this->_unstripped_token_value(tok)
                     );
                 }
                 else {
-                    std::cout << " - unknown argument\n";
                     curr_arg_opt.reset();
                     unknown_args.emplace_back(this->_unstripped_token_value(tok));
-                    std::cout << " - added to unknown args:";
-                    for (const auto& ua : unknown_args)
-                        std::cout << ' ' << ua;
-                    std::cout << std::endl;
                     break;
                 }
             }
 
-            std::cout << " - valid flag token\n";
-            if (tok.arg->mark_used()) {
-                std::cout << " - argument accepts further values\n";
+            if (tok.arg->mark_used())
                 curr_arg_opt = tok.arg;
-            }
-            else {
-                std::cout << " - argument does not accept further values\n";
+            else
                 curr_arg_opt.reset();
-            }
 
             break;
         }
         case detail::argument_token::t_value: {
-            std::cout << " - value token\n";
-
             if (not curr_arg_opt) {
-                std::cout << " - no current argument\n";
                 if (curr_positional_arg_it == this->_positional_args.end()) {
-                    std::cout << " - no positional arguments left\n";
                     unknown_args.emplace_back(tok.value);
-                    std::cout << " - added to unknown args:";
-                    for (const auto& ua : unknown_args)
-                        std::cout << ' ' << ua;
-                    std::cout << std::endl;
                     break;
                 }
 
-                std::cout << " - switching to the next positional argument" << std::endl;
                 curr_arg_opt = *curr_positional_arg_it;
             }
 
-            std::cout
-                << " - setting value for argument: " << curr_arg_opt->name().str() << std::endl;
             if (auto& curr_arg = *curr_arg_opt; not curr_arg.set_value(std::string(tok.value))) {
                 // advance to the next positional argument if possible
-                std::cout << " - argument cannot accept further values" << std::endl;
                 if (curr_arg.is_positional()
                     and curr_positional_arg_it != this->_positional_args.end()
                     and ++curr_positional_arg_it != this->_positional_args.end()) {
-                    std::cout << " - switching to the next positional argument" << std::endl;
                     curr_arg_opt = *curr_positional_arg_it;
                     break;
                 }
 
-                std::cout << " - no positional arguments left or the current argument is optional"
-                          << std::endl;
                 curr_arg_opt.reset();
             }
 

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -7,11 +7,8 @@
 #pragma once
 
 #include "argument_base.hpp"
-#include "typing_utility.hpp"
 
 #include <cstdint>
-#include <functional>
-#include <optional>
 #include <string>
 
 namespace ap::detail {

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -22,9 +22,9 @@ struct argument_token {
 
     /// @brief The token type discriminator.
     enum class token_type : std::uint8_t {
+        t_value, ///< Represents a value argument.
         t_flag_primary, ///< Represents the primary (--) flag argument.
-        t_flag_secondary, ///< Represents the secondary (-) flag argument.
-        t_value ///< Represents a value argument.
+        t_flag_secondary ///< Represents the secondary (-) flag argument.
     };
     using enum token_type;
 

--- a/include/ap/detail/argument_token.hpp
+++ b/include/ap/detail/argument_token.hpp
@@ -18,7 +18,7 @@ namespace ap::detail {
 
 /// @brief Structure representing a single command-line argument token.
 struct argument_token {
-    using arg_ptr_opt_t = uptr_opt_t<detail::argument_base>;
+    using arg_ptr_t = std::shared_ptr<detail::argument_base>; ///< Argument pointer type alias.
 
     /// @brief The token type discriminator.
     enum class token_type : std::uint8_t {
@@ -55,12 +55,12 @@ struct argument_token {
      * @return true if `type` is either `t_flag_primary` or `t_flag_secondary`, false otherwise.
      */
     [[nodiscard]] bool is_valid_flag_token() const noexcept {
-        return this->is_flag_token() and this->arg.has_value();
+        return this->is_flag_token() and this->arg != nullptr;
     }
 
     token_type type; ///< The token's type discrimiator value.
     std::string value; ///< The actual token's value.
-    arg_ptr_opt_t arg = std::nullopt; ///< The corresponding argument.
+    arg_ptr_t arg = nullptr; ///< The corresponding argument
 };
 
 } // namespace ap::detail

--- a/include/ap/detail/concepts.hpp
+++ b/include/ap/detail/concepts.hpp
@@ -116,7 +116,7 @@ template <typename T, typename U, type_validator TV = type_validator::same>
 concept c_valid_type = is_valid_type_v<T, U, TV>;
 
 /**
- * @brief Validates that R is a range of type T (ignoring the cvref attributes).
+ * @brief Validates that R is a range of type T (ignoring the cvref qualifiers).
  * @tparam R The range type to check.
  * @tparam V The expected range value type.
  * @tparam TV The validation rule (`same` or `convertible`).
@@ -125,20 +125,5 @@ template <typename R, typename V, type_validator TV = type_validator::same>
 concept c_range_of =
     std::ranges::range<R>
     and c_valid_type<std::remove_cvref_t<std::ranges::range_value_t<R>>, V, TV>;
-
-/**
- * @brief Validates that R is a sized range of type T (ignoring the cvref attributes).
- * @tparam R The range type to check.
- * @tparam V The expected range value type.
- * @tparam TV The validation rule (`same` or `convertible`).
- */
-template <typename R, typename V, type_validator TV = type_validator::same>
-concept c_sized_range_of =
-    std::ranges::sized_range<R>
-    and c_valid_type<std::remove_cvref_t<std::ranges::range_value_t<R>>, V, TV>;
-
-template <typename I, typename V, type_validator TV = type_validator::same>
-concept c_forward_iterator_of =
-    std::forward_iterator<I> and c_valid_type<std::remove_cvref_t<std::iter_value_t<I>>, V, TV>;
 
 } // namespace ap::detail

--- a/include/ap/detail/concepts.hpp
+++ b/include/ap/detail/concepts.hpp
@@ -137,4 +137,8 @@ concept c_sized_range_of =
     std::ranges::sized_range<R>
     and c_valid_type<std::remove_cvref_t<std::ranges::range_value_t<R>>, V, TV>;
 
+template <typename I, typename V, type_validator TV = type_validator::same>
+concept c_forward_iterator_of =
+    std::forward_iterator<I> and c_valid_type<std::remove_cvref_t<std::iter_value_t<I>>, V, TV>;
+
 } // namespace ap::detail

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -34,6 +34,10 @@ struct argument_parser_test_fixture {
         return std::format("-ta-{}", i);
     }
 
+    [[nodiscard]] std::string strip_flag_prefix(const argument_token& tok) const {
+        return this->sut._strip_flag_prefix(tok);
+    }
+
     [[nodiscard]] argument_value_type init_arg_value(std::size_t i) const {
         return std::format("test-value-{}", i);
     }
@@ -147,9 +151,8 @@ struct argument_parser_test_fixture {
 
         for (std::size_t i = 0ull; i < n_optional_args; ++i) {
             const auto arg_idx = n_positional_args + i;
-            const auto arg_name = init_arg_name_primary(arg_idx);
 
-            argument_token flag_tok{argument_token::t_flag_primary, arg_name};
+            argument_token flag_tok{argument_token::t_flag_primary, init_arg_flag_primary(arg_idx)};
             const auto opt_arg_it = this->sut._find_opt_arg(flag_tok);
             if (opt_arg_it != this->sut._optional_args.end())
                 flag_tok.arg = *opt_arg_it;

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -14,14 +14,16 @@ using ap::detail::c_argument_value_type;
 namespace ap_testing {
 
 struct argument_parser_test_fixture {
-    argument_parser_test_fixture() = default;
-    virtual ~argument_parser_test_fixture() = default;
-
     using arg_ptr_t = ap::argument_parser::arg_ptr_t;
     using arg_token_list_t = ap::argument_parser::arg_token_list_t;
 
+    using parsing_state = ap::argument_parser::parsing_state;
+
     using argument_value_type = std::string;
     using invalid_argument_value_type = int;
+
+    argument_parser_test_fixture() = default;
+    virtual ~argument_parser_test_fixture() = default;
 
     // test utility functions
     [[nodiscard]] std::string init_arg_flag_primary(std::size_t i) const {
@@ -178,7 +180,9 @@ struct argument_parser_test_fixture {
     }
 
     void parse_args_impl(const arg_token_list_t& arg_tokens) {
-        this->sut._parse_args_impl(arg_tokens, this->unknown_args);
+        this->state.curr_arg = nullptr;
+        this->state.curr_pos_arg_it = this->sut._positional_args.begin();
+        this->sut._parse_args_impl(arg_tokens, this->state);
     }
 
     [[nodiscard]] arg_ptr_t get_argument(std::string_view arg_name) const {
@@ -186,7 +190,7 @@ struct argument_parser_test_fixture {
     }
 
     ap::argument_parser sut;
-    std::vector<std::string> unknown_args;
+    parsing_state state;
 };
 
 } // namespace ap_testing

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -17,8 +17,8 @@ struct argument_parser_test_fixture {
     argument_parser_test_fixture() = default;
     virtual ~argument_parser_test_fixture() = default;
 
+    using arg_ptr_t = ap::argument_parser::arg_ptr_t;
     using arg_token_list_t = ap::argument_parser::arg_token_list_t;
-    using arg_opt_t = ap::argument_parser::arg_opt_t;
 
     using argument_value_type = std::string;
     using invalid_argument_value_type = int;
@@ -109,9 +109,9 @@ struct argument_parser_test_fixture {
         typename F = std::function<void(positional_argument<T>&)>>
     void add_positional_args(const std::size_t n, F&& setup_arg = [](positional_argument<T>&) {}) {
         for (std::size_t i = 0ull; i < n; ++i)
-            setup_arg(
-                sut.add_positional_argument<T>(init_arg_name_primary(i), init_arg_name_secondary(i))
-            );
+            setup_arg(this->sut.add_positional_argument<T>(
+                init_arg_name_primary(i), init_arg_name_secondary(i)
+            ));
     }
 
     template <
@@ -123,7 +123,7 @@ struct argument_parser_test_fixture {
         F&& setup_arg = [](optional_argument<T>&) {}
     ) {
         for (std::size_t i = 0ull; i < n; ++i)
-            setup_arg(sut.add_optional_argument<T>(
+            setup_arg(this->sut.add_optional_argument<T>(
                 init_arg_name_primary(begin_idx + i), init_arg_name_secondary(begin_idx + i)
             ));
     }
@@ -148,9 +148,9 @@ struct argument_parser_test_fixture {
             const auto arg_name = init_arg_name_primary(arg_idx);
 
             argument_token flag_tok{argument_token::t_flag_primary, arg_name};
-            const auto opt_arg_it = sut._find_opt_arg(flag_tok);
-            if (opt_arg_it != sut._optional_args.end())
-                flag_tok.arg.emplace(*opt_arg_it);
+            const auto opt_arg_it = this->sut._find_opt_arg(flag_tok);
+            if (opt_arg_it != this->sut._optional_args.end())
+                flag_tok.arg = *opt_arg_it;
 
             arg_tokens.push_back(std::move(flag_tok));
             arg_tokens.push_back(argument_token{argument_token::t_value, init_arg_value(arg_idx)});
@@ -161,28 +161,28 @@ struct argument_parser_test_fixture {
 
     // argument_parser private member accessors
     [[nodiscard]] const std::optional<std::string>& get_program_name() const {
-        return sut._program_name;
+        return this->sut._program_name;
     }
 
     [[nodiscard]] const std::optional<std::string>& get_program_description() const {
-        return sut._program_description;
+        return this->sut._program_description;
     }
 
     [[nodiscard]] const std::optional<std::string>& get_program_version() const {
-        return sut._program_version;
+        return this->sut._program_version;
     }
 
     // private function callers
     [[nodiscard]] arg_token_list_t tokenize(int argc, char* argv[]) {
-        return sut._tokenize(std::span(argv + 1, static_cast<std::size_t>(argc - 1)));
+        return this->sut._tokenize(std::span(argv + 1, static_cast<std::size_t>(argc - 1)));
     }
 
     void parse_args_impl(const arg_token_list_t& arg_tokens) {
-        sut._parse_args_impl(arg_tokens, this->unknown_args);
+        this->sut._parse_args_impl(arg_tokens, this->unknown_args);
     }
 
-    [[nodiscard]] arg_opt_t get_argument(std::string_view arg_name) const {
-        return sut._get_argument(arg_name);
+    [[nodiscard]] arg_ptr_t get_argument(std::string_view arg_name) const {
+        return this->sut._get_argument(arg_name);
     }
 
     ap::argument_parser sut;

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -292,11 +292,11 @@ TEST_CASE_FIXTURE(
 
     const auto input_arg = get_argument("input");
     REQUIRE(input_arg);
-    CHECK(is_positional<std::string>(input_arg.value()));
+    CHECK(is_positional<std::string>(*input_arg));
 
     const auto output_arg = get_argument("output");
     REQUIRE(output_arg);
-    CHECK(is_positional<std::string>(output_arg.value()));
+    CHECK(is_positional<std::string>(*output_arg));
 }
 
 TEST_CASE_FIXTURE(
@@ -329,14 +329,14 @@ TEST_CASE_FIXTURE(
 
     const auto help_arg = get_argument(help_flag);
     REQUIRE(help_arg);
-    CHECK(is_optional<bool>(help_arg.value()));
+    CHECK(is_optional<bool>(*help_arg));
 
     const auto input_arg = get_argument(input_flag);
     REQUIRE(input_arg);
-    CHECK(is_optional<std::string>(input_arg.value()));
+    CHECK(is_optional<std::string>(*input_arg));
 
 
     const auto output_arg = get_argument(output_flag);
     REQUIRE(output_arg);
-    CHECK(is_optional<std::string>(output_arg.value()));
+    CHECK(is_optional<std::string>(*output_arg));
 }

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -72,7 +72,8 @@ TEST_CASE_FIXTURE(
     std::size_t opt_arg_idx = n_positional_args;
     for (std::size_t i = n_positional_args; i < arg_tokens.size(); i += 2ull) {
         REQUIRE_EQ(arg_tokens.at(i).type, argument_token::t_flag_primary);
-        CHECK(init_arg_name(opt_arg_idx).match(arg_tokens.at(i).value));
+        const auto stripped_flag = strip_flag_prefix(arg_tokens.at(i));
+        CHECK(init_arg_name(opt_arg_idx).match(stripped_flag));
 
         REQUIRE_EQ(arg_tokens.at(i + 1ull).type, argument_token::t_value);
         CHECK_EQ(arg_tokens.at(i + 1ull).value, init_arg_value(opt_arg_idx));

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -95,6 +95,11 @@ TEST_CASE_FIXTURE(
     auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
     arg_tokens.erase(std::next(arg_tokens.begin(), static_cast<std::ptrdiff_t>(first_opt_arg_idx)));
 
+    std::cout << "Arg tokens:\n";
+    for (const auto& tok : arg_tokens)
+        std::cout << "  Type: " << static_cast<int>(tok.type) << ", Value: " << tok.value << '\n';
+    std::cout << std::endl;
+
     CHECK_NOTHROW(parse_args_impl(arg_tokens));
     CHECK_NE(
         std::ranges::find(unknown_args, init_arg_value(first_opt_arg_idx)), unknown_args.end()

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -95,11 +95,6 @@ TEST_CASE_FIXTURE(
     auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
     arg_tokens.erase(std::next(arg_tokens.begin(), static_cast<std::ptrdiff_t>(first_opt_arg_idx)));
 
-    std::cout << "Arg tokens:\n";
-    for (const auto& tok : arg_tokens)
-        std::cout << "  Type: " << static_cast<int>(tok.type) << ", Value: " << tok.value << '\n';
-    std::cout << std::endl;
-
     CHECK_NOTHROW(parse_args_impl(arg_tokens));
     CHECK_NE(
         std::ranges::find(unknown_args, init_arg_value(first_opt_arg_idx)), unknown_args.end()

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -97,7 +97,8 @@ TEST_CASE_FIXTURE(
 
     CHECK_NOTHROW(parse_args_impl(arg_tokens));
     CHECK_NE(
-        std::ranges::find(unknown_args, init_arg_value(first_opt_arg_idx)), unknown_args.end()
+        std::ranges::find(state.unknown_args, init_arg_value(first_opt_arg_idx)),
+        state.unknown_args.end()
     );
 }
 
@@ -110,7 +111,7 @@ TEST_CASE_FIXTURE(
     const auto arg_tokens = init_arg_tokens(n_positional_args, n_optional_args);
 
     CHECK_NOTHROW(parse_args_impl(arg_tokens));
-    CHECK(unknown_args.empty());
+    CHECK(state.unknown_args.empty());
 }
 
 // _get_argument

--- a/tests/source/test_argument_token.cpp
+++ b/tests/source/test_argument_token.cpp
@@ -54,10 +54,9 @@ TEST_CASE("is_valid_flag_token should return true if the token is a flag token a
     CHECK_FALSE(sut_type{t_flag_primary, ""}.is_valid_flag_token());
     CHECK_FALSE(sut_type{t_flag_secondary, ""}.is_valid_flag_token());
 
-    std::unique_ptr<argument_base> arg_ptr =
-        std::make_unique<optional_argument<>>(argument_name{""});
-    const typename sut_type::arg_ptr_opt_t arg_ptr_opt{std::ref(arg_ptr)};
+    std::shared_ptr<argument_base> arg_ptr =
+        std::make_shared<optional_argument<>>(argument_name{""});
 
-    CHECK(sut_type{t_flag_primary, "", arg_ptr_opt}.is_valid_flag_token());
-    CHECK(sut_type{t_flag_secondary, "", arg_ptr_opt}.is_valid_flag_token());
+    CHECK(sut_type{t_flag_primary, "", arg_ptr}.is_valid_flag_token());
+    CHECK(sut_type{t_flag_secondary, "", arg_ptr}.is_valid_flag_token());
 }


### PR DESCRIPTION
- Replaced `std::unique_ptr` with `std::shared_ptr` in the argument lists within `argument_parser`
- Replaced optional argument reference type with `std::shared_ptr`
    - Previously: `std::optional<std::reference_wrapper<std::unique_ptr<argument_base>>>` 
- Aligned argument token building to store original (unstripped) command-line values
- Defined a *parsing state* structure within `argument_parser` to replace passing multiple parsing parameters by reference with a single compound type