### PR TITLE
CPP-AP: version 3.0.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ else()
 endif()
 
 project(cpp-ap
-    VERSION 3.0.0.8
+    VERSION 3.0.0
     DESCRIPTION "Command-line argument parser for C++20"
     HOMEPAGE_URL "https://github.com/SpectraL519/cpp-ap"
     LANGUAGES CXX

--- a/Doxyfile
+++ b/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = CPP-AP
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0.8
+PROJECT_NUMBER         = 3.0.0
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -1,4 +1,4 @@
 module(
     name = "cpp-ap",
-    version = "3.0.0.8",
+    version = "3.0.0",
 )

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -15,7 +15,7 @@
     - [help](#1-help---the-arguments-description-which-will-be-printed-when-printing-the-parser-class-instance) - the text shown in the help message to describe an argument
     - [hidden](#2-hidden---if-this-option-is-set-for-an-argument-then-it-will-not-be-included-in-the-program-description) - hides the argument from the generated program description and help output
     - [required](#3-required---if-this-option-is-set-for-an-argument-and-its-value-is-not-passed-in-the-command-line-an-exception-will-be-thrown) - marks the argument as mandatory; not using it will cause an error
-    - [supress arg checks](#4-supress_arg_checks---using-a-supressing-argument-results-in-supressing-requirement-checks-for-other-arguments) - if a supressing argument is used, other requirement validation will be skipped for other arguments
+    - [suppress arg checks](#4-suppress_arg_checks---using-a-suppressing-argument-results-in-suppressing-requirement-checks-for-other-arguments) - if a suppressing argument is used, other requirement validation will be skipped for other arguments
     - [nargs](#5-nargs---sets-the-allowed-number-of-values-to-be-parsed-for-an-argument) - defines how many values an argument can or must accept
     - [greedy](#6-greedy---if-this-option-is-set-the-argument-will-consume-all-command-line-values-until-its-upper-nargs-bound-is-reached) - makes the argument consume all following values until its limit is reached
     - [choices](#7-choices---a-list-of-valid-argument-values) - restricts the valid inputs to a predefined set of values
@@ -24,8 +24,6 @@
   - [Parameters Specific for Optional Arguments](#parameters-specific-for-optional-arguments)
     - [on-flag actions](#1-on-flag-actions---functions-that-are-called-immediately-after-parsing-an-arguments-flag) - executes custom code immediately when the argument’s flag is present
     - [implicit values](#2-implicit_values---a-list-of-values-which-will-be-set-for-an-argument-if-only-its-flag-but-no-values-are-parsed-from-the-command-line) - automatically assigns a value if an argument flag is used without an explicit value
-
-
 - [Predefined Parameter Values](#predefined-parameter-values)
 - [Default Arguments](#default-arguments)
 - [Argument Groups](#argument-groups)
@@ -321,8 +319,8 @@ Optional arguments:
 >
 > - If a positional argument is defined as non-required, then no required positional argument can be defined after (only other non-required positional arguments and optional arguments will be allowed).
 > - For both positional and optional arguments:
->   - enabling the `required` option disables the `supress_arg_checks` option
->   - disabling the `required` option has no effect on the `supress_arg_checks` option.
+>   - enabling the `required` option disables the `suppress_arg_checks` option
+>   - disabling the `required` option has no effect on the `suppress_arg_checks` option.
 
 ```cpp
 // example: positional arguments
@@ -379,29 +377,29 @@ Command                                 Result
 
 <br />
 
-#### 4. `supress_arg_checks` - Using a supressing argument results in supressing requirement checks for other arguments.
+#### 4. `suppress_arg_checks` - Using a suppressing argument results in suppressing requirement checks for other arguments.
 
-If an argument is defined with the `supress_arg_checks` option enabled and such argument is explicitly used in the command-line, then requirement validation will be supressed/skipped for other arguments. This includes validating whether:
+If an argument is defined with the `suppress_arg_checks` option enabled and such argument is explicitly used in the command-line, then requirement validation will be suppressed/skipped for other arguments. This includes validating whether:
 - a required argument has been parsed
 - the number of values parsed for an argument matches the specified [nargs](#5-nargs---sets-the-allowed-number-of-values-to-be-parsed-for-an-argument) range.
 
 > [!NOTE]
 >
-> - All arguments have the `supress_arg_checks` option disabled by default.
-> - The default value of the value parameter of the `argument::supress_arg_checks(bool)` method is `true` for all arguments.
+> - All arguments have the `suppress_arg_checks` option disabled by default.
+> - The default value of the value parameter of the `argument::suppress_arg_checks(bool)` method is `true` for all arguments.
 
 > [!WARNING]
 >
-> - Enabling the `supress_arg_checks` option has no effect on [argument group](#argument-groups) requirements validation.
+> - Enabling the `suppress_arg_checks` option has no effect on [argument group](#argument-groups) requirements validation.
 > - For both positional and optional arguments:
->   - enabling the `supress_arg_checks` option disables the `required` option
->   - disabling the `supress_arg_checks` option has no effect on the `required` option.
+>   - enabling the `suppress_arg_checks` option disables the `required` option
+>   - disabling the `suppress_arg_checks` option has no effect on the `required` option.
 
 ```cpp
 // example: optional arguments
 parser.add_positional_argument("input");
 parser.add_optional_argument("output", "o").required();
-parser.add_optional_argument("version", "v").supress_arg_checks();
+parser.add_optional_argument("version", "v").suppress_arg_checks();
 
 parser.parse_args(argc, argv);
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -15,7 +15,7 @@
     - [help](#1-help---the-arguments-description-which-will-be-printed-when-printing-the-parser-class-instance)
     - [hidden](#2-hidden---if-this-option-is-set-for-an-argument-then-it-will-not-be-included-in-the-program-description)
     - [required](#3-required---if-this-option-is-set-for-an-argument-and-its-value-is-not-passed-in-the-command-line-an-exception-will-be-thrown)
-    - [bypass required](#4-bypass_required---if-this-option-is-set-for-an-argument-the-required-option-for-other-arguments-will-be-discarded-if-the-bypassing-argument-is-used-in-the-command-line)
+    - [supress arg checks](#4-supress_arg_checks---using-a-supressing-argument-results-in-supressing-requirement-checks-for-other-arguments)
     - [nargs](#5-nargs---sets-the-allowed-number-of-values-to-be-parsed-for-an-argument)
     - [greedy](#6-greedy---if-this-option-is-set-the-argument-will-consume-all-command-line-values-until-its-upper-nargs-bound-is-reached)
     - [choices](#7-choices---a-list-of-valid-argument-values)
@@ -319,8 +319,8 @@ Optional arguments:
 >
 > - If a positional argument is defined as non-required, then no required positional argument can be defined after (only other non-required positional arguments and optional arguments will be allowed).
 > - For both positional and optional arguments:
->   - enabling the `required` option disables the `bypass_required` option
->   - disabling the `required` option has no effect on the `bypass_required` option.
+>   - enabling the `required` option disables the `supress_arg_checks` option
+>   - disabling the `required` option has no effect on the `supress_arg_checks` option.
 
 ```cpp
 // example: positional arguments
@@ -377,24 +377,29 @@ Command                                 Result
 
 <br />
 
-#### 4. `bypass_required` - If this option is set for an argument, the `required` option for other arguments will be discarded if the bypassing argument is used in the command-line.
+#### 4. `supress_arg_checks` - Using a supressing argument results in supressing requirement checks for other arguments.
+
+If an argument is defined with the `supress_arg_checks` option enabled and such argument is explicitly used in the command-line, then requirement validation will be supressed/skipped for other arguments. This includes validating whether:
+- a required argument has been parsed
+- the number of values parsed for an argument matches the specified [nargs](#5-nargs---sets-the-allowed-number-of-values-to-be-parsed-for-an-argument) range.
 
 > [!NOTE]
 >
-> - Both all arguments have the `bypass_required` option disabled.
-> - The default value of the value parameter of the `argument::bypass_required(bool)` method is `true` for all arguments.
+> - All arguments have the `supress_arg_checks` option disabled by default.
+> - The default value of the value parameter of the `argument::supress_arg_checks(bool)` method is `true` for all arguments.
 
 > [!WARNING]
 >
-> For both positional and optional arguments:
-> - enabling the `bypass_required` option disables the `required` option
-> - disabling the `bypass_required` option has no effect on the `required` option.
+> - Enabling the `supress_arg_checks` option has no effect on [argument group](#argument-groups) requirements validation.
+> - For both positional and optional arguments:
+>   - enabling the `supress_arg_checks` option disables the `required` option
+>   - disabling the `supress_arg_checks` option has no effect on the `required` option.
 
 ```cpp
 // example: optional arguments
 parser.add_positional_argument("input");
 parser.add_optional_argument("output", "o").required();
-parser.add_optional_argument("version", "v").bypass_required();
+parser.add_optional_argument("version", "v").supress_arg_checks();
 
 parser.parse_args(argc, argv);
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -12,18 +12,20 @@
   - [Boolean Flags](#boolean-flags)
 - [Argument Parameters](#argument-parameters)
   - [Common Parameters](#common-parameters)
-    - [help](#1-help---the-arguments-description-which-will-be-printed-when-printing-the-parser-class-instance)
-    - [hidden](#2-hidden---if-this-option-is-set-for-an-argument-then-it-will-not-be-included-in-the-program-description)
-    - [required](#3-required---if-this-option-is-set-for-an-argument-and-its-value-is-not-passed-in-the-command-line-an-exception-will-be-thrown)
-    - [supress arg checks](#4-supress_arg_checks---using-a-supressing-argument-results-in-supressing-requirement-checks-for-other-arguments)
-    - [nargs](#5-nargs---sets-the-allowed-number-of-values-to-be-parsed-for-an-argument)
-    - [greedy](#6-greedy---if-this-option-is-set-the-argument-will-consume-all-command-line-values-until-its-upper-nargs-bound-is-reached)
-    - [choices](#7-choices---a-list-of-valid-argument-values)
-    - [value actions](#8-value-actions---functions-that-are-called-after-parsing-an-arguments-value)
-    - [default values](#9-default_values---a-list-of-values-which-will-be-used-if-no-values-for-an-argument-have-been-parsed)
+    - [help](#1-help---the-arguments-description-which-will-be-printed-when-printing-the-parser-class-instance) - the text shown in the help message to describe an argument
+    - [hidden](#2-hidden---if-this-option-is-set-for-an-argument-then-it-will-not-be-included-in-the-program-description) - hides the argument from the generated program description and help output
+    - [required](#3-required---if-this-option-is-set-for-an-argument-and-its-value-is-not-passed-in-the-command-line-an-exception-will-be-thrown) - marks the argument as mandatory; not using it will cause an error
+    - [supress arg checks](#4-supress_arg_checks---using-a-supressing-argument-results-in-supressing-requirement-checks-for-other-arguments) - if a supressing argument is used, other requirement validation will be skipped for other arguments
+    - [nargs](#5-nargs---sets-the-allowed-number-of-values-to-be-parsed-for-an-argument) - defines how many values an argument can or must accept
+    - [greedy](#6-greedy---if-this-option-is-set-the-argument-will-consume-all-command-line-values-until-its-upper-nargs-bound-is-reached) - makes the argument consume all following values until its limit is reached
+    - [choices](#7-choices---a-list-of-valid-argument-values) - restricts the valid inputs to a predefined set of values
+    - [value actions](#8-value-actions---functions-that-are-called-after-parsing-an-arguments-value) - allows you to run custom code after the argument’s value is parsed
+    - [default values](#9-default_values---a-list-of-values-which-will-be-used-if-no-values-for-an-argument-have-been-parsed) - specifies fallback values to use if none are provided
   - [Parameters Specific for Optional Arguments](#parameters-specific-for-optional-arguments)
-    - [on-flag actions](#1-on-flag-actions---functions-that-are-called-immediately-after-parsing-an-arguments-flag)
-    - [implicit values](#2-implicit_values---a-list-of-values-which-will-be-set-for-an-argument-if-only-its-flag-but-no-values-are-parsed-from-the-command-line)
+    - [on-flag actions](#1-on-flag-actions---functions-that-are-called-immediately-after-parsing-an-arguments-flag) - executes custom code immediately when the argument’s flag is present
+    - [implicit values](#2-implicit_values---a-list-of-values-which-will-be-set-for-an-argument-if-only-its-flag-but-no-values-are-parsed-from-the-command-line) - automatically assigns a value if an argument flag is used without an explicit value
+
+
 - [Predefined Parameter Values](#predefined-parameter-values)
 - [Default Arguments](#default-arguments)
 - [Argument Groups](#argument-groups)
@@ -527,7 +529,7 @@ Actions are represented as functions, which take the argument's value as an argu
   ```cpp
   void is_valid_user_tag(const std::string& tag) {
       if (tag.empty() or tag.front() != '@')
-          throw std::runtime_error(std::format("Invalid user tag: `{}` — must start with '@'", tag));
+          throw std::runtime_error(std::format("Invalid user tag: `{}` - must start with '@'", tag));
   }
 
   parser.add_optional_argument<std::string>("user", "u")

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -318,9 +318,7 @@ Optional arguments:
 > [!WARNING]
 >
 > - If a positional argument is defined as non-required, then no required positional argument can be defined after (only other non-required positional arguments and optional arguments will be allowed).
-> - For both positional and optional arguments:
->   - enabling the `required` option disables the `suppress_arg_checks` option
->   - disabling the `required` option has no effect on the `suppress_arg_checks` option.
+> - If an argument is suppressing (see [suppress arg checks](#4-suppress_arg_checks---using-a-suppressing-argument-results-in-suppressing-requirement-checks-for-other-arguments) and [Suppressing Argument Group Checks](#suppressing-argument-group-checks)), then it cannot be required (an exception will be thrown).
 
 ```cpp
 // example: positional arguments
@@ -391,9 +389,7 @@ If an argument is defined with the `suppress_arg_checks` option enabled and such
 > [!WARNING]
 >
 > - Enabling the `suppress_arg_checks` option has no effect on [argument group](#argument-groups) requirements validation.
-> - For both positional and optional arguments:
->   - enabling the `suppress_arg_checks` option disables the `required` option
->   - disabling the `suppress_arg_checks` option has no effect on the `required` option.
+> - Enabling argument checks suppressing is not possible for required arguments (an exception will be thrown).
 
 ```cpp
 // example: optional arguments
@@ -938,6 +934,26 @@ Output Options: (required, mutually exclusive)
   --output, -o : Print output to a given file
   --print, -p  : Print output to the console
 ```
+
+### Suppressing Argument Group Checks
+
+Similarly to [suppressing argument checks](#4-suppress_arg_checks---using-a-suppressing-argument-results-in-suppressing-requirement-checks-for-other-arguments), an argument can suppress the requirement checks of argument groups:
+
+```c++
+argument.suppress_group_checks();
+```
+
+If such argument is used the requirement checks associated with the [group attributes](#group-attributes) will not be validated.
+
+> [!NOTE]
+>
+> - All arguments have the `suppress_group_checks` option disabled by default.
+> - The default value of the value parameter of the `argument::suppress_group_checks(bool)` method is `true` for all arguments.
+
+> [!WARNING]
+>
+> - Enabling the `suppress_group_checks` option has no effect on argument requirements validation.
+> - Enabling argument group checks suppressing is not possible for required arguments (an exception will be thrown).
 
 <br/>
 <br/>

--- a/include/ap/argument.hpp
+++ b/include/ap/argument.hpp
@@ -117,10 +117,10 @@ public:
         return this->_required;
     }
 
-    /// @return `true` if required argument bypassing is enabled for the argument, `false` otherwise.
-    /// @note Required argument bypassing is enabled only if the argument is not required.
-    [[nodiscard]] bool is_bypass_required_enabled() const noexcept override {
-        return not this->_required and this->_bypass_required;
+    /// @return `true` if required argument checks supressing is enabled for the argument, `false` otherwise.
+    /// @note Argument checks supressing can only be enabled if the argument is not required.
+    [[nodiscard]] bool supresses_arg_checks() const noexcept override {
+        return not this->_required and this->_supress_arg_checks;
     }
 
     /// @return `true` if the argument is greedy, `false` otherwise.
@@ -152,40 +152,40 @@ public:
 
     /**
      * @brief Set the `required` attribute of the argument
-     * @param r The attribute value.
+     * @param value The attribute value (default: `true`).
      * @return Reference to the argument instance.
-     * @attention Setting the `required` attribute to `true` disables the `bypass_required` attribute.
+     * @attention Setting the `required` attribute to `true` disables the `supress_arg_checks` attribute.
      */
-    argument& required(const bool r = true) noexcept {
-        this->_required = r;
+    argument& required(const bool value = true) noexcept {
+        this->_required = value;
         if (this->_required)
-            this->_bypass_required = false;
+            this->_supress_arg_checks = false;
         return *this;
     }
 
     /**
-     * @brief Enable/disable bypassing the `required` attribute for the argument.
-     * @param br The attribute value.
+     * @brief Enable/disable supressing argument checks for other arguments.
+     * @param value The attribute value (default: `true`).
      * @return Reference to the argument instance.
-     * @attention Setting the `bypass_required` option to `true` disables the `required` attribute.
+     * @attention Setting the `supress_arg_checks` attribute to `true` disables the `required` attribute.
      */
-    argument& bypass_required(const bool br = true) noexcept {
-        this->_bypass_required = br;
-        if (this->_bypass_required)
+    argument& supress_arg_checks(const bool value = true) noexcept {
+        this->_supress_arg_checks = value;
+        if (this->_supress_arg_checks)
             this->_required = false;
         return *this;
     }
 
     /**
      * @brief Set the `greedy` attribute of the argument.
-     * @param g The attribute value.
+     * @param value The attribute value (default: `true`).
      * @return Reference to the argument instance.
      * @note The method is enabled only if `value_type` is not `none_type`.
      */
-    argument& greedy(const bool g = true) noexcept
+    argument& greedy(const bool value = true) noexcept
     requires(not util::c_is_none<value_type>)
     {
-        this->_greedy = g;
+        this->_greedy = value;
         return *this;
     }
 
@@ -438,8 +438,8 @@ private:
         bld.params.reserve(6ull);
         if (this->_required != _default_required)
             bld.add_param("required", std::format("{}", this->_required));
-        if (this->is_bypass_required_enabled())
-            bld.add_param("bypass required", "true");
+        if (this->supresses_arg_checks())
+            bld.add_param("supress arg checks", "true");
         if (this->_nargs_range != _default_nargs_range)
             bld.add_param("nargs", this->_nargs_range);
         if constexpr (util::c_writable<value_type>) {
@@ -704,7 +704,7 @@ private:
         _value_actions; ///< The argument's value actions collection.
 
     bool _required : 1; ///< The argument's `required` attribute value.
-    bool _bypass_required : 1 = false; ///< The argument's `bypass_required` attribute value.
+    bool _supress_arg_checks : 1 = false; ///< The argument's `supress_arg_checks` attribute value.
     bool _greedy : 1 = false; ///< The argument's `greedy` attribute value.
     bool _hidden : 1 = false; ///< The argument's `hidden` attribute value.
 

--- a/include/ap/argument.hpp
+++ b/include/ap/argument.hpp
@@ -670,11 +670,15 @@ private:
         }
         else {
             if (not (std::istringstream(str_value) >> value))
-                throw parsing_failure::invalid_value(this->_name, str_value);
+                throw parsing_failure(std::format(
+                    "Cannot parse value `{}` for argument [{}].", str_value, this->_name.str()
+                ));
         }
 
         if (not this->_is_valid_choice(value))
-            throw parsing_failure::invalid_choice(this->_name, str_value);
+            throw parsing_failure(std::format(
+                "Value `{}` is not a valid choice for argument [{}].", str_value, this->_name.str()
+            ));
 
         const auto apply_visitor = action::util::apply_visitor<value_type>{value};
         for (const auto& action : this->_value_actions)

--- a/include/ap/argument_parser.hpp
+++ b/include/ap/argument_parser.hpp
@@ -1360,35 +1360,35 @@ private:
      * @throws ap::parsing_failure if the state of the parsed arguments is invalid.
      */
     void _verify_final_state() const {
-        const bool supress_arg_checks = this->_are_arg_checks_supressed();
+        const bool suppress_arg_checks = this->_are_arg_checks_suppressed();
         for (const auto& group : this->_argument_groups)
-            this->_verify_group_requirements(*group, supress_arg_checks);
+            this->_verify_group_requirements(*group, suppress_arg_checks);
     }
 
     /**
      * @brief Check whether required argument bypassing is enabled
      * @return true if at least one argument with enabled required argument bypassing is used, false otherwise.
      */
-    [[nodiscard]] bool _are_arg_checks_supressed() const noexcept {
+    [[nodiscard]] bool _are_arg_checks_suppressed() const noexcept {
         // TODO: use std::views::join after the transition to C++23
         return std::ranges::any_of(
                    this->_positional_args,
                    [](const arg_ptr_t& arg) {
-                       return arg->is_used() and arg->supresses_arg_checks();
+                       return arg->is_used() and arg->suppresses_arg_checks();
                    }
                )
             or std::ranges::any_of(this->_optional_args, [](const arg_ptr_t& arg) {
-                   return arg->is_used() and arg->supresses_arg_checks();
+                   return arg->is_used() and arg->suppresses_arg_checks();
                });
     }
 
     /**
      * @brief Verifies whether the requirements of the given argument group are satisfied.
      * @param group The argument group to verify.
-     * @param supress_arg_checks A flag indicating whether argument checks are suppressed.
+     * @param suppress_arg_checks A flag indicating whether argument checks are suppressed.
      * @throws ap::parsing_failure if the requirements are not satistied.
      */
-    void _verify_group_requirements(const argument_group& group, const bool supress_arg_checks)
+    void _verify_group_requirements(const argument_group& group, const bool suppress_arg_checks)
         const {
         if (group._arguments.empty())
             return;
@@ -1410,7 +1410,7 @@ private:
 
             if (used_arg_it != group._arguments.end()) {
                 // only the one used argument has to be validated
-                this->_verify_argument_requirements(*used_arg_it, supress_arg_checks);
+                this->_verify_argument_requirements(*used_arg_it, suppress_arg_checks);
                 return;
             }
         }
@@ -1422,17 +1422,17 @@ private:
 
         // all arguments in the group have to be validated
         for (const auto& arg : group._arguments)
-            this->_verify_argument_requirements(arg, supress_arg_checks);
+            this->_verify_argument_requirements(arg, suppress_arg_checks);
     }
 
     /**
      * @brief Verifies whether the requirements of the given argument are satisfied.
      * @param arg The argument to verify.
-     * @param supress_arg_checks A flag indicating whether argument checks are suppressed.
+     * @param suppress_arg_checks A flag indicating whether argument checks are suppressed.
      * @throws ap::parsing_failure if the requirements are not satistied.
      */
-    void _verify_argument_requirements(const arg_ptr_t& arg, const bool supress_arg_checks) const {
-        if (supress_arg_checks)
+    void _verify_argument_requirements(const arg_ptr_t& arg, const bool suppress_arg_checks) const {
+        if (suppress_arg_checks)
             return;
 
         if (arg->is_required() and not arg->has_value())

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -45,9 +45,11 @@ public:
     /// @return `true` if the argument is required, `false` otherwise.
     virtual bool is_required() const noexcept = 0;
 
-    /// @return `true` if required argument checks supressing is enabled for the argument, `false` otherwise.
-    /// @note Argument checks supressing can only be enabled if the argument is not required.
-    virtual bool supresses_arg_checks() const noexcept = 0;
+    /// @return `true` if argument checks suppressing is enabled for the argument, `false` otherwise.
+    virtual bool suppresses_arg_checks() const noexcept = 0;
+
+    /// @return `true` if argument group checks suppressing is enabled for the argument, `false` otherwise.
+    virtual bool suppresses_group_checks() const noexcept = 0;
 
     /// @return `true` if the argument is greedy, `false` otherwise.
     virtual bool is_greedy() const noexcept = 0;

--- a/include/ap/detail/argument_base.hpp
+++ b/include/ap/detail/argument_base.hpp
@@ -45,8 +45,9 @@ public:
     /// @return `true` if the argument is required, `false` otherwise.
     virtual bool is_required() const noexcept = 0;
 
-    /// @return `true` if the argument is allowed to bypass the required check, `false` otherwise.
-    virtual bool is_bypass_required_enabled() const noexcept = 0;
+    /// @return `true` if required argument checks supressing is enabled for the argument, `false` otherwise.
+    /// @note Argument checks supressing can only be enabled if the argument is not required.
+    virtual bool supresses_arg_checks() const noexcept = 0;
 
     /// @return `true` if the argument is greedy, `false` otherwise.
     virtual bool is_greedy() const noexcept = 0;

--- a/include/ap/exceptions.hpp
+++ b/include/ap/exceptions.hpp
@@ -37,20 +37,6 @@ struct invalid_configuration : public argument_parser_exception {
     ) noexcept {
         return invalid_configuration(std::format("Given name [{}] already used.", arg_name.str()));
     }
-
-    struct positional {
-        static invalid_configuration required_after_non_required(
-            const detail::argument_name& required_arg_name,
-            const detail::argument_name& non_required_arg_name
-        ) noexcept {
-            return invalid_configuration(std::format(
-                "Required positional argument [{}] cannot be defined after a non-required "
-                "positional argument [{}].",
-                required_arg_name.str(),
-                non_required_arg_name.str()
-            ));
-        }
-    };
 };
 
 /// @brief Exception type used for errors encountered during the argument parsing operation.
@@ -59,42 +45,6 @@ struct parsing_failure : public argument_parser_exception {
 
     static parsing_failure unknown_argument(const std::string_view arg_name) noexcept {
         return parsing_failure(std::format("Unknown argument [{}].", arg_name));
-    }
-
-    static parsing_failure value_already_set(const detail::argument_name& arg_name) noexcept {
-        return parsing_failure(
-            std::format("Value for argument [{}] has already been set.", arg_name.str())
-        );
-    }
-
-    static parsing_failure invalid_value(
-        const detail::argument_name& arg_name, const std::string& value
-    ) noexcept {
-        return parsing_failure(
-            std::format("Cannot parse value `{}` for argument [{}].", value, arg_name.str())
-        );
-    }
-
-    static parsing_failure invalid_choice(
-        const detail::argument_name& arg_name, const std::string& value
-    ) noexcept {
-        return parsing_failure(std::format(
-            "Value `{}` is not a valid choice for argument [{}].", value, arg_name.str()
-        ));
-    }
-
-    static parsing_failure required_argument_not_parsed(const detail::argument_name& arg_name
-    ) noexcept {
-        return parsing_failure(
-            std::format("No values parsed for a required argument [{}]", arg_name.str())
-        );
-    }
-
-    static parsing_failure argument_deduction_failure(const std::vector<std::string>& values
-    ) noexcept {
-        return parsing_failure(
-            std::format("Failed to deduce the argument for values [{}]", util::join(values))
-        );
     }
 
     static parsing_failure invalid_nvalues(

--- a/tests/include/argument_parser_test_fixture.hpp
+++ b/tests/include/argument_parser_test_fixture.hpp
@@ -191,6 +191,11 @@ struct argument_parser_test_fixture {
         return this->sut._get_argument(arg_name);
     }
 
+    // exception message builders
+    std::string required_argument_not_parsed_msg(const argument_name& arg_name) const {
+        return std::format("No values parsed for a required argument [{}]", arg_name.str());
+    }
+
     ap::argument_parser sut{program_name};
     parsing_state state{sut};
 

--- a/tests/include/argument_test_fixture.hpp
+++ b/tests/include/argument_test_fixture.hpp
@@ -126,6 +126,17 @@ struct argument_test_fixture {
     [[nodiscard]] bool is_bypass_required_enabled(const argument<ArgT, T>& arg) const {
         return arg.is_bypass_required_enabled();
     }
+
+    // exception message builders
+    std::string invalid_value_msg(const argument_name& arg_name, const std::string& value) const {
+        return std::format("Cannot parse value `{}` for argument [{}].", value, arg_name.str());
+    }
+
+    std::string invalid_choice_msg(const argument_name& arg_name, const std::string& value) const {
+        return std::format(
+            "Value `{}` is not a valid choice for argument [{}].", value, arg_name.str()
+        );
+    }
 };
 
 } // namespace ap_testing

--- a/tests/include/argument_test_fixture.hpp
+++ b/tests/include/argument_test_fixture.hpp
@@ -32,13 +32,13 @@ struct argument_test_fixture {
     }
 
     template <argument_type ArgT, c_argument_value_type T>
-    bool set_required(argument<ArgT, T>& arg, const bool r) const {
-        return arg._required = r;
+    bool set_required(argument<ArgT, T>& arg, const bool value) const {
+        return arg._required = value;
     }
 
     template <argument_type ArgT, c_argument_value_type T>
-    bool set_bypass_required(argument<ArgT, T>& arg, const bool br) const {
-        return arg._bypass_required = br;
+    bool set_supress_arg_checks(argument<ArgT, T>& arg, const bool value) const {
+        return arg._supress_arg_checks = value;
     }
 
     template <argument_type ArgT, c_argument_value_type T>

--- a/tests/include/argument_test_fixture.hpp
+++ b/tests/include/argument_test_fixture.hpp
@@ -32,16 +32,6 @@ struct argument_test_fixture {
     }
 
     template <argument_type ArgT, c_argument_value_type T>
-    bool set_required(argument<ArgT, T>& arg, const bool value) const {
-        return arg._required = value;
-    }
-
-    template <argument_type ArgT, c_argument_value_type T>
-    bool set_supress_arg_checks(argument<ArgT, T>& arg, const bool value) const {
-        return arg._supress_arg_checks = value;
-    }
-
-    template <argument_type ArgT, c_argument_value_type T>
     bool set_value(argument<ArgT, T>& arg, const T& value) const {
         return set_value(arg, as_string(value));
     }

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -369,12 +369,13 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
-    "parse_args should not throw if there is a positional argument which has the bypass_required "
+    "parse_args should not throw if there is a positional argument which has the "
+    "supress_arg_checks "
     "option enabled and is used"
 ) {
     const std::size_t n_positional_args = 1ull;
     const auto bypass_required_arg_name = init_arg_name(n_positional_args - 1ull).primary.value();
-    sut.add_positional_argument(bypass_required_arg_name).bypass_required();
+    sut.add_positional_argument(bypass_required_arg_name).supress_arg_checks();
     const std::string bypass_required_arg_value = "bypass_required_arg_value";
 
     for (std::size_t i = 0ull; i < n_optional_args; ++i)
@@ -392,7 +393,7 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
-    "parse_args should not throw if there is an optional argument which has the bypass_required "
+    "parse_args should not throw if there is an optional argument which has the supress_arg_checks "
     "option enabled and is used"
 ) {
     add_arguments(n_positional_args, n_optional_args);
@@ -403,7 +404,7 @@ TEST_CASE_FIXTURE(
     )
         .default_values(false)
         .implicit_values(true)
-        .bypass_required();
+        .supress_arg_checks();
 
     std::string arg_flag;
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -1464,6 +1464,28 @@ TEST_CASE_FIXTURE(
     free_argv(argc, argv);
 }
 
+TEST_CASE_FIXTURE(
+    test_argument_parser_parse_args,
+    "parse_args should not throw when the group requirements are not satisfied but a group check "
+    "suppressing argument is used"
+) {
+    const std::string suppressing_arg_name = "suppress";
+    sut.add_flag(suppressing_arg_name).suppress_group_checks();
+
+    const std::string req_me_gr_name = "Required & Mutually Exclusive Group";
+    auto& req_me_gr = sut.add_group(req_me_gr_name).mutually_exclusive();
+
+    for (std::size_t i = 0ull; i < n_optional_args; ++i)
+        sut.add_optional_argument(req_me_gr, init_arg_name_primary(i));
+
+    std::vector<std::string> argv_vec{std::format("--{}", suppressing_arg_name)};
+
+    REQUIRE_NOTHROW(sut.parse_args(argv_vec));
+    CHECK(sut.value<bool>(suppressing_arg_name));
+    for (std::size_t i = 0ull; i < n_optional_args; ++i)
+        CHECK_FALSE(sut.is_used(init_arg_name_primary(i)));
+}
+
 // subparsers
 
 TEST_CASE_FIXTURE(

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -155,8 +155,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::required_argument_not_parsed({init_arg_name_primary(last_pos_arg_idx)})
-            .what(),
+        required_argument_not_parsed_msg({init_arg_name_primary(last_pos_arg_idx)}).c_str(),
         parsing_failure
     );
 
@@ -179,10 +178,13 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        invalid_configuration::positional::required_after_non_required(
-            {required_arg_name}, {non_required_arg_name}
+        std::format(
+            "Required positional argument [{}] cannot be defined after a non-required positional "
+            "argument [{}].",
+            required_arg_name,
+            non_required_arg_name
         )
-            .what(),
+            .c_str(),
         invalid_configuration
     );
 
@@ -206,7 +208,8 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::argument_deduction_failure(unknown_args).what(),
+        std::format("Failed to deduce the argument for values [{}]", ap::util::join(unknown_args))
+            .c_str(),
         parsing_failure
     );
 
@@ -230,7 +233,7 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         sut.parse_args(argc, argv),
-        parsing_failure::required_argument_not_parsed(required_arg_name).what(),
+        required_argument_not_parsed_msg(required_arg_name).c_str(),
         parsing_failure
     );
 

--- a/tests/source/test_argument_parser_parse_args.cpp
+++ b/tests/source/test_argument_parser_parse_args.cpp
@@ -370,12 +370,12 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
     "parse_args should not throw if there is a positional argument which has the "
-    "supress_arg_checks "
+    "suppress_arg_checks "
     "option enabled and is used"
 ) {
     const std::size_t n_positional_args = 1ull;
     const auto bypass_required_arg_name = init_arg_name(n_positional_args - 1ull).primary.value();
-    sut.add_positional_argument(bypass_required_arg_name).supress_arg_checks();
+    sut.add_positional_argument(bypass_required_arg_name).required(false).suppress_arg_checks();
     const std::string bypass_required_arg_value = "bypass_required_arg_value";
 
     for (std::size_t i = 0ull; i < n_optional_args; ++i)
@@ -393,7 +393,8 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     test_argument_parser_parse_args,
-    "parse_args should not throw if there is an optional argument which has the supress_arg_checks "
+    "parse_args should not throw if there is an optional argument which has the "
+    "suppress_arg_checks "
     "option enabled and is used"
 ) {
     add_arguments(n_positional_args, n_optional_args);
@@ -404,7 +405,7 @@ TEST_CASE_FIXTURE(
     )
         .default_values(false)
         .implicit_values(true)
-        .supress_arg_checks();
+        .suppress_arg_checks();
 
     std::string arg_flag;
 

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -129,7 +129,7 @@ TEST_CASE_FIXTURE(
     CHECK_EQ(required_it->value, "true");
 
     // other parameters
-    sut.bypass_required();
+    sut.supress_arg_checks();
     sut.nargs(non_default_range);
     sut.choices(choices);
     sut.default_values(default_value);
@@ -138,10 +138,10 @@ TEST_CASE_FIXTURE(
     // check the descriptor parameters
     bld = get_help_builder(sut, verbose);
 
-    const auto bypass_required_it =
-        std::ranges::find(bld.params, "bypass required", &parameter_descriptor::name);
-    REQUIRE_NE(bypass_required_it, bld.params.end());
-    CHECK_EQ(bypass_required_it->value, "true");
+    const auto supress_arg_checks_it =
+        std::ranges::find(bld.params, "supress arg checks", &parameter_descriptor::name);
+    REQUIRE_NE(supress_arg_checks_it, bld.params.end());
+    CHECK_EQ(supress_arg_checks_it->value, "true");
 
     const auto nargs_it = std::ranges::find(bld.params, "nargs", &parameter_descriptor::name);
     REQUIRE_NE(nargs_it, bld.params.end());
@@ -193,64 +193,64 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "bypass_required() should return the value set using the `bypass_required` param setter"
+    "supress_arg_checks() should return the value set using the `supress_arg_checks` param setter"
 ) {
     auto sut = sut_type(arg_name_primary);
 
-    sut.bypass_required(true);
-    CHECK(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks(true);
+    CHECK(sut.supresses_arg_checks());
 
-    sut.bypass_required(false);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks(false);
+    CHECK_FALSE(sut.supresses_arg_checks());
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "is_bypass_required_enabled() should return true only if the `required` flag is set to false "
+    "supresses_arg_checks() should return true only if the `required` flag is set to false "
     "and "
-    "the `bypass_required` flags is set to true"
+    "the `supress_arg_checks` flags is set to true"
 ) {
     auto sut = sut_type(arg_name_primary);
 
     // disabled
     set_required(sut, false);
-    set_bypass_required(sut, false);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, false);
+    CHECK_FALSE(sut.supresses_arg_checks());
 
     set_required(sut, true);
-    set_bypass_required(sut, false);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, false);
+    CHECK_FALSE(sut.supresses_arg_checks());
 
     set_required(sut, true);
-    set_bypass_required(sut, true);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, true);
+    CHECK_FALSE(sut.supresses_arg_checks());
 
     // enabled
     set_required(sut, false);
-    set_bypass_required(sut, true);
-    CHECK(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, true);
+    CHECK(sut.supresses_arg_checks());
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "required(true) should disable `bypass_required` option and bypass_required(true) should "
+    "required(true) should disable `supress_arg_checks` option and supress_arg_checks(true) should "
     "disable the `required` option"
 ) {
     auto sut = sut_type(arg_name_primary);
 
     REQUIRE_FALSE(sut.is_required());
-    REQUIRE_FALSE(sut.is_bypass_required_enabled());
+    REQUIRE_FALSE(sut.supresses_arg_checks());
 
-    sut.bypass_required();
-    CHECK(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks();
+    CHECK(sut.supresses_arg_checks());
     CHECK_FALSE(sut.is_required());
 
     sut.required();
     CHECK(sut.is_required());
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    CHECK_FALSE(sut.supresses_arg_checks());
 
-    sut.bypass_required();
-    CHECK(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks();
+    CHECK(sut.supresses_arg_checks());
     CHECK_FALSE(sut.is_required());
 }
 

--- a/tests/source/test_optional_argument.cpp
+++ b/tests/source/test_optional_argument.cpp
@@ -482,7 +482,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_WITH_AS(
             set_value(sut, empty_str),
-            parsing_failure::invalid_value(arg_name_primary, empty_str).what(),
+            invalid_value_msg(arg_name_primary, empty_str).c_str(),
             parsing_failure
         );
         CHECK_FALSE(has_value(sut));
@@ -490,7 +490,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("given string is non-convertible to value_type") {
         REQUIRE_THROWS_WITH_AS(
             set_value(sut, invalid_value_str),
-            parsing_failure::invalid_value(arg_name_primary, invalid_value_str).what(),
+            invalid_value_msg(arg_name_primary, invalid_value_str).c_str(),
             parsing_failure
         );
         CHECK_FALSE(has_value(sut));
@@ -506,7 +506,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_THROWS_WITH_AS(
         set_value(sut, invalid_choice),
-        parsing_failure::invalid_choice(arg_name_primary, as_string(invalid_choice)).what(),
+        invalid_choice_msg(arg_name_primary, as_string(invalid_choice)).c_str(),
         parsing_failure
     );
     CHECK_FALSE(has_value(sut));

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -14,14 +14,8 @@ namespace {
 
 constexpr std::string_view help_msg = "test help msg";
 
-constexpr std::string_view primary_name = "test";
-const auto primary_name_opt = std::make_optional<std::string>(primary_name);
-
-constexpr std::string_view secondary_name = "t";
-const auto secondary_name_opt = std::make_optional<std::string>(secondary_name);
-
-const argument_name arg_name(primary_name_opt, secondary_name_opt);
-const argument_name arg_name_primary(primary_name_opt, std::nullopt);
+constexpr std::string_view name_value = "test";
+const argument_name arg_name(std::make_optional<std::string>(name_value), std::nullopt);
 
 using sut_value_type = int;
 using sut_type = positional_argument<sut_value_type>;
@@ -40,30 +34,17 @@ const range non_default_range = range{1ull, choices.size()};
 } // namespace
 
 TEST_CASE_FIXTURE(argument_test_fixture, "name() should return the proper argument_name instance") {
-    SUBCASE("initialized with the primary name only") {
-        const auto sut = sut_type(arg_name_primary);
-        const auto name = get_name(sut);
-
-        CHECK(name.match(primary_name));
-        CHECK_FALSE(name.match(secondary_name));
-    }
-
-    SUBCASE("initialized with the primary and secondary names") {
-        const auto sut = sut_type(arg_name);
-        const auto name = get_name(sut);
-
-        CHECK(name.match(primary_name));
-        CHECK(name.match(secondary_name));
-    }
+    const auto sut = sut_type(arg_name);
+    CHECK_EQ(get_name(sut), arg_name);
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "help() should return nullopt by default") {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK_FALSE(get_help(sut));
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "help() should return a massage set for the argument") {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.help(help_msg);
 
     const auto stored_help_msg = get_help(sut);
@@ -116,7 +97,8 @@ TEST_CASE_FIXTURE(
     CHECK(bld.params.empty());
 
     // other parameters
-    sut.supress_arg_checks();
+    sut.required(false);
+    sut.suppress_arg_checks();
     sut.nargs(non_default_range);
     sut.choices(choices);
     sut.default_values(default_value);
@@ -124,12 +106,12 @@ TEST_CASE_FIXTURE(
     // check the descriptor parameters
     bld = get_help_builder(sut, verbose);
 
-    const auto supress_arg_checks_it =
-        std::ranges::find(bld.params, "supress arg checks", &parameter_descriptor::name);
-    REQUIRE_NE(supress_arg_checks_it, bld.params.end());
-    CHECK_EQ(supress_arg_checks_it->value, "true");
+    const auto suppress_arg_checks_it =
+        std::ranges::find(bld.params, "suppress arg checks", &parameter_descriptor::name);
+    REQUIRE_NE(suppress_arg_checks_it, bld.params.end());
+    CHECK_EQ(suppress_arg_checks_it->value, "true");
 
-    // automatically set to false with supress_arg_checks
+    // automatically set to false with suppress_arg_checks
     const auto required_it = std::ranges::find(bld.params, "required", &parameter_descriptor::name);
     REQUIRE_NE(required_it, bld.params.end());
     CHECK_EQ(required_it->value, "false");
@@ -152,7 +134,7 @@ TEST_CASE_FIXTURE(
     argument_test_fixture,
     "is_hidden() should return false by default or the value passed in the attribute setter"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     REQUIRE_FALSE(sut.is_hidden());
 
     sut.hidden();
@@ -160,7 +142,7 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "is_required() should return true by default") {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     CHECK(sut.is_required());
 }
 
@@ -168,7 +150,7 @@ TEST_CASE_FIXTURE(
     argument_test_fixture,
     "is_required() should return the value set using the `required` param setter"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
 
     sut.required(false);
     CHECK_FALSE(sut.is_required());
@@ -178,72 +160,88 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(
-    argument_test_fixture,
-    "supresses_arg_checks() should return the value set using the `supress_arg_checks` param setter"
+    argument_test_fixture, "required(true) should throw if an argument is supressing"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
+    sut.required(false);
 
-    sut.supress_arg_checks(true);
-    CHECK(sut.supresses_arg_checks());
+    SUBCASE("suppressing argument checks") {
+        sut.suppress_arg_checks();
+    }
+    SUBCASE("suppressing argument group checks") {
+        sut.suppress_group_checks();
+    }
+    SUBCASE("suppressing all checks") {
+        sut.suppress_arg_checks();
+        sut.suppress_group_checks();
+    }
 
-    sut.supress_arg_checks(false);
-    CHECK_FALSE(sut.supresses_arg_checks());
+    CAPTURE(sut);
+
+    CHECK_THROWS_WITH_AS(
+        sut.required(true),
+        std::format("A suppressing argument [{}] cannot be required!", arg_name.str()).c_str(),
+        ap::invalid_configuration
+    );
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "supresses_arg_checks() should return true only if the `required` flag is set to false "
-    "and the `supress_arg_checks` flags is set to true"
+    "suppresses_arg_checks() should return the value set using the `suppress_arg_checks` param "
+    "setter if the argument is not required"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
 
-    // disabled
-    set_required(sut, false);
-    set_supress_arg_checks(sut, false);
-    CHECK_FALSE(sut.supresses_arg_checks());
+    CHECK_THROWS_WITH_AS(
+        sut.suppress_arg_checks(true),
+        std::format("A required argument [{}] cannot suppress argument checks!", arg_name.str())
+            .c_str(),
+        ap::invalid_configuration
+    );
 
-    set_required(sut, true);
-    set_supress_arg_checks(sut, false);
-    CHECK_FALSE(sut.supresses_arg_checks());
+    sut.required(false);
 
-    set_required(sut, true);
-    set_supress_arg_checks(sut, true);
-    CHECK_FALSE(sut.supresses_arg_checks());
+    sut.suppress_arg_checks(true);
+    CHECK(sut.suppresses_arg_checks());
 
-    // enabled
-    set_required(sut, false);
-    set_supress_arg_checks(sut, true);
-    CHECK(sut.supresses_arg_checks());
+    sut.suppress_arg_checks(false);
+    CHECK_FALSE(sut.suppresses_arg_checks());
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "required(true) should disable `supress_arg_checks` option and supress_arg_checks(true) should "
-    "disable the `required` option"
+    "suppresses_group_checks() should return the value set using the `suppress_group_checks` param "
+    "setter if the argument is not required"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
 
-    REQUIRE(sut.is_required());
-    REQUIRE_FALSE(sut.supresses_arg_checks());
+    CHECK_THROWS_WITH_AS(
+        sut.suppress_group_checks(true),
+        std::format(
+            "A required argument [{}] cannot suppress argument group checks!", arg_name.str()
+        )
+            .c_str(),
+        ap::invalid_configuration
+    );
 
-    sut.supress_arg_checks();
-    CHECK(sut.supresses_arg_checks());
-    CHECK_FALSE(sut.is_required());
+    sut.required(false);
 
-    sut.required();
-    CHECK(sut.is_required());
-    CHECK_FALSE(sut.supresses_arg_checks());
+    sut.suppress_group_checks(true);
+    CHECK(sut.suppresses_group_checks());
+
+    sut.suppress_group_checks(false);
+    CHECK_FALSE(sut.suppresses_group_checks());
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "is_used() should return false by default") {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK_FALSE(is_used(sut));
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture, "is_used() should return true when argument contains a value"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     REQUIRE_FALSE(is_used(sut));
 
     set_value(sut, valid_value);
@@ -251,24 +249,24 @@ TEST_CASE_FIXTURE(
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "count() should return 0 by default") {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK_EQ(get_count(sut), 0ull);
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "count() should return 1 when argument contains a value") {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     set_value(sut, valid_value);
 
     CHECK_EQ(get_count(sut), 1ull);
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "has_value() should return false by default") {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK_FALSE(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "has_value() should return true if the value is set") {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     set_value(sut, valid_value);
 
     CHECK(has_value(sut));
@@ -277,14 +275,14 @@ TEST_CASE_FIXTURE(argument_test_fixture, "has_value() should return true if the 
 TEST_CASE_FIXTURE(
     argument_test_fixture, "has_value() should return true if the default value is set"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.default_values(default_value);
 
     CHECK(has_value(sut));
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "has_parsed_values() should return false by default") {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK_FALSE(has_parsed_values(sut));
 }
 
@@ -292,28 +290,28 @@ TEST_CASE_FIXTURE(
     argument_test_fixture,
     "has_parsed_values() should return false regardless of the default value parameter"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.default_values(default_value);
 
     CHECK_FALSE(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "has_parsed_values() should true if the value is set") {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     set_value(sut, valid_value);
 
     CHECK(has_parsed_values(sut));
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "has_predefined_values() should return false by default") {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK_FALSE(has_predefined_values(sut));
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture, "has_predefined_values() should return true if the default value is set"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.default_values(default_value);
 
     CHECK(has_predefined_values(sut));
@@ -322,7 +320,7 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     argument_test_fixture, "value() should throw if the argument's value has not been set"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
 
     REQUIRE_FALSE(has_value(sut));
     CHECK_THROWS_AS(static_cast<void>(get_value(sut)), std::logic_error);
@@ -331,7 +329,7 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     argument_test_fixture, "value() should return the argument's value if it has been set"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     set_value(sut, valid_value);
 
     REQUIRE(has_value(sut));
@@ -343,7 +341,7 @@ TEST_CASE_FIXTURE(
     "value() should return the default argument's default value if it has been set and no values "
     "were parsed"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.default_values(default_value);
 
     REQUIRE(has_value(sut));
@@ -353,7 +351,7 @@ TEST_CASE_FIXTURE(
 TEST_CASE_FIXTURE(
     argument_test_fixture, "value() should return the argument's parsed value if it has been set"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.default_values(default_value);
     set_value(sut, valid_value);
 
@@ -366,12 +364,12 @@ TEST_CASE_FIXTURE(
     "set_value(any) should throw when the given string cannot be converted to an instance of "
     "value_type"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
 
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_WITH_AS(
             set_value(sut, empty_str),
-            invalid_value_msg(arg_name_primary, empty_str).c_str(),
+            invalid_value_msg(arg_name, empty_str).c_str(),
             parsing_failure
         );
         CHECK_FALSE(has_value(sut));
@@ -380,7 +378,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("given string is non-convertible to value_type") {
         REQUIRE_THROWS_WITH_AS(
             set_value(sut, invalid_value_str),
-            invalid_value_msg(arg_name_primary, invalid_value_str).c_str(),
+            invalid_value_msg(arg_name, invalid_value_str).c_str(),
             parsing_failure
         );
         CHECK_FALSE(has_value(sut));
@@ -391,12 +389,12 @@ TEST_CASE_FIXTURE(
     argument_test_fixture,
     "set_value(any) should throw when the choices set does not contain the parsed value"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.choices(choices);
 
     REQUIRE_THROWS_WITH_AS(
         set_value(sut, invalid_choice),
-        invalid_choice_msg(arg_name_primary, std::to_string(invalid_choice)).c_str(),
+        invalid_choice_msg(arg_name, std::to_string(invalid_choice)).c_str(),
         parsing_failure
     );
     CHECK_FALSE(has_value(sut));
@@ -407,7 +405,7 @@ TEST_CASE_FIXTURE(
     "set_value(any) should throw when adding the given value would result in exceeding the maximum "
     "number of values specified by nargs"
 ) {
-    auto sut = sut_type(arg_name_primary).nargs(non_default_range);
+    auto sut = sut_type(arg_name).nargs(non_default_range);
 
     for (const auto value : choices)
         REQUIRE_NOTHROW(set_value(sut, value));
@@ -419,13 +417,13 @@ TEST_CASE_FIXTURE(
 
     CHECK_THROWS_WITH_AS(
         set_value(sut, valid_value),
-        parsing_failure::invalid_nvalues(arg_name_primary, std::weak_ordering::greater).what(),
+        parsing_failure::invalid_nvalues(arg_name, std::weak_ordering::greater).what(),
         parsing_failure
     );
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "set_value(any) should perform the specified action") {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
 
     SUBCASE("observe action") {
         const auto is_power_of_two = [](const sut_value_type n) {
@@ -468,7 +466,7 @@ TEST_CASE_FIXTURE(argument_test_fixture, "set_value(any) should perform the spec
 TEST_CASE_FIXTURE(
     argument_test_fixture, "nvalues_ordering() should return less for default nargs (1)"
 ) {
-    const auto sut = sut_type(arg_name_primary);
+    const auto sut = sut_type(arg_name);
     CHECK(std::is_lt(nvalues_ordering(sut)));
 }
 
@@ -476,7 +474,7 @@ TEST_CASE_FIXTURE(
     argument_test_fixture,
     "nvalues_ordering() should return equivalent if a default value has been set"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.nargs(non_default_range);
 
     sut.default_values(default_value);
@@ -489,7 +487,7 @@ TEST_CASE_FIXTURE(
     "nvalues_ordering() should return equivalent only when the number of values "
     "is in the specified range"
 ) {
-    auto sut = sut_type(arg_name_primary);
+    auto sut = sut_type(arg_name);
     sut.nargs(non_default_range);
 
     REQUIRE(std::is_lt(nvalues_ordering(sut)));

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -116,7 +116,7 @@ TEST_CASE_FIXTURE(
     CHECK(bld.params.empty());
 
     // other parameters
-    sut.bypass_required();
+    sut.supress_arg_checks();
     sut.nargs(non_default_range);
     sut.choices(choices);
     sut.default_values(default_value);
@@ -124,12 +124,12 @@ TEST_CASE_FIXTURE(
     // check the descriptor parameters
     bld = get_help_builder(sut, verbose);
 
-    const auto bypass_required_it =
-        std::ranges::find(bld.params, "bypass required", &parameter_descriptor::name);
-    REQUIRE_NE(bypass_required_it, bld.params.end());
-    CHECK_EQ(bypass_required_it->value, "true");
+    const auto supress_arg_checks_it =
+        std::ranges::find(bld.params, "supress arg checks", &parameter_descriptor::name);
+    REQUIRE_NE(supress_arg_checks_it, bld.params.end());
+    CHECK_EQ(supress_arg_checks_it->value, "true");
 
-    // automatically set to false with bypass_required
+    // automatically set to false with supress_arg_checks
     const auto required_it = std::ranges::find(bld.params, "required", &parameter_descriptor::name);
     REQUIRE_NE(required_it, bld.params.end());
     CHECK_EQ(required_it->value, "false");
@@ -179,61 +179,60 @@ TEST_CASE_FIXTURE(
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "bypass_required() should return the value set using the `bypass_required` param setter"
+    "supresses_arg_checks() should return the value set using the `supress_arg_checks` param setter"
 ) {
     auto sut = sut_type(arg_name_primary);
 
-    sut.bypass_required(true);
-    CHECK(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks(true);
+    CHECK(sut.supresses_arg_checks());
 
-    sut.bypass_required(false);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks(false);
+    CHECK_FALSE(sut.supresses_arg_checks());
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "is_bypass_required_enabled() should return true only if the `required` flag is set to false "
-    "and "
-    "the `bypass_required` flags is set to true"
+    "supresses_arg_checks() should return true only if the `required` flag is set to false "
+    "and the `supress_arg_checks` flags is set to true"
 ) {
     auto sut = sut_type(arg_name_primary);
 
     // disabled
     set_required(sut, false);
-    set_bypass_required(sut, false);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, false);
+    CHECK_FALSE(sut.supresses_arg_checks());
 
     set_required(sut, true);
-    set_bypass_required(sut, false);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, false);
+    CHECK_FALSE(sut.supresses_arg_checks());
 
     set_required(sut, true);
-    set_bypass_required(sut, true);
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, true);
+    CHECK_FALSE(sut.supresses_arg_checks());
 
     // enabled
     set_required(sut, false);
-    set_bypass_required(sut, true);
-    CHECK(sut.is_bypass_required_enabled());
+    set_supress_arg_checks(sut, true);
+    CHECK(sut.supresses_arg_checks());
 }
 
 TEST_CASE_FIXTURE(
     argument_test_fixture,
-    "required(true) should disable `bypass_required` option and bypass_required(true) should "
+    "required(true) should disable `supress_arg_checks` option and supress_arg_checks(true) should "
     "disable the `required` option"
 ) {
     auto sut = sut_type(arg_name_primary);
 
     REQUIRE(sut.is_required());
-    REQUIRE_FALSE(sut.is_bypass_required_enabled());
+    REQUIRE_FALSE(sut.supresses_arg_checks());
 
-    sut.bypass_required();
-    CHECK(sut.is_bypass_required_enabled());
+    sut.supress_arg_checks();
+    CHECK(sut.supresses_arg_checks());
     CHECK_FALSE(sut.is_required());
 
     sut.required();
     CHECK(sut.is_required());
-    CHECK_FALSE(sut.is_bypass_required_enabled());
+    CHECK_FALSE(sut.supresses_arg_checks());
 }
 
 TEST_CASE_FIXTURE(argument_test_fixture, "is_used() should return false by default") {

--- a/tests/source/test_positional_argument.cpp
+++ b/tests/source/test_positional_argument.cpp
@@ -372,7 +372,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("given string is empty") {
         REQUIRE_THROWS_WITH_AS(
             set_value(sut, empty_str),
-            parsing_failure::invalid_value(arg_name_primary, empty_str).what(),
+            invalid_value_msg(arg_name_primary, empty_str).c_str(),
             parsing_failure
         );
         CHECK_FALSE(has_value(sut));
@@ -381,7 +381,7 @@ TEST_CASE_FIXTURE(
     SUBCASE("given string is non-convertible to value_type") {
         REQUIRE_THROWS_WITH_AS(
             set_value(sut, invalid_value_str),
-            parsing_failure::invalid_value(arg_name_primary, invalid_value_str).what(),
+            invalid_value_msg(arg_name_primary, invalid_value_str).c_str(),
             parsing_failure
         );
         CHECK_FALSE(has_value(sut));
@@ -397,7 +397,7 @@ TEST_CASE_FIXTURE(
 
     REQUIRE_THROWS_WITH_AS(
         set_value(sut, invalid_choice),
-        parsing_failure::invalid_choice(arg_name_primary, std::to_string(invalid_choice)).what(),
+        invalid_choice_msg(arg_name_primary, std::to_string(invalid_choice)).c_str(),
         parsing_failure
     );
     CHECK_FALSE(has_value(sut));


### PR DESCRIPTION
- Removed unnecessary exception builders
- Renamed the `bypass_required` argument attribute to `suppress_arg_checks`
- Introduced the `suppress_group_checks` argument attribute
- Aligned the tutorial page and documentation comments