### PR TITLE
YT-CPPAP-60: Runtime unknown flag handling method parameter

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 3.0.0.4
+    VERSION 3.0.0.5
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0.4
+PROJECT_NUMBER         = 3.0.0.5
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp-ap",
-    version = "3.0.0.4",
+    version = "3.0.0.5",
 )

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -1014,6 +1014,19 @@ The available policies are:
 >
 > - The unkown argument flags handling polciy only affects the parser's behaviour when calling the `parse_args` or `try_parse_args` methods.
 > - When parsing known args with `parse_known_args` or `try_parse_known_args` all unknown arguments (flags and values) are collected and returned as the parsing result, ignoring the specified policy for handling unknown arguments.
+>
+> Consider a similar example as above with only the argument parsing function changed:
+> ```cpp
+> const auto unknown_args = parser.try_parse_known_args(argc, argv);
+> std::cout << "known = " << ap::util::join(parser.values("known")) << std::endl
+>           << "unknown = " << ap::util::join(unknown_args) << std::endl;
+> ```
+> This would produce the following output regardless of the specified unknown arguments policy.
+> ```shell
+> > ./test --known --unknown
+> known =
+> unknown = --unknown
+> ```
 
 <br />
 <br />

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -112,6 +112,7 @@ The parameters you can specify for a parser's instance are:
 - The program's name, version and description - used in the parser's configuration output (`std::cout << parser`).
 - Verbosity mode - `false` by default; if set to `true` the parser's configuration output will include more detailed info about arguments' parameters in addition to their names and help messages.
 - [Arguments](#adding-arguments) - specify the values/options accepted by the program.
+- [The unknown argument flags handling policy](#4-unknown-argument-flag-handling).
 
 ```cpp
 ap::argument_parser parser;
@@ -602,12 +603,12 @@ Command                       Result
 
 ### Actions
 
-- `print_config` | on-flag
+- `print_help` | on-flag
 
-  Prints the configuration of the parser to the output stream and optionally exits with the given code.
+  Prints the parser's help message to the output stream and optionally exits with the given code.
 
   ```cpp
-  typename ap::action_type::on_flag::type print_config(
+  typename ap::action_type::on_flag::type print_help(
       const ap::argument_parser& parser,
       const std::optional<int> exit_code = std::nullopt,
       std::ostream& os = std::cout
@@ -707,8 +708,8 @@ parser.default_arguments(<args>);
 
   ```cpp
   // equivalent to:
-  parser.add_flag("help", "h")
-        .action<action_type::on_flag>(action::print_config(arg_parser, EXIT_SUCCESS))
+  parser.add_optional_argument<ap::none_type>("help", "h")
+        .action<action_type::on_flag>(ap::action::print_help(parser, EXIT_SUCCESS))
         .help("Display the help message");
   ```
 
@@ -937,33 +938,82 @@ optional: opt-value
 
 <br />
 
-#### 4. Unrecognized argument flag handling
+#### 4. Unknown Argument Flag Handling
 
-By default the `argument_parser` class treats *all\** command-line arguments beggining with a `--` or `-` prefix as optional argument flags and if the flag's value does not match any of the specified arguments, then such flag is considered *unknown* and an exception will be thrown.
+A command-line argument beginning with a flag prefix (`--` or `-`) that doesn't match any of the specified optional arguments or a compound of optional arguments (only for short flags) is considered **unknown** or **unrecognized**.
 
-> [*all\**] If a command-line argument begins with a flag prefix, but contains whitespaces (e.g. `"--flag value"`), then it is treated as a value and not a flag.
+By default an argument parser will throw an exception if an unkown argument flag is encountered.
 
-This behavior can be altered so that the unknown argument flags will be treated as values, not flags. For example:
+This behavior can be modified using the `unknown_arguments_policy` method of the `argument_parser` class, which sets the policy for handling unknown argument flags.
+
+
+**Example:**
 
 ```cpp
-parser.add_optional_argument("option", "o");
-parser.try_parse_args(argc, argv);
-std::cout << "option: " << parser.value("option");
+#include <ap/argument_parser.hpp>
 
-/*
-./program --option --unknown-flag
-option: --unknown-flag
+int main(int argc, char* argv[]) {
+    ap::argument_parser parser;
+
+    parser.program_name("test")
+          .program_description("A simple test program")
+          .default_arguments(ap::default_argument::o_help)
+          // set the unknown argument flags handling policy
+          .unknown_arguments_policy(ap::unknown_policy::<policy>);
+
+    parser.add_optional_argument("known", "k")
+          .help("A known optional argument");
+
+    parser.try_parse_args(argc, argv);
+
+    std::cout << "known = " << ap::util::join(parser.values("known")) << std::endl;
+
+    return 0;
+}
 ```
 
-To do this add the following in your `CMakeLists.txt` file:
-```cmake
-target_compile_definitions(cpp-ap PRIVATE AP_UNKNOWN_FLAGS_AS_VALUES)
-```
-or simply add:
-```cpp
-#define AP_UNKNOWN_FLAGS_AS_VALUES
-```
-before the `#include <ap/argument_parser.hpp>` statement.
+The available policies are:
+- `ap::unknown_policy::fail` (default) - throws an exception if an unknown argument flag is encountered:
+
+    ```bash
+    > ./test --known --unknown
+    [ap::error] Unknown argument [--unknown].
+    Program: test
+
+      A simple test program
+
+    Optional arguments:
+
+      --help, -h  : Display the help message
+      --known, -k : A known optional argument
+    ```
+
+- `ap::unknown_policy::warn` - prints a warning message to the standard error stream and continues parsing the remaining arguments:
+
+    ```bash
+    > ./test --known --unknown
+    [ap::warning] Unknown argument '--unknown' will be ignored.
+    known =
+    ```
+
+- `ap::unknown_policy::ignore` - ignores unknown argument flags and continues parsing the remaining arguments:
+
+    ```shell
+    ./test --known --unknown
+    known =
+    ```
+
+- `ap::unknown_policy::as_values` - treats unknown argument flags as values:
+
+    ```shell
+    > ./test --known --unknown
+    known = --unknown
+    ```
+
+> [!IMPORTANT]
+>
+> - The unkown argument flags handling polciy only affects the parser's behaviour when calling the `parse_args` or `try_parse_args` methods.
+> - When parsing known args with `parse_known_args` or `try_parse_known_args` all unknown arguments (flags and values) are collected and returned as the parsing result, ignoring the specified policy for handling unknown arguments.
 
 <br />
 <br />

--- a/include/ap/action/predefined.hpp
+++ b/include/ap/action/predefined.hpp
@@ -20,12 +20,12 @@ std::ostream& operator<<(std::ostream& os, const argument_parser&) noexcept;
 namespace action {
 
 /**
- * @brief Returns an *on-flag* action which prints the argument parser's configuration.
- * @param parser The argument parser the configuration of which will be printed.
+ * @brief Returns an *on-flag* action which prints the argument parser's help message.
+ * @param parser The argument parser the help message of which will be printed.
  * @param exit_code The exit code with which `std::exit` will be called (if not `std::nullopt`).
- * @param os The output stream to which the configuration will be printed.
+ * @param os The output stream to which the help message will be printed.
  */
-inline typename ap::action_type::on_flag::type print_config(
+inline typename ap::action_type::on_flag::type print_help(
     const argument_parser& parser,
     const std::optional<int> exit_code = std::nullopt,
     std::ostream& os = std::cout

--- a/include/ap/argument.hpp
+++ b/include/ap/argument.hpp
@@ -42,7 +42,7 @@ enum class argument_type : bool { positional, optional };
  * @attention Some member functions are conditionally enabled/disabled depending on the argument type and value type.
  *
  * Example usage:
- * @code
+ * @code{.cpp}
  * ap::argument_parser parser;
  * parser.add_positional_argument("input", "i")
  *       .help("An input file path");

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -932,7 +932,7 @@ private:
 
         switch (this->_unknown_policy) {
         case unknown_policy::fail:
-            throw parsing_failure::unknwon_argument(tok.value);
+            throw parsing_failure::unknown_argument(tok.value);
         case unknown_policy::warn:
             std::cerr << "[ap::warning] Unknown argument '" << tok.value << "' will be ignored."
                       << std::endl;
@@ -1085,7 +1085,7 @@ private:
                 }
                 else {
                     // should never happen as unknown flags are filtered out during tokenization
-                    throw parsing_failure::unknwon_argument(tok.value);
+                    throw parsing_failure::unknown_argument(tok.value);
                 }
             }
 

--- a/include/ap/exceptions.hpp
+++ b/include/ap/exceptions.hpp
@@ -57,7 +57,7 @@ struct invalid_configuration : public argument_parser_exception {
 struct parsing_failure : public argument_parser_exception {
     explicit parsing_failure(const std::string& message) : argument_parser_exception(message) {}
 
-    static parsing_failure unknwon_argument(const std::string_view arg_name) noexcept {
+    static parsing_failure unknown_argument(const std::string_view arg_name) noexcept {
         return parsing_failure(std::format("Unknown argument [{}].", arg_name));
     }
 

--- a/include/ap/exceptions.hpp
+++ b/include/ap/exceptions.hpp
@@ -57,8 +57,8 @@ struct invalid_configuration : public argument_parser_exception {
 struct parsing_failure : public argument_parser_exception {
     explicit parsing_failure(const std::string& message) : argument_parser_exception(message) {}
 
-    static parsing_failure unrecognized_argument(const std::string_view arg_name) noexcept {
-        return parsing_failure(std::format("Unrecognized argument [{}].", arg_name));
+    static parsing_failure unknwon_argument(const std::string_view arg_name) noexcept {
+        return parsing_failure(std::format("Unknown argument [{}].", arg_name));
     }
 
     static parsing_failure value_already_set(const detail::argument_name& arg_name) noexcept {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -69,9 +69,9 @@ add_doctest("source/test_argument_token.cpp")
 add_doctest("source/test_argument_parser_add_argument.cpp")
 add_doctest("source/test_argument_parser_info.cpp")
 add_doctest("source/test_argument_parser_parse_args.cpp")
-add_doctest("source/test_argument_parser_parse_args_unknown_flags_as_values.cpp"
-    COMPILE_DEFINITIONS "AP_UNKNOWN_FLAGS_AS_VALUES"
-)
+# add_doctest("source/test_argument_parser_parse_args_unknown_flags_as_values.cpp"
+#     COMPILE_DEFINITIONS "AP_UNKNOWN_FLAGS_AS_VALUES"
+# )
 add_doctest("source/test_nargs_range.cpp")
 add_doctest("source/test_none_type_argument.cpp")
 add_doctest("source/test_optional_argument.cpp")

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -179,7 +179,7 @@ struct argument_parser_test_fixture {
 
     // private function callers
     [[nodiscard]] arg_token_list_t tokenize(int argc, char* argv[]) {
-        return this->sut._tokenize(std::span(argv + 1, static_cast<std::size_t>(argc - 1)));
+        return this->sut._tokenize(std::span(argv + 1, static_cast<std::size_t>(argc - 1)), state);
     }
 
     void parse_args_impl(const arg_token_list_t& arg_tokens) {

--- a/tests/source/test_argument_parser_add_argument.cpp
+++ b/tests/source/test_argument_parser_add_argument.cpp
@@ -329,7 +329,7 @@ TEST_CASE_FIXTURE(
 
     const auto help_arg = get_argument(help_flag);
     REQUIRE(help_arg);
-    CHECK(is_optional<bool>(*help_arg));
+    CHECK(is_optional<ap::none_type>(*help_arg));
 
     const auto input_arg = get_argument(input_flag);
     REQUIRE(input_arg);

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -281,7 +281,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::unrecognized_argument(unknown_arg_name).what(),
+        parsing_failure::unknwon_argument(unknown_arg_name).what(),
         parsing_failure
     );
 
@@ -322,7 +322,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::unrecognized_argument(invalid_flag).what(),
+        parsing_failure::unknwon_argument(invalid_flag).what(),
         parsing_failure
     );
 
@@ -1118,7 +1118,7 @@ TEST_CASE_FIXTURE(
     // parse args
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::unrecognized_argument(invalid_flag).what(),
+        parsing_failure::unknwon_argument(invalid_flag).what(),
         parsing_failure
     );
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -6,6 +6,7 @@ using namespace ap_testing;
 using namespace ap::nargs;
 using ap::invalid_configuration;
 using ap::parsing_failure;
+using ap::unknown_policy;
 
 struct test_argument_parser_parse_args : public argument_parser_test_fixture {
     const std::string_view test_program_name = "test program name";
@@ -277,11 +278,11 @@ TEST_CASE_FIXTURE(
     auto argc = get_argc(no_args, n_opt_clargs);
     auto argv = init_argv(no_args, n_opt_clargs);
 
-    const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
+    const auto unknown_arg_flag = init_arg_flag_primary(opt_arg_idx);
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::unknwon_argument(unknown_arg_name).what(),
+        parsing_failure::unknown_argument(unknown_arg_flag).what(),
         parsing_failure
     );
 
@@ -322,7 +323,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::unknwon_argument(invalid_flag).what(),
+        parsing_failure::unknown_argument(invalid_flag).what(),
         parsing_failure
     );
 
@@ -1118,7 +1119,7 @@ TEST_CASE_FIXTURE(
     // parse args
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::unknwon_argument(invalid_flag).what(),
+        parsing_failure::unknown_argument(invalid_flag).what(),
         parsing_failure
     );
 
@@ -1172,5 +1173,128 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(sut.count("third-arg"), third_arg_count);
 
     // cleanup
+    free_argv(argc, argv);
+}
+
+// unknown_arguments_policy
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when an unrecognized argument flag is used with the default unknown "
+    "arguments handling policy (fail)"
+) {
+    add_arguments(no_args, no_args);
+
+    constexpr std::size_t n_opt_clargs = 1ull;
+    constexpr std::size_t opt_arg_idx = 0ull;
+
+    auto argc = get_argc(no_args, n_opt_clargs);
+    auto argv = init_argv(no_args, n_opt_clargs);
+
+    const auto unknown_arg_name = init_arg_flag_primary(opt_arg_idx);
+
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(unknown_arg_name).what(),
+        parsing_failure
+    );
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should throw when an unrecognized argument flag is used with the default unknown "
+    "arguments handling policy (fail)"
+) {
+    const auto unknown_arg_flag = "--unknown";
+    const std::vector<std::string> argv_vec{"program", unknown_arg_flag};
+
+    const auto argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
+
+    CHECK_THROWS_WITH_AS(
+        sut.parse_args(argc, argv),
+        parsing_failure::unknown_argument(unknown_arg_flag).what(),
+        parsing_failure
+    );
+
+    free_argv(argc, argv);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should print a warning to std::cerr when an unrecognized argument flag is used "
+    "with the warn unknown arguments handling policy"
+) {
+    sut.unknown_arguments_policy(unknown_policy::warn);
+
+    const auto unknown_arg_flag = "--unknown";
+    const std::vector<std::string> argv_vec{"program", unknown_arg_flag};
+
+    const auto argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
+
+    // redirect std::cerr
+    std::stringstream tmp_buffer;
+    auto* cerr_buffer = std::cerr.rdbuf(tmp_buffer.rdbuf());
+
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+
+    CHECK_EQ(
+        tmp_buffer.str(),
+        std::format("[ap::warning] Unknown argument '{}' will be ignored.\n", unknown_arg_flag)
+    );
+
+    free_argv(argc, argv);
+
+    // reset std::cerr
+    std::cerr.rdbuf(cerr_buffer);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should do nothing when an unrecognized argument flag is used with the ignore "
+    "unknown arguments handling policy"
+) {
+    sut.unknown_arguments_policy(unknown_policy::ignore);
+
+    const auto unknown_arg_flag = "--unknown";
+    const std::vector<std::string> argv_vec{"program", unknown_arg_flag};
+
+    const auto argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
+
+    // redirect std::cerr
+    std::stringstream tmp_buffer;
+    auto* cerr_buffer = std::cerr.rdbuf(tmp_buffer.rdbuf());
+
+    REQUIRE_NOTHROW(sut.parse_args(argc, argv));
+
+    CHECK_EQ(tmp_buffer.str(), "");
+
+    free_argv(argc, argv);
+
+    // reset std::cerr
+    std::cerr.rdbuf(cerr_buffer);
+}
+
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should treat an unrecognized argument flag as a value with the as_values unknown "
+    "arguments handling policy"
+) {
+    sut.unknown_arguments_policy(unknown_policy::as_values);
+    sut.add_positional_argument("known");
+
+    const auto unknown_arg_flag = "--unknown";
+    const std::vector<std::string> argv_vec{"program", unknown_arg_flag};
+
+    const auto argc = static_cast<int>(argv_vec.size());
+    auto argv = to_char_2d_array(argv_vec);
+
+    CHECK_NOTHROW(sut.parse_args(argc, argv));
+    CHECK_EQ(sut.value("known"), unknown_arg_flag);
+
     free_argv(argc, argv);
 }


### PR DESCRIPTION
- Removed the `AP_UNKNOWN_FLAGS_AS_VALUES` macro support
- Introduced the `unknown_policy` discriminator type with the following values:
   - fail (default): throw an exception when an unknown argument is encountered
   - warn: issue a warning when an unknown argument is encountered
   - ignore: ignore unknown arguments
   - as_values: treat unknown arguments as positional values
- Added an `unknown_arguments_policy` method to the `argument_parser` class
- Aligned the tokenization and parsing logic to properly handle the new unknown argument flags handling policies